### PR TITLE
fix #34870 pornxs.com

### DIFF
--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -533,6 +533,7 @@ rarbgproxied.org,rarbg.to,rarbg-to.proxydude.xyz,rarbg-to.pbproxy.red,rarbg.unbl
 alluc.ee###resultlist > div#resultitems[-ext-has="> div"]~iframe:not([src])
 !
 spankwire.com###js-react-video-player > div > div > div:has(> a[href="https://www.czechsexcasting.com/"])
+pornxs.com#?#.video__container > .video__inner > div > div:contains(Advertisement)
 levelsex.com,fapjournal.com#?#.content-wrap > div > .related:has(> div > .recommended-logo)
 icegay.tv#?#.b-secondary-column__randoms > div.b-head > h3:contains(Sponsored)
 techgenix.com#?#ul.sidebar_widget > li:has(> div > .dfp_ad_pos)
@@ -557,7 +558,6 @@ wallpaperstudio10.com##.col-md-5 > div[class="card card-body"]:has(> div.text-ce
 sexy-youtubers.com##.site-sidebar > aside.widget:contains(var ad_idzone)
 mocasoft.net##.main-content > div[class^="mag-box block-custom-content"]:first-child:has(> div.container-wrapper > div.mag-box-container > div.entry > p > ins.adsbygoogle)
 milffox.com###page_content > div#side_content:has(> div > div.banner)
-pornxs.com##.video__container > .video__inner > div:not([class="video__content"])
 petri.com###sidebar > div.widget:has(> header > h6:contains(Sponsors))
 vortez.net##.sidebar-content > div.split-panel > div.right > div.panel-block:has(> div.panel-title > h2:contains(Advertisement))
 shareae.com###sidebar > div.block:has(h3.sidehead:contains(Advertising))

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -146,6 +146,7 @@ kiss-anime.ws##script[id^="BB_SLOT_"] ~ div[id][style^="overflow: hidden; width:
 aplayer2.me,viralizeit.net,sex3.com,softonic.com,3pornstarmovies.com,flvto.biz,govtsmartjob.com,cutearn.ca,dfporn.net,cll.press,hellporno.net,youramateurporn.com,getlink.pw,embedtvseries.com,keygames.com,uclick.in,flv2mp3.by,doodhwali.com,smutindia.com,dvdcover.com,xxxadultphoto.com,gabicoins.com,qpdownload.com,windows10portal.com,2conv.com,javcloud.com,underhentai.net,cutwin.com,hqasiananal.com,bradsknutson.com,flv2mp3.org,subscene.com,yourlink.in,iplayer.pw,qpornx.com,sofifa.com,jawcloud.co,indiansgetfucked.com,medi-bayreuth.de,oxforddictionaries.com,tube18.sex##.banner
 !
 eroticasearch.net###grid > .column > div[style]:not([id])
+pornxs.com##.video__container > .video__inner > div > div[data-place^="ntv"]
 rapidgatorporn.net##.full-block > center > [href][target="_blank"] > img
 ||rapidgatorporn.net/templates/rapidgatorporn/images/Flashbit.gif
 thisvid.com##.main-nav > li > a[target="_blank"]
@@ -2662,12 +2663,6 @@ addictinginfo.com###sidebar > #text-37
 bestmalevideos.com##.sidebar > div[id^="ad"]
 playcast.se###ckeckaddblock
 clipwatching.com##.cover
-pornxs.com##.ra-wrapper > .ra
-pornxs.com##.top-content > .ra
-pornxs.com##.video_spots__adv
-pornxs.com##a.squares__item-spot
-pornxs.com###player-container > #player-container-overlap
-pornxs.com###player-container > #player-container-overlap + .i4d
 tvcatchup.com##.abContainer
 jsoneditoronline.org###ad
 ||search.stream.cr/core/ads.js
@@ -4195,9 +4190,6 @@ freebitcoin.win##a[href^="https://coinad.com"]
 hentaihaven.org##.widget-area > #custom_html-3
 ||mirrorcreator.com/file_nugget.php
 fantasti.cc##.adv-notice
-pornxs.com##.partner-head-box
-pornxs.com##.video-actions .noPopunder > span
-pornxs.com##.adv_list
 amateurporn1.com##.thumbs-cubes-holder
 amateurporn1.com##.cs-link
 amateurporn1.com##.main-holder > .row + .content-holder > .thumbs-holder > .thumb:first-child
@@ -5494,7 +5486,6 @@ susutinv2.com##.adsbygoogle
 porntube.com##.videoplayer.last > div.container > div.row > div > div.row > div.col-xs-12 > div.cpp
 smallnetbuilder.com###leaderboardspacer
 forums.overclockers.co.uk###Offer
-pornxs.com##.bottom-sb
 ||pornxs.com/ajax.php?action=get_link$important
 ||pornxs.com/js/a/*.js
 whatismybrowser.com##.fun.desktop
@@ -6840,13 +6831,11 @@ vipbox.tech###html2
 csport.xyz,streamonsports.com,1me.club,streamhub.live,buffstream.net,fgames.pw,livegoal.pw,streamgaroo.com,vipbox.online###html3
 relink.to###iBunkerSlideWrap
 vidspot.net###iframebanner
-pornxs.com###imfloat
 iwatchgameofthrones.net###img-ad
 vidwatch.me###impo_overlay
 pinflix.com,pornhd.com###inVidZone
 pornhd.com###inVideoZone
 pornshareproject.org###index_stats > center > a > img
-pornxs.com###initializeAd
 lazarangelov.academy###inside-banner
 pornokeep.com,xxxtubedot.com,enjoyfuck.com,fuckgonzo.com###invideo_2
 modelsxxxtube.com,pornexpanse.com,tubesex.me,tubevintageporn.com,xxxadd.com,whitexxxtube.com###invideo_new
@@ -6894,7 +6883,6 @@ workgroupvideo.com###over-large
 arsopo.com,workgroupvideo.com###over-small
 123movies.is###overlay-123plugin
 strikeout.co,vipbox.tv###overlay_countdown
-pornxs.com###p4uze40
 porn-bb.net###page-body > div > center > a > img
 te-en.com###page-body > p > span[style="font-weight: bold; "] > a > img
 te-en.com###page-body > p > span[style="font-weight: bold; "] ~ a > img
@@ -6911,7 +6899,6 @@ vshare.eu###player-preview-container
 iyottube.com,shemalemodelstube.com,xxxity.com,handjobhub.com,wankflix.com,tgpdog.com,messytube.com,madnessporn.com,gaytiger.com,italianoxxx.com,pornpy.com,live-privates.com,shemalestube.com,amateurporn1.com,dreamamateurs.com,pornwatchers.com,ashemaletv.com,xxxkingtube.com,avforme.com,hotclips24.com,homemoviestube.com,pornclipsxxx.com,free-sex-video.net,dato.porn,freepornhq.xxx,nudez.com,myindianporn.com###playerOverlay
 daclips.in###player_ads
 exashare.com###player_imgo
-pornxs.com###pointearn_modal
 watch5s.to###pop-subscribe
 france24.com###popit
 ddlvalley.cool###post-347375
@@ -7088,7 +7075,7 @@ iwatchgameofthrones.net##.adclose-btn
 ndtv.com##.adcont
 newstracklive.com##.addBox
 fapjournal.com##.ads-video-page
-fapjournal.com,javengsub.com,youramateurporn.com,indiansexvideos.porn,onle.co,dausel.co,dotpelangi.xyz,yesnetwork.com,indiatoday.in,vidcloud.icu,mangafox.cc,mangafull.net,appvn.com,chia-anime.tv,hentaihaven.org,h2mp3.com,livetvcafe.me,photagram.net,tapas.io,freefrontend.com,ally.sh,myplaycity.com,cafemovie.me,mercadojobs.com,thepiratebay.org,sgxnifty.org,justmp4.com,cyberscoop.com,stream-mydirtyhobby.biz,filmcomment.com,youngpornvideos.com,eventcinemas.com.au,findyourlucky.com,iwannawatch.to,linuxmint.com,mobafire.com,pornxs.com,themepack.me##.ads
+fapjournal.com,javengsub.com,youramateurporn.com,indiansexvideos.porn,onle.co,dausel.co,dotpelangi.xyz,yesnetwork.com,indiatoday.in,vidcloud.icu,mangafox.cc,mangafull.net,appvn.com,chia-anime.tv,hentaihaven.org,h2mp3.com,livetvcafe.me,photagram.net,tapas.io,freefrontend.com,ally.sh,myplaycity.com,cafemovie.me,mercadojobs.com,thepiratebay.org,sgxnifty.org,justmp4.com,cyberscoop.com,stream-mydirtyhobby.biz,filmcomment.com,youngpornvideos.com,eventcinemas.com.au,findyourlucky.com,iwannawatch.to,linuxmint.com,mobafire.com,themepack.me##.ads
 google.ae,google.at,google.be,google.by,google.ca,google.ch,google.cl,google.cn,google.co.id,google.co.in,google.co.jp,google.co.th,google.co.uk,google.co.ve,google.co.za,google.com,google.com.ar,google.com.au,google.com.bd,google.com.br,google.com.co,google.com.eg,google.com.hk,google.com.mx,google.com.my,google.com.ng,google.com.pe,google.com.ph,google.com.pk,google.com.sa,google.com.sg,google.com.tr,google.com.tw,google.com.ua,google.com.vn,google.de,google.dk,google.ee,google.es,google.fr,google.gr,google.hu,google.ie,google.it,google.nl,google.no,google.pl,google.pt,google.ro,google.rs,google.ru,google.se,google.sk,google.tn##.ads-ad
 heroesfire.com,mobafire.com,pgfire.net,vaingloryfire.com##.ads-narrow
 hwinfo.com##.ads2
@@ -7388,7 +7375,6 @@ redtube.com##.removeAdLink
 alluc.ee##.resblockx
 sammobile.com##.rev
 allrecipes.com##.review-ad-space
-pornxs.com##.right-add
 jizzbunker.com##.right-banners
 pcmag.com##.right-frame
 royalcams.com,100tipcams.com,adultcams.me,adultchat2100.com,alphafreecams.com,bimbolive.com,bongacam.net,bongacam.org,bongacams-chat.ru,bongacams.com,bongacams.eu,bongacams2.com,cammbi.com,dcmoz.net,prostocams.com,r2games.com,redlightarea.com,smutcam.com##.right_banner


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/34870
I deleted this rule `pornxs.com##.video__container > .video__inner > div:not([class="video__content"])` because it broke the site functional (not main player - overlay player from videos below). Also deleted obsolete rules and some left-overs from overlay player.