### PR TITLE
fix #41853 hl-live.de

### DIFF
--- a/GermanFilter/sections/antiadblock.txt
+++ b/GermanFilter/sections/antiadblock.txt
@@ -730,6 +730,8 @@ thueringer-allgemeine.de#@#.ad01
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39642
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 ||buy.tinypass.com/checkout/template/show?displayMode=$domain=waz.de
+! https://github.com/AdguardTeam/AdguardFilters/issues/41853
+@@||hl-live.de/*/adserversolutions/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34042
 !+ NOT_PLATFORM(windows, mac, android)
 @@||zwergenstadt.com^$generichide


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41853
It is blocked by `/adserversolutions/*` from `EasyList`.