### PR TITLE
fix #28050 ru.sports.euro2016liverus

### DIFF
--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -16,6 +16,7 @@
 ||graph.facebook.com^$app=com.billiards.city.pool.nation.club
 ||graph.facebook.com^$app=ibecsystems.kz.zakonkz
 ||graph.facebook.com^$app=com.supergame.ultrasharp.cutitdown
+||graph.facebook.com^$app=ru.sports.euro2016liverus
 ||graph.facebook.com^$app=com.candl.chronos
 ||graph.facebook.com^$app=com.advancedprocessmanager
 ||graph.facebook.com^$app=tv.fourgtv.fourgtv


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/28050

(fb authorization doesn't breaking)