### PR TITLE
headlines.yahoo.co.jp #24645

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -25,6 +25,10 @@ togetter.com##.togech_box
 togetter.com##.ad_topics_custom
 j-cast.com##.ad_entry_toptext
 trafficnews.jp##.ad-large-big
+yahoo.co.jp##.adUltra
+yahoo.co.jp##p[style="margin:0;padding:5px 0px 5px 10px;font-size:13px;"]
+yahoo.co.jp##a[href^="https://ard.yahoo.co.jp/"]
+yahoo.co.jp##a[href="https://premono.yahoo.co.jp"]
 adulti25.com##section[id="about"] a[target="_blank"] > img
 momon-ga.com##.article-body > div[class="check"]
 dailyanime.news##.centerBanner

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -737,7 +737,7 @@ gamme.com.tw###wrap > .shareBtn.collapsed
 gamme.com.tw##.post > .share_like_area > .sharebtns > li > [class]:not(.sharebtns_url):not(.sharebtns_msg)
 muzmo.ru##.items > div[class="ajax-item item-song"]:not([id])
 literaturus.ru##.PlusFollowers
-news.yahoo.co.jp##.socialBtn
+yahoo.co.jp##.socialBtn
 evrl.to##div[class^="vk_group"]
 carnegie.ru##.selectionSharer
 yeniasir.com.tr##.infoMediaShare > ul > li:not(:first-child)


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/24645

− yahoo.co.jp##.socialBtn — is common for news.yahoo.co.jp, headlines.yahoo.co.jp etc.
− yahoo.co.jp##.adUltra — for desktop browser 
− all the other — for mobile browser