### PR TITLE
fix #41211 anitokyo.tv

### DIFF
--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -55,7 +55,7 @@ autonews.ru,rbc.ru,sportrbc.ru#@#.banner__container
 od-news.com#@##adsense
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41211
 anitokyo.tv#$#.adsbox.ads.new-ads.wrap-ads { height: 1px!important; }
-!+ PLATFORM(ext_android_cb, ext_safari, ios)
+!+ PLATFORM(ext_android_cb, ios)
 anitokyo.tv#@#.wrap-ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37527
 sebeadmin.ru#%#AG_abortInlineScript('script', 'document.createElement');

--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -53,6 +53,10 @@ autonews.ru,rbc.ru,sportrbc.ru#@#.banner__container
 @@||ddnk.advertur.ru/*/loader.js$domain=slomal-telefon.ru
 ! https://forum.adguard.com/index.php?threads/https-od-news-com.34353/
 od-news.com#@##adsense
+! https://github.com/AdguardTeam/AdguardFilters/issues/41211
+anitokyo.tv#$#.adsbox.ads.new-ads.wrap-ads { height: 1px!important; }
+!+ PLATFORM(ext_android_cb, ext_safari, ios)
+anitokyo.tv#@#.wrap-ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37527
 sebeadmin.ru#%#AG_abortInlineScript('script', 'document.createElement');
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41211
Also works `anitokyo.tv#%#AG_abortOnPropertyRead('premiumButton');`, but it hides premium button and simple way is better.