### PR TITLE
fix #40728 ifys.net

### DIFF
--- a/TurkishFilter/sections/antiadblock.txt
+++ b/TurkishFilter/sections/antiadblock.txt
@@ -123,8 +123,6 @@ intekno.net#@##adcontent
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29470
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||masonlar.org^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/28772
-ifsalarlayasiyoruz.pw,ifsalarlayasiyoruz.me,turkifsa.me#@##adsense
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28643
 @@||teve2.com.tr/static_files/adframe.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27590


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/40728
Deleted obsolete rule because these sites were banned by the U.S. government.