### PR TITLE
gismeteo.ru [by, md, kz] - direct

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -261,8 +261,9 @@ otzovik.com#%#AG_defineProperty('Ya.loaderVer', { value: undefined });
 ! auto.ru
 auto.ru#%#//scriptlet('abort-on-property-read', 'Object.prototype.getAdditionalBanners')
 auto.ru#%#//scriptlet('set-constant', 'window.AD2', 'undefined')
-! gismeteo domains
-gismeteo.ru,gismeteo.by,gismeteo.pl,gismeteo.lt,gismeteo.md,gismeteo.kz#%#//scriptlet('abort-on-property-read', 'Object.prototype.loadAd')
+! gismeteo domains: gismeteo.ru,gismeteo.by,gismeteo.pl,gismeteo.lt,gismeteo.md,gismeteo.kz
+gismeteo.ru,gismeteo.by,gismeteo.md,gismeteo.kz#%#//scriptlet("abort-on-property-read", "Object.prototype.loadRtb")
+gismeteo.by#%#//scriptlet("abort-on-property-write", "yaads")
 !
 ! checkadblock.ru
 ||d2wy8f7a9ursnm.cloudfront.net/v*/bugsnag.min.js$domain=checkadblock.ru


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardExtra/issues/67
I noticed direct on this domains: 
```
gismeteo.ru
gismeteo.by
gismeteo.md
gismeteo.kz
```

. For `gismeteo.by` we need additional scriptlet.
