### PR TITLE
Attempted to add Tor domains to some entries

### DIFF
--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -1095,9 +1095,9 @@ intercelestial.com##.swal2-container
 @@||vcstream.to^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18113
 @@||facebook.com/adsmanager/manage^
-facebook.com#@#.AdBox
-facebook.com#@#.Ad
-facebook.com#@#.advert
+facebook.com,facebookcorewwwi.onion#@#.AdBox
+facebook.com,facebookcorewwwi.onion#@#.Ad
+facebook.com,facebookcorewwwi.onion#@#.advert
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17252
 @@||maps4heroes.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17316

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -4,17 +4,17 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21771
 softpedia.com##.main > div[class^="container_"] > div[class$="_30 grid_48"]:has(> .dlcls > span.promoted[style])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21090
-facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div.d_gj-ysfupy > .n_gj-ysddak)
+facebook.com,facebookcorewwwi.onion##div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div.d_gj-ysfupy > .n_gj-ysddak)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21497
 readheroacademia.com###main > .chapter_coin > center:has(> h3 > strong:contains(Advertisement))
 readheroacademia.com###main > .code-block[style] > center:has(> h3 > strong:contains(Advertisement))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20655
 mylust.com##.box > .title:contains(Advertisement)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21090
-facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div._5pcp._5lel span a[href="#"] > div[class])
+facebook.com,facebookcorewwwi.onion##div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div._5pcp._5lel span a[href="#"] > div[class])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21365
-nytimes.com###site-content > div[class^="css-"][class*=" "] > div[class^="css-"][class*=" "] > div[class^="css-"][class*=" "]:contains(Advertisement)
-nytimes.com###app > div[class^="css-"][class*=" "]:not([data-reactroot]) > div[class^="css-"][class*=" "]:contains(Advertisement)
+nytimes.com,nytimes3xbfgragh.onion###site-content > div[class^="css-"][class*=" "] > div[class^="css-"][class*=" "] > div[class^="css-"][class*=" "]:contains(Advertisement)
+nytimes.com,nytimes3xbfgragh.onion###app > div[class^="css-"][class*=" "]:not([data-reactroot]) > div[class^="css-"][class*=" "]:contains(Advertisement)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21268
 filikula.co##.idTabs > li[-ext-has='a[href^="#tab-ad"]']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21149

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -195,7 +195,7 @@ putlocker.bet##.content-box > .message ~ table[-ext-has='a[href^="/watching/"] >
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8819
 putlocker.at##.content-box > table[-ext-has='a[href^="http://putlocker.at/play"]']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8124
-facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id"][-ext-has='a.uiStreamSponsoredLink']
+facebook.com,facebookcorewwwi.onion##div[id^="substream_"] div[id^="hyperfeed_story_id"][-ext-has='a.uiStreamSponsoredLink']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8402
 pajiba.com###burstBox > h2:has(> b:contains(Advertisement))
 pajiba.com###burstBox > h2:has(> b:contains(Advertisement)) + hr
@@ -315,10 +315,10 @@ dailytelegraph.com.au##.widget-area-main-content > div.widget_newscorpau_capi_sy
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8124
 t.facebook.com##div[id^="more_pager_pagelet_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="/ads/about"]']
 t.facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="https://t.facebook.com/ads/about"]']
-facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='div[id^="feed_subtitle"] > span > a[href="#"] > div[class] > div[class]:not(.timestampContent)']
+facebook.com,facebookcorewwwi.onion##div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='div[id^="feed_subtitle"] > span > a[href="#"] > div[class] > div[class]:not(.timestampContent)']
 !facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div._5pcp._5lel > span div a[href="#"])
 ! https://forum.adguard.com/index.php?threads/facebook-com.21192/
-facebook.com##div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='._5paw > a._3e_2[href^="https://l.facebook.com"]']
+facebook.com,facebookcorewwwi.onion##div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='._5paw > a._3e_2[href^="https://l.facebook.com"]']
 ! https://forum.adguard.com/index.php?threads/movieonline-io-fake-button.24728/
 movieonline.io##.col3-r > .col3-btn:not([id])[-ext-has='>a[href^="//go.oclasrv.com/afu.php?"]']
 ! https://forum.adguard.com/index.php?threads/http-www-thebody-com.24551/

--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -1352,7 +1352,7 @@ linx.cloud#$#div[id^="MGWrap"] { position: absolute!important; left: -3000px!imp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6327
 medicalnewstoday.com#$#body > #navigation { margin-bottom: 0px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6373
-nytimes.com#$#.bottom-left-ad { position: absolute!important; left: -3000px!important; }
+nytimes.com,nytimes3xbfgragh.onion#$#.bottom-left-ad { position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6359
 dotesports.com#$#.row._mwxnus{ margin-top: 10px!important; }
 dotesports.com#$#.row._1nsgeoz { margin-top: 0px!important; }

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -508,7 +508,7 @@ amaturetube.net##.banner-pop
 ||mycut.me^$domain=shortadd.com
 3movs.com##div[class="3M-textlink"]
 ||cdn.gadgets360.com/pricee/assets/affiliate/js/pwdgt.min.js$domain=ndtv.com
-nytimes.com##.ad
+nytimes.com,nytimes3xbfgragh.onion##.ad
 pinsystem.co.uk##.mh-sidebar > div[id^="enhancedtextwidget-"]
 ||ferrolad.com/oiopub^
 psdkey.es###third .m-text[style^="height:620px"]

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -1311,7 +1311,7 @@ kissasian.ch###adsFloat1
 kissasian.ch##.wrap > div[style*="text-align: center; margin: 10px"]
 kissasian.ch##iframe[src^="http://kissasian.ch/ads"]
 ||www2.escdn.co/script.js$important
-facebook.com###pagelet_ego_pane > .pagelet:not(.egoOrganicColumn)
+facebook.com,facebookcorewwwi.onion###pagelet_ego_pane > .pagelet:not(.egoOrganicColumn)
 dansmovies.com##.addsinside
 nastyrat.com###bn
 ||nastyrat.com/*_*.js|


### PR DESCRIPTION
As I have recently begun to experiment with .onion domains in Tor Browser (e.g. for the purposes of https://github.com/DandelionSprout/adfilt/blob/master/BrowseWebsitesWithoutLoggingIn.txt), I've learned that filter entries that apply to e.g. Facebook and NY Times, don't automatically apply to their .onion domains.

So I decided to attempt to add those domains to the relevant entries, and am suggesting that it could become some sort of policy to add .onion domains to theorethical future Facebook, NY Times and DuckDuckGo entries.