### PR TITLE
Update general_extensions.txt

### DIFF
--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -59,7 +59,7 @@ dvdschnaeppchen.de#%#AG_onLoad(function() { window.myatu_bgm = 0; });
 chip.de#%#var originalUserAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: function() { return originalUserAgent + ' Edge'; } });
 ! http://forum.adguard.com/showthread.php?5955
 menshealth.de#%#function google_ad_request_done() {};
-derstandard.at#%#document.cookie = "MGUID=";
+@@||ad1.adfarm1.adition.com/s$script,domain=derstandard.at
 !
 !--------------------------------------!
 !------- CSS fixes --------------------!

--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -59,6 +59,7 @@ dvdschnaeppchen.de#%#AG_onLoad(function() { window.myatu_bgm = 0; });
 chip.de#%#var originalUserAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: function() { return originalUserAgent + ' Edge'; } });
 ! http://forum.adguard.com/showthread.php?5955
 menshealth.de#%#function google_ad_request_done() {};
+derstandard.at#%#document.cookie = "MGUID=";
 !
 !--------------------------------------!
 !------- CSS fixes --------------------!


### PR DESCRIPTION
to fix the issue: https://github.com/AdguardTeam/AdguardFilters/issues/28046

[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

[//]: # (Substitute this line with a description of the problem)

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](%screenshot_url%)
</details><br/>

* **Expected behaviour**: 

[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)

<details><summary>Screenshot:</summary>

![image](%url_of_screenshot%)
</details><br/>

***Steps to reproduce the problem***:

[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)

***System configuration***

**Filters:**

[//]: # (Substitute this line with the list of your active filters, separated by commas)

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | iOS
Operating system version (Android/iOS) | iOS 12
Browser:                               | Safari
AdGuard version:                       | ?
Filters enabled:                       | ?
AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
Filtering quality (Android only):      | High-quality / High-speed / Simplified
HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
Simplified filters (iOS only)          | On / Off
AdGuard DNS:                           | None / Default / Family Protection
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
