### PR TITLE
Remove rule for heise.de

### DIFF
--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -24,8 +24,6 @@ msn.com#@#[src*="data:"]
 @@||reports.adguard.com/*.json
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8946
 @@||onhelp.me^$extension
-! https://github.com/AdguardTeam/AdguardAssistant/issues/217
-@@||heise.de^$extension
 ! https://github.com/AdguardTeam/AdguardFilters/issues/16082
 @@||photos.shutterfly.com^$extension
 ! END: Temporary


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardAssistant/issues/217