### PR TITLE
fix #27543 chepetsk.ru

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -30,6 +30,7 @@ gdetraffic.com##.bg-link
 ||skin.ru/assets/img/promo/
 ||ximad.com/html_alternative_content/
 vk.com,ximad.com##object[data^="html_alternative_content/"]
+chepetsk.ru##.banner
 itweek.ru##.tbl-interesno
 4rama.com###logo~a[rel="nofollow"]
 4rama.com###content > a[rel="nofollow"]

--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -36,6 +36,8 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 maptiler.com#@#div.bannerbg
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28524
 draftkings.com#@#.ad-container
+! https://github.com/AdguardTeam/AdguardFilters/issues/27543
+@@||yastatic.net/share2/share.js$domain=chepetsk.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27085
 @@||yastatic.net/pcode/adfox/loader.js$domain=nashe.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27181

--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -36,8 +36,6 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 maptiler.com#@#div.bannerbg
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28524
 draftkings.com#@#.ad-container
-! https://github.com/AdguardTeam/AdguardFilters/issues/27543
-@@||yastatic.net/share2/share.js$domain=chepetsk.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27085
 @@||yastatic.net/pcode/adfox/loader.js$domain=nashe.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27181

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -61,6 +61,7 @@ teknobalta.com##.penci-social-buttons
 letelegramme.fr###toolsbar > a[class*="pw-button-"][onclick*="partage"]
 hyser.com.ua##.b__share--buttons
 atasehirweb.com##.d-share
+chepetsk.ru##.float-social-wrp
 digitalmusicnews.com##.cb-social-sharing
 hubpages.com###social_share_widget > a[class]
 gdetraffic.com##.widgets.wbg

--- a/SocialFilter/sections/whitelist.txt
+++ b/SocialFilter/sections/whitelist.txt
@@ -220,7 +220,7 @@ bie-dro.de#@#.header-social
 @@||addthis.com/js/*/addthis_widget.js^$domain=hatsandcaps.co.uk
 ! Fixing broken buttons on some sites
 @@||yandex.st/share/share.js$domain=66.ru|calculatewater.ru|ktk.kz|splav.ru|vnukovo.ru|foxtrot.com.ua|yadi.sk|gama-gama.ru|foxtrot.com.ua|radiorecord.ru|xn--80aneaaefcxzcih6g1e.xn--p1ai
-@@||yastatic.net/share*/share.js$domain=iz.ru|thequestion.ru|readovka.ru|mazda.ru|vse.fm|kinogo-720.net|xn--80aneaaefcxzcih6g1e.xn--p1ai|playground.ru|foxtrot.com.ua|biglion.ru|master-of-orion.ru|ktk.kz|universarium.org|pix.playground.ru|xn--80aaelc4ars1a7ab6d.xn--p1ai
+@@||yastatic.net/share*/share.js$domain=chepetsk.ru|iz.ru|thequestion.ru|readovka.ru|mazda.ru|vse.fm|kinogo-720.net|xn--80aneaaefcxzcih6g1e.xn--p1ai|playground.ru|foxtrot.com.ua|biglion.ru|master-of-orion.ru|ktk.kz|universarium.org|pix.playground.ru|xn--80aaelc4ars1a7ab6d.xn--p1ai
 ! zenmate.com preemium trial sign up
 zenmate.com#@#.social-networks
 ! https://forum.adguard.com/index.php?threads/14697/


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/27543


`@@||yastatic.net/share2/share.js$domain=chepetsk.ru` — fixing [photo viewer](https://chepetsk.ru/photogalery/foto-dnya/280773/)