### PR TITLE
removed xxl.fi#%#document.cookie = "cookies-accepted=true";

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -3059,7 +3059,6 @@ peugeot-motocycles.com#%#document.cookie = "seenCookieBanner=true";
 bajajauto.com#%#document.cookie = "agree_web=Agree";
 penny.hu#%#document.cookie = "accepted-cookie-consent=yes";
 gamer.nl#%#document.cookie = "SITE_COOKIE_CONSENT=True";
-xxl.fi#%#document.cookie = "cookies-accepted=true";
 woolworth.de#%#document.cookie = "useragreement=1";
 bndestem.nl#%#AG_onLoad(function() { if (document.cookie.indexOf('nl_cookiewall_version') == -1) { document.cookie = "nl_cookiewall_version=4"; location.reload(); } });
 sportnieuws.nl#%#AG_onLoad(function() { setTimeout(function() { if(window.location.href.indexOf("/cookie-wall") != -1){ var el = document.querySelector('#agree_with_cookie_terms'); if(el) el.click(); }}, 300); });


### PR DESCRIPTION
That is not needed anymore.

It was needed because blocking cookie banner caused breakages #27719 but as xxl.fi have updated their website and changed that cookie message so that it won't cause breakages if it's blocked.