### PR TITLE
fix #40427 dominos.de

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -2512,6 +2512,9 @@ calvinklein.be#$#body { overflow: visible!important; }
 calvinklein.be#$#.cookie-notice { display: none !important; }
 calvinklein.be#$#.ReactModal__Overlay { display: none !important; }
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/40427
+!+ PLATFORM(ios)
+dominos.de##.DE_v1 div[role="alertdialog"]
 !+ NOT_PLATFORM(ios, ext_android_cb, ext_opera, ext_ublock, ext_ff)
 m.standaard.be##.dialog-backdrop
 !+ NOT_PLATFORM(ios, ext_android_cb, ext_opera, ext_ublock, ext_ff)


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/40427
Only reproduced on iOS and can be blocked by this rule.