### PR TITLE
Fix Cookie overlay on AdguardTeam/AdguardFilters/issues/49133

### DIFF
--- a/AnnoyancesFilter/sections/cookies_general.txt
+++ b/AnnoyancesFilter/sections/cookies_general.txt
@@ -893,7 +893,6 @@
 ###viewlet-cookiepolicy
 ###vscookieAlertCont
 ###vvc_cookie
-###wa_cmpOverlay
 ###warn-cookies-area
 ###warning_cookie
 ###wdg_cookie_bar

--- a/AnnoyancesFilter/sections/cookies_general.txt
+++ b/AnnoyancesFilter/sections/cookies_general.txt
@@ -893,6 +893,7 @@
 ###viewlet-cookiepolicy
 ###vscookieAlertCont
 ###vvc_cookie
+###wa_cmpOverlay
 ###warn-cookies-area
 ###warning_cookie
 ###wdg_cookie_bar

--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -793,7 +793,7 @@ migora.pl###topInfoContainer1 > #topInfo1
 commerzbank.de###uc-banner-modal
 dormando.de###up-cookie
 vive.com###vive-cookie-notice
-frontpage.fok.nl,linkiesta.it,klusidee.nl,welklidwoord.be,welklidwoord.nl###wa_cmpOverlay
+frontpage.fok.nl,linkiesta.it,klusidee.nl,vandale.nl,welklidwoord.be,welklidwoord.nl###wa_cmpOverlay
 soakandsleep.com###wagento-cp-wrap
 tarifikolay.com###warnings > .personal-data-usage
 mysoftware.esko.com###web-messages


### PR DESCRIPTION
This fixes the Cookie overlay reported on https://github.com/AdguardTeam/AdguardFilters/issues/49133 

Other cookie generics worthy from this site:

`##.as-oil-content-overlay`
`##.as-oil[data-qa="oil-Layer"]`