### PR TITLE
thesaurus.weblio.jp #24223

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -31,6 +31,7 @@ travelchannel.co.uk#$##cppd { display: none!important; }
 travelchannel.co.uk#$#body { overflow: visible!important; }
 motocms.com##.cookie_block
 docmorris.de##.cookie
+||weblio.hs.llnwd.net/e7/script/include/free_or_premium_registration_cookie.js
 tesco.pl##.cp-cookie-bar
 travelplanet.pl###cookie--info-wrapper
 targeo.pl##body > div[style^="position: absolute; z-index:"]:not([class]):not([id])

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -29,6 +29,8 @@ shibukoi.com##div[class="home_widget top mobile cf"]
 ||coinch.me/js/link.js
 ||kabooo.net/js/link.js
 javynow.com##.fam_ad
+thesaurus.weblio.jp##.kwydn-wrap
+||weblio.hs.llnwd.net/e7/script/include/foot_ad_pc.js
 iqoo.me##article.ad_article
 eropasture.com##.access-t
 eropasture.com##.sp_head_box


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/24223

− `thesaurus.weblio.jp##.kwydn-wrap` is hiding ad buttons in mobile browser
− empty place under the footer cannot be deleted in mobile browser
− it's not an annoyance, but rather the weblio app link (on the screenshot)