### PR TITLE
fix #6945

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -1408,8 +1408,7 @@ convertinmp4.com###b728l
 primewire.ag##a[href^="/gohere.php?"][style*="images/download_button_hover"][class]
 cs-fundamentals.com###right-col-block-ad
 photopea.com##.rightmost
-||moviechat.org/images/affiliates/
-moviechat.org##.adc
+||moviechat.org/images/aff
 theage.com.au##iframe[name="compare_save"]
 theage.com.au###jobs
 turbobit.net##a[href*="&campaign="] > img


### PR DESCRIPTION
They're now using `https://moviechat.org/images/aff/` for image ads, and the CSS rule just removed a few blank pixels. It's better not to hide the section for it to be possible to know if they've changed the image URLs again.