### PR TITLE
fix businesstimes.com.sg styles

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -6518,7 +6518,6 @@ zserials.tv##noindex a[rel="nofollow"] > img
 ||bsn.ru/img/uploads/tgb/
 ||buhgalter911.com/uploads/other/az240x300.gif
 ||bukovina.biz.ua/img/
-||businesstimes.com.sg^*/ad
 ||bz.nextmail.ru/bsys/genb.php
 ||bzh.life/system/brandings/
 ||c-inform.info/images/poll_banner/


### PR DESCRIPTION
[businesstimes.com.sg](https://www.businesstimes.com.sg/technology/warning-issued-over-attacks-on-key-internet-infrastructure)

russian filter blocks css