### PR TITLE
Annoyances: silence intercom.com push notification

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -734,3 +734,6 @@ gazetevatan.com##a[href="https://www.facebook.com/sampiy10"]
 erzurumgazetesi.com.tr##div[style="width:300px; margin-bottom:20px;"] > a[class^="social_"]
 gazetevatan.com##form ._soc.news
 ||i.hizliresim.com/4r4kBG.gif
+! Prevent https://www.intercom.com/engage push notification "ding" sound from loading
+! ex. https://js.intercomcdn.com/audio/notification.0d062b33.mp3
+js.intercomcdn.com/audio/*


### PR DESCRIPTION
Sites like www.alphaflow.com (as of 2017-11-14T20:52Z, see in an incognito window) and any others using Intercom's Engage product will pop up a loud autoplaying audio notification on the load of their widget. The widget and the message themselves are useful (as this is usually used for B2B product support) but the audio is incredibly disruptive (especially in work environments).