### PR TITLE
healthline.com #25912

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -29,6 +29,8 @@ download.komputerswiat.pl###dl_breaking_news
 ||assets-ssl.nnm*/forum/new_year/$domain=nnm-club-me.appspot.com|nnm-club.lib|nnm-club.tv|nnm-club.name|nnm-club.me|nnmclub.to
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25810
 deccoria.pl##.dc-layout__nav-bar
+! healthline.com #25912 -- hiding all annoying popups
+||cloudfront.net/_next/chunks/eea-*.js$domain=healthline.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25804
 cdaction.pl,pcformat.pl,poboczem.pl,pomponik.pl,smaker.pl,styl.pl,swiatkobiety.pl,tipy.interia.pl##body > .topbar
 styl.pl##.mobile-topbar-container


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/25912

hiding all annoyings (not only privacy request, but e-mail subscription popup as well). 
that's why it's not in cookie section