### PR TITLE
Hide friends recommendation from private page VK.com

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -656,6 +656,7 @@ wikipedia.org##.cnotice
 emaze.com#%#var _st = window.setTimeout; window.setTimeout = function(a, b) { if(!/loginPopup.show/.test(a)){ _st(a,b);}};
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23739
 vk.com##.feed_friends_recomm
+vk.com###profile_friends_recomm
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7747
 vk.com##aside[aria-label="Актуальные новости"]
 ! https://forum.adguard.com/index.php?threads/https-www-cinemaximum-com-tr.26866/


### PR DESCRIPTION

***Description***:
* **Current behaviour**: 
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/4050715/72277954-c21c2a80-3654-11ea-9681-8c1c90cf2e02.png)

</details><br/>

* **Expected behaviour**: 

[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/4050715/72278180-48387100-3655-11ea-856e-fa053600e980.png)

</details><br/>

***Steps to reproduce the problem***:
* Go to private profile in VK.com

**My Solution:**
`vk.com###profile_friends_recomm`

***System configuration***

Information                            | Value
---                                    | ---
Operating system:                      | Ubuntu Linux
Browser:                               | Chrome
AdGuard version:                       | 3.3.8
