### PR TITLE
fix #41306 rutracker.org

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -8117,7 +8117,7 @@ mirtesen.aif.ru,mirtesen.profile.ru,mirtesen.sovsport.ru,mirtesen.spletnik.ru,mi
 !
 ! START: rutracker/pornolab
 ||static.t-ru.org/templates/v1/images/vpn/vpn_button_
-cccp-rutracker.org,pornolab.biz,pornolab.cc,pornolab.lib,pornolab.net,rutracker-org.appspot.com,rutracker.cr,rutracker.lib,rutracker.net,rutracker.nl,rutracker.org##.attach > tbody > tr[class="row3 tCenter"]:last-child > td[style="height: 24px;"]
+cccp-rutracker.org,pornolab.biz,pornolab.cc,pornolab.lib,pornolab.net,rutracker-org.appspot.com,rutracker.cr,rutracker.lib,rutracker.net,rutracker.nl,rutracker.org##.attach > tbody > tr[class="row3 tCenter"]:last-child > td[style="padding: 6px;"]
 cccp-rutracker.org,pornolab.biz,pornolab.cc,pornolab.lib,pornolab.net,rutracker-org.appspot.com,rutracker.cr,rutracker.lib,rutracker.net,rutracker.nl,rutracker.org###adriver-240x120
 cccp-rutracker.org,pornolab.biz,pornolab.cc,pornolab.lib,pornolab.net,rutracker-org.appspot.com,rutracker.cr,rutracker.lib,rutracker.net,rutracker.nl,rutracker.org###bn-bot-wrap
 cccp-rutracker.org,pornolab.biz,pornolab.cc,pornolab.lib,pornolab.net,rutracker-org.appspot.com,rutracker.cr,rutracker.lib,rutracker.net,rutracker.nl,rutracker.org###bn-mg-bottom


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41306
A bit changed rule or it can be blocked by that rule `rutracker.org##.attach > tbody > tr[class] > td[colspan][style] > a[rel="nofollow"][target="_blank"]`.