### PR TITLE
Move Olark to "widgets" list its Chat section

### DIFF
--- a/AnnoyancesFilter/sections/widgets.txt
+++ b/AnnoyancesFilter/sections/widgets.txt
@@ -139,11 +139,15 @@ javtasty.com##.table > .block-chat
 anime-skorpik.com###sgeChat
 taraftarium24-tv.com###free-chat-nandox
 tuttosportweb.com###sidebar
+||assets.olark.com^
 ||chatbro.com/embed_chats/
+||log.olark.com^
 ||nandox.com/*free-chat^$domain=taraftarium24-tv.com
+||nrpc.olark.com^
 ||secure.livechatinc.com^$third-party
 ||sge-chat.skorpik.ru^
 ||smartsuppchat.com/loader.js
+||stats.olark.com^
 ||tuttosportweb.com/tochat
 ||xatech.com/web_gear/chat/chat.swf
 nhentai.net##footer > p > b

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -190,7 +190,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||analytics.xyscdn.com^
 ||app.adjust.io^
 ||ascstats.iobit.com^
-||assets.olark.com^
 ||b-aws.aol.com^
 ||b-aws.huffingtonpost.com^
 ||b.huffingtonpost.com^
@@ -245,7 +244,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||lively-collect-elb-*.amazonaws.com^$third-party
 ||log-live.direct.ly^$third-party
 ||log.adap.tv^$object-subrequest
-||log.olark.com^
 ||log.rutube.ru^
 ||logdev.openload.co^
 ||logs.thebloggernetwork.com^
@@ -256,7 +254,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||metrics.toysrus.com^
 ||mevents.trusteer.com^$third-party
 ||mtp.spaces.ru^
-||nrpc.olark.com^
 ||o.addthis.com^
 ||onclickpredictiv.com^$third-party
 ||perr.h-cdn.com^
@@ -281,7 +278,6 @@ charlestownwyllie.oaklawnnonantum.com^
 ||stats-newyork1.bloxcms.com^
 ||stats.mako.co.il^
 ||stats.mirror.co.uk^
-||stats.olark.com^
 ||stats.openload.co^
 ||stats.videoseyredin.net^
 ||stats2.arstechnica.com^


### PR DESCRIPTION
Categorizing this more specifically according to its actual purpose.

People who are looking to block "spyware" (a huge list) might not want to block chat products in the process (a much smaller list). Or vice versa, honestly.

Full disclosure, I work for Olark, so infer whatever nefarious motives you need to from there. For what it's worth, I completely sympathize with people who want to block us, I just want to make sure that people aren't blocking us as a side-effect of blocking something unrelated (because that causes support load for us).