### PR TITLE
Disable stealth mode on door2windows.com

### DIFF
--- a/ExperimentalFilter/sections/English/whitelist.txt
+++ b/ExperimentalFilter/sections/English/whitelist.txt
@@ -7,3 +7,5 @@
 !
 ! This section contains all kinds of exception rules.
 !
+! Disables referer manipulation to allow downloads on door2windows without excepting the whole page
+@@||www.door2windows.com^$stealth


### PR DESCRIPTION
Disable referer manipulation to allow downloads on door2windows without excepting the whole page