### PR TITLE
P: www.dobreprogramy.pl

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -2467,7 +2467,7 @@ m.standaard.be##.dialog-backdrop
 m.standaard.be##.gdpr-dialog
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33914
 !+ PLATFORM(ios, ext_android_cb, ext_safari, ext_edge)
-||wp.pl/*-FwkqOxhmGz4XCSo7GGYbPhcJKjsYZhs-$script,domain=~pilot.wp.pl
+||wp.pl/*-FwkqOxhmGz4XCSo7GGYbPhcJKjsYZhs-$script,domain=~pilot.wp.pl|~www.dobreprogramy.pl
 !
 patient.info#$##cookie-policy-overlay { display: none !important; }
 patient.info#$#body { overflow: visible!important; }


### PR DESCRIPTION
https://github.com/MajkiIT/polish-ads-filter/issues/13715
https://github.com/MajkiIT/polish-ads-filter/issues/14332

[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

[//]: # (Substitute this line with a description of the problem)

Empty spaces after block Wirtualna Polska js library, better allow file than remove this empty spaces via cosmetic filters or with CSS (repair broken software update list in right corner).

---

GDPR pop-up cannot hiden by procedural cosmetic filtering - videos no start without accept or reject GDPR.