### PR TITLE
fix #41127 properm.ru

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -46,6 +46,7 @@ dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,ec
 ||nanosystems.it/js/nanoGDPR.min.js
 youtube.com##.mealbar-promo-renderer
 ulule.com###react-ulule-header > div[class="sc-gojNiO gBoKcs"]
+||properm.ru/*/panel_$script
 xlbygg.se##.cookievarning-wrap:not(body):not(html)
 tvguide.com##body > div[x-enc][id^="-m_"][class^="-"]
 appledaily.com###div-GDPR-message

--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -28,6 +28,9 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 aliexpress.com#@#.right-banner
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38706
 lacentrale.fr#@#.adContainer
+! https://github.com/AdguardTeam/AdguardFilters/issues/41127
+@@||ads.adfox.ru^$xmlhttprequest,domain=properm.ru
+@@||yastatic.net/pcode/adfox/loader.js$domain=properm.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38042
 0xxx.ws#@#.rkl
 ! https://forum.adguard.com/index.php?threads/https-medicina-ua.34345/

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -28,6 +28,7 @@ avclub.com,clickhole.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotak
 medium.com##a[href*="/share/twitter?source=follow_footer"]
 medium.com##a[href*="/share/facebook?source=follow_footer"]
 tvspielfilm.de##.social-media-links
+properm.ru##a.t-social-button:not(.t-social-button_blablanator)
 timesofindia.indiatimes.com##.shareIcons
 quoodo.com##.share_div
 belsat.eu##.social_global


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41127
Whitelisted `adfox` for fix blank article.