### PR TITLE
Update specific.txt

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -7543,6 +7543,7 @@ zvukoff.ru##.adv-list-top
 ||город-кингисепп.рф/200x150_
 ||куражбамбей.рф/sites/default/files/serial_adv_files/
 ||легион.net/wp-content/uploads/2016/02/200x170-180x153.png
+||мвд.рф$$script[src="nocopy"]
 ||п.база-наруто.рф//c/
 ||рефераты-и-сочинения.рф/images/hosting.gif
 ||форум-мебельщиков.рф/banner/


### PR DESCRIPTION
Добавил блокировку скрипта, блокирующего контекстное меню и копирование-вставку для более удобного написания обращений в полицию. Скрипт мвд.рф/media/mvd-2015/js/nocopy.js отключает контекстное меню браузера и копирование-вставку в форму обращения, что приводит к невозможности скопировать составленное, например, в блокноте, обращение в форму на сайте https://мвд.рф/request_main. Правило действует и для региональных управлений мвд, например https://66.мвд.рф/request_main.