### PR TITLE
Fix #36111 magic-puff.ru

### DIFF
--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -24,6 +24,8 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 @@||vetton.ru^$jsinject,elemhide
 !#################
 !
+!https://github.com/AdguardTeam/AdguardFilters/issues/36111
+magic-puff.ru#@#.top_banner
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35339
 @@||fanserials.*/*-*-ad.html
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35101


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/36111
(the wrong name "Fix #36088 piratedhub.com" was given by mistake, sorry)

AdGuard Forum link:
https://forum.adguard.com/index.php?threads/%D0%9B%D0%BE%D0%B6%D0%BD%D0%BE%D0%B5-%D1%81%D1%80%D0%B0%D0%B1%D0%B0%D1%82%D1%8B%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-https-magic-puff-ru.33504/