### PR TITLE
fix #27284 jayisgames.com

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -53,6 +53,7 @@ kanasoku.info##.adc_g_ko_sec
 egmnow.com##.pt_mobile_ad_iframe
 egmnow.com##.pt-embed-ad-single-mobile
 m.sondakika.com##.text_reklam
+jayisgames.com##.widget-support
 newtoki.com###hd_pop
 carsales.com.au##.mrec-container
 m.adevarul.ro##.article > div[style="width:336px;height:280px;margin:5px auto;"]:not([id]):not([class])


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/27284

sponsor banner should be hidden by general filters, but other isn't an ad