### PR TITLE
alternativeto.net: Fix disappearing bottomNotifier

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -1153,7 +1153,7 @@ denofgeek.com,expertreviews.co.uk,theweek.co.uk,autoexpress.co.uk,alphr.com,itpr
 paradigit.nl###acceptCookiesForm
 energy.de###attention_cookies
 eindhoven.nl,verzekerdbijhema.nl###bcpm-notification-outer-border
-alternativeto.net###bottomNotifierContent
+alternativeto.net###bottomNotifierContent .EUc__message
 ariva.de###bottomWarnings
 deutsche-handwerks-zeitung.de###cc-box
 fiber.nl###ccm-banner-wrap


### PR DESCRIPTION
Refs 9f7dbb6ef93bf456a0591ceeea4a04c1412cad22, https://forum.adguard.com/index.php?threads/resolved-alternativeto-net-cookie-notice.18795/

The `#bottomNotifierContent` on alternativeto.net is used for functionality in the site, e.g. reporting problems with entries or suggesting features. The current filter makes the whole element disappear, rendering these features unusable. The proposed change filters only cookie consent on the site, targeting the element's class in the original request (although it looks like the cookie consent message doesn't appear on alternativeto.net anymore).