### PR TITLE
fix #40994 beeng.net

### DIFF
--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -5977,6 +5977,9 @@ brandbuffet.in.th#@#.category-advertorial
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40962
 @@||win10.vn/wp-content/plugins/dh-anti-adblocker/assets/js/showads.js
 win10.vn#%#AG_setConstant('canRunAds', 'true');
+! https://github.com/AdguardTeam/AdguardFilters/issues/40994
+beeng.net##.image-plus
+beeng.net###emebeded_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40675
 @@||fullcrackpc.com/ads.js
 fullcrackpc.com##.float-ck


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/40994
Popup not reproduced with `ABPVN list`.