### PR TITLE
Remove self-promotion from userstyles.org results

### DIFF
--- a/ExperimentalFilter/sections/English/specific_web_sites.txt
+++ b/ExperimentalFilter/sections/English/specific_web_sites.txt
@@ -3,3 +3,4 @@
 ! This section contain any type of rule grouped by domain.
 !
 !
+userstyles.org##.us-stylecard--short:has(.fallbackDiv)


### PR DESCRIPTION
Without rule:

![image](https://user-images.githubusercontent.com/3318223/58307558-56ecc200-7dff-11e9-8539-2ed2ded1be35.png)

With rule:

![image](https://user-images.githubusercontent.com/3318223/58307665-b34fe180-7dff-11e9-8f67-63aca6534eae.png)
