### PR TITLE
Update the careless mistake of static filter "~"

### DIFF
--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -44,7 +44,7 @@ protopage.com#%#(function(){var pageParams={};Object.defineProperty(window,"page
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6150
 !+ PLATFORM(mac)
 @@||8ch.net^$elemhide,jsinject,content
-~
+!
 ! outlook.live.com - when this file is modified by AG, windows defender detects it as a HTML/Phish
 @@||outlook.live.com/owa/projection.aspx$document
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6100


### PR DESCRIPTION
Found this careless mistake you made when it crashes the player in Openload.co.

Example link : https://openload.co/f/kUEfGclsU9o

The "~" should be "!" I guess?

Information | value
-- | --
Operating system: | Windows 7
Browser: | chrome
Adguard filters: | 7
Ticket ID (if exists): | /