### PR TITLE
fix #41876 history.com

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -2097,7 +2097,7 @@ masterani.me##a[href^="https://www.masterani.me/out/"] > img
 ||masterani.me/static/neenee/*-*.$image
 sunderlandecho.com##.slab__block > #adSlotMainContent1 + .backfill-cta
 history.com##.m-header-ad
-history.com##.m-in-content-ad-row
+history.com##aside.m-in-content-ad-row
 postandcourier.com##.dfp-ad-div
 postandcourier.com##div[itemprop="articleBody"] #queryly_campaign
 nudogram.com##ul.primary > li > a[target="_blank"]:not([href*="nudogram.com"])


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/41876
`history.com##.m-in-content-ad-row` this rule didn't work on my end with ext/app, but with that `history.com##aside.m-in-content-ad-row` it's ok.