### PR TITLE
Revert "netlify.com https://github.com/AdguardTeam/AdguardFilters/issues/11282"

### DIFF
--- a/SpywareFilter/sections/whitelist.txt
+++ b/SpywareFilter/sections/whitelist.txt
@@ -1,9 +1,4 @@
 !
-!
-!### Temporary ###
-! https://github.com/AdguardTeam/AdguardFilters/issues/11282
-@@||gci-leaders.netlify.com/i18n/*$domain=netlify.com
-!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11050
 @@||trc.taboola.com/msn-msn/*$domain=msn.com
 @@||cdn.taboola.com/libtrc^$domain=msn.com


### PR DESCRIPTION
Follow-up for https://github.com/AdguardTeam/AdguardFilters/issues/11282

This reverts commit 8c06c53d8c18402ac14db49071240c1087836634.

The netlify filter was removed from easyprivacy.
See https://github.com/easylist/easylist/issues/898