### PR TITLE
fix katcr.co

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -973,6 +973,9 @@ g-tv.ru/videomore_gtv.php?video_id=*&auto_play=1$domain=kino-dom.tv
 24tv.ua##.programs_wrap
 ! translate.google.ru/com - Improve Google Translate
 translate.google.com,translate.google.com.ua,translate.google.ru###gt-promo-lr
+! katcr.co "IP-LOGGED"
+katcr.co##.logo
+katcr.co##.alert--danger.alert
 !
 ! sports.ru - START
 !


### PR DESCRIPTION
**"IP-LOGGED" information box**
on search results, "Browse" page, individual torrent pages and the torrent listing page that clicking the logo leads you to:
`katcr.co##.logo`
Not sure why the ID is ".logo". I do not block any logos.
And on `https://katcr.co/gallery/movies/page/`:
`katcr.co##.alert--danger.alert`

[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**:  A red box telling you that your IP is logged and that you should "protect your online privacy". There are no links to a VPN or anything, so it is not a sponsored message, just annoying.

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/57503195/72084170-4db75380-3303-11ea-9d26-99704e8b0f6c.png)
)
</details><br/>

***Steps to reproduce the problem***:

Go to any of the mentioned pages (I am purposly not linking directly) and you will see it.

***System configuration***

**Filters:**

Plently but I have checked that there is not a conflict. I am not using Fanboy's annoyances.

Information                            | Value
---                                    | ---
Operating system:                      | W10 64-bit
Operating system version (Android/iOS) | ?
Browser:                               | Firefox 72.0.1 64-bit
AdGuard version:                       | I am using uBlock Origin
Filters enabled:                       | ?
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
