### PR TITLE
Update general_elemhide.txt

### DIFF
--- a/TurkishFilter/sections/general_elemhide.txt
+++ b/TurkishFilter/sections/general_elemhide.txt
@@ -23,7 +23,6 @@
 ##.rkads
 ##div[id^="floatLayer"]
 ##div[class^="ad-1000x"]
-~sweetalert.js.org##.swal-overlay
 ##img[alt="jigolo"]
 ##a[href*="megabatorturkiyebay"] > img
 ##a[href*="seriouslove.club"] > img


### PR DESCRIPTION
deleted swal-overlay filter. This filter prevents the operation of the SweetAlert plugin on all other sites.