### PR TITLE
fix #41774 jetfilmizle.vip

### DIFF
--- a/EnglishFilter/sections/whitelist_stealth.txt
+++ b/EnglishFilter/sections/whitelist_stealth.txt
@@ -30,7 +30,7 @@
 ! https://forum.adguard.com/index.php?threads/34955/ [Stealth Mode - Referrer]
 @@||potokcdn.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41774 [Stealth Mode - Referrer]
-@@||hls.jetcdn.co^$stealth
+@@||hls.jetcdn.co/public/dist/index.html^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40983 [Stealth Mode - Referrer]
 @@||linkvietvip.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41136 [Stealth Mode - Referrer]

--- a/EnglishFilter/sections/whitelist_stealth.txt
+++ b/EnglishFilter/sections/whitelist_stealth.txt
@@ -29,6 +29,8 @@
 @@||algolia.net/*/indexes/*/queries?x-algolia-agent*vue-instantsearch*algolia-api-key$stealth
 ! https://forum.adguard.com/index.php?threads/34955/ [Stealth Mode - Referrer]
 @@||potokcdn.com^$stealth
+! https://github.com/AdguardTeam/AdguardFilters/issues/41774 [Stealth Mode - Referrer]
+@@||hls.jetcdn.co^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40983 [Stealth Mode - Referrer]
 @@||linkvietvip.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41136 [Stealth Mode - Referrer]

--- a/EnglishFilter/sections/whitelist_stealth.txt
+++ b/EnglishFilter/sections/whitelist_stealth.txt
@@ -30,7 +30,7 @@
 ! https://forum.adguard.com/index.php?threads/34955/ [Stealth Mode - Referrer]
 @@||potokcdn.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41774 [Stealth Mode - Referrer]
-@@||hls.jetcdn.co/public/dist/index.html^$stealth
+@@||hls.jetcdn.co/public/dist/index.html$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40983 [Stealth Mode - Referrer]
 @@||linkvietvip.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41136 [Stealth Mode - Referrer]


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41774#issuecomment-538633378
`[Stealth Mode - Referrer]` breaks page navigation. You can reproduce it with app.