### PR TITLE
I added the Tor versions of major domains, for their entries that originally lacked them, in Base and Mobile

### DIFF
--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -6990,7 +6990,7 @@ aranzulla.it#?#body > div[id][class][-ext-has="a[href^='/locked-no-script.php']"
 @@||traffichaus.com/scripts/*ad*.js$domain=spankwire.com|hdzog.com
 ! https://forum.adguard.com/index.php?threads/facebook-com.12519/
 @@||fbcdn-creative-a.akamaihd.net/hads-ak-prn2/
-@@||ad.atdmt.com/m/*account_id=*&source=cm&step=1^$domain=facebook.com
+@@||ad.atdmt.com/m/*account_id=*&source=cm&step=1^$domain=facebook.com|facebookcorewwwi.onion
 ! https://forum.adguard.com/index.php?threads/14760/
 ! https://forum.adguard.com/index.php?threads/http-jav-720p-com-nsfw.20255/
 @@||dato.porn/js/pop.js|
@@ -7665,7 +7665,7 @@ envatostuff.rocks##.adblock_detector
 ! http://forum.adguard.com/showthread.php?7001
 zippymoviez.cc###h97e
 ! http://forum.adguard.com/showthread.php?6948
-pornhub.com###abAlert
+pornhub.com,pornhubthbh7ap3u.onion###abAlert
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/774
 dayt.se#$##synpit { height:1px!important; }
 ! http://forum.adguard.com/showthread.php?6916

--- a/EnglishFilter/sections/content_blocker.txt
+++ b/EnglishFilter/sections/content_blocker.txt
@@ -2007,7 +2007,7 @@ fxporn.net#@#.video_ads
 @@||ahcdn.com/*.mp4$domain=xhamster.com
 @@||xhcdn.com/*.mp4$domain=xhamster.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7211
-@@||google.com/recaptcha/$domain=pornhub.com
+@@||google.com/recaptcha/$domain=pornhub.com|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6731
 @@||cdnjs.cloudflare.com/ajax/libs/$domain=xmoviesforyou.com
 @@||fruithosted.net/dl/*.mp4
@@ -2185,7 +2185,7 @@ cari.com.my###cvidloader
 ! finn.no - fixing advertisement, which opens in the new tab
 @@||finn.no/*/ad.html?
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1142
-@@||static.pornhub.phncdn.com^$domain=pornhub.com
+@@||static.pornhub.phncdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion
 ! http://forum.adguard.com/showthread.php?7751
 ! Fixing endless loading
 @@||b.kavanga.ru/exp?sid=$domain=deita.ru

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -323,8 +323,8 @@ duplichecker.com#$?#.adsbygoogle { remove: true; }
 duplichecker.com#?#.side-bar > .search-panel-sec:has(> .adds_box)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/36458
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33406
-nytimes.com#?#div[class^="css-"][class*=" "]:has(> div[class^="css-"][class*=" "] > div[class^="css-"] > div > .ad)
-nytimes.com#?#div[data-testid="block-Well"] > div[class^="css-"] > [class^="css-"][data-well-section="well-section"]:has(> div[class^="css-"] > div > .ad)
+nytimes.com,nytimes3xbfgragh.onion#?#div[class^="css-"][class*=" "]:has(> div[class^="css-"][class*=" "] > div[class^="css-"] > div > .ad)
+nytimes.com,nytimes3xbfgragh.onion#?#div[data-testid="block-Well"] > div[class^="css-"] > [class^="css-"][data-well-section="well-section"]:has(> div[class^="css-"] > div > .ad)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33323
 mensxp.com#?#.mb-50 > div[class*=" "]:has(> div > div > a[onclick])
 ! pcsteps.com - ad in article
@@ -354,8 +354,8 @@ hackedonlinegames.com#$?#div[class=""][style^="display: block !important; visibi
 economictimes.indiatimes.com#?#.pageContent > .articleSep:has(div[class*=" "] > div > div > a[onclick])
 economictimes.indiatimes.com#?#.tabdata > div[class*=" "]:has(> div > a[onclick])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31362
-nytimes.com#?##app > #site-content > div[class] > div[class^="css-"] > div[class^="css-"][class*=" "]:has( div[class^="css-"][class*=" "] > .ad)
-nytimes.com#?#div[data-testid="block-Well"] > div[class] > div[data-well-section="well-section"]:has( > div[class] > .ad)
+nytimes.com,nytimes3xbfgragh.onion#?##app > #site-content > div[class] > div[class^="css-"] > div[class^="css-"][class*=" "]:has( div[class^="css-"][class*=" "] > .ad)
+nytimes.com,nytimes3xbfgragh.onion#?#div[data-testid="block-Well"] > div[class] > div[data-well-section="well-section"]:has( > div[class] > .ad)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30970
 wordexcerpt.com#?##main-sidebar > .widget_text > div[id^="custom_html-"].default:has(> .c-widget-wrap > .font-heading > h4:contains(Advertisement))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30737
@@ -888,8 +888,8 @@ time.com#?#div[class="row vZMmMa_9"] > div[class="column small-12"] > div.row[-e
 dailytelegraph.com.au#?#.widget-area-main-content > div.widget_newscorpau_capi_sync_collection > div.tgs-mosaicv2-rootwidget div.tgc-mosaicv2-slim-m_flex_child[-ext-has='> article.tge-cardv2 > a.tge-cardv2_wrapper[href="#"]']
 ! facebook.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8124
-t.facebook.com#?#div[id^="more_pager_pagelet_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="/ads/about"]']
-t.facebook.com#?#div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="https://t.facebook.com/ads/about"]']
+t.facebook.com,t.facebookcorewwwi.onion#?#div[id^="more_pager_pagelet_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="/ads/about"]']
+t.facebook.com,t.facebookcorewwwi.onion#?#div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='a[href^="https://t.facebook.com/ads/about"]']
 ! facebook.com,facebookcorewwwi.onion#?#div[id^="substream_"] div[id^="hyperfeed_story_id_"][-ext-has='div[id^="feed_subtitle"] > span > a[href="#"] > div[class] > div[class]:not(.timestampContent)']
 ! facebook.com#?#div[id^="substream_"] div[id^="hyperfeed_story_id_"]:has(div._5pcp._5lel > span div a[href="#"])
 ! https://forum.adguard.com/index.php?threads/facebook-com.21192/
@@ -955,8 +955,8 @@ audiobookbay.me,audiobookbay.la,audiobookeo.com#?##page > div#rsidebar > ul > li
 audiobookbay.me,audiobookbay.la,audiobookeo.com#?##page > div#rsidebar > ul > li[-ext-has="> h2:contains(Sponsor Links)"]
 audiobookbay.me,audiobookbay.la,audiobookeo.com#?#.torrent_info > tbody > tr[-ext-has='> td[valign="top"]:contains(Ads:)']
 ! https://github.com/uBlockOrigin/uAssets/issues/471
-pornhub.com#?#.sectionWrapper > div[class*=" "][-ext-has='> div[class]:only-child > a.removeAdLink']
-pornhub.com#?#body > .wrapper + div[class][-ext-has='> .removeAdLink']
+pornhub.com,pornhubthbh7ap3u.onion#?#.sectionWrapper > div[class*=" "][-ext-has='> div[class]:only-child > a.removeAdLink']
+pornhub.com,pornhubthbh7ap3u.onion#?#body > .wrapper + div[class][-ext-has='> .removeAdLink']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5454
 csgosquad.com#?#.col-xs-6 > .panel[-ext-has='>.panel-heading>.panel-title:contains(Advertisement)']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5403
@@ -1057,7 +1057,7 @@ listoffreeware.com#?#div[class$="post excerpt"][-ext-has='ins[class$="adsbygoogl
 ! https://forum.adguard.com/index.php?threads/13471/
 cnn.com#?#div[class^="column zn__column--idx-"][-ext-has='h2[data-analytics$="Paid Partner Content_list-xs_"]']
 ! https://forum.adguard.com/index.php?threads/13479/
-pornhub.com#?#.sectionWrapper > div.psWrapper[-ext-has="a.removeAdsStyle"]
+pornhub.com,pornhubthbh7ap3u.onion#?#.sectionWrapper > div.psWrapper[-ext-has="a.removeAdsStyle"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7912
 thedailybeast.com#?#.HomePage__two-columns-wrapper .Card[-ext-has='.AdSlot']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8377

--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -150,7 +150,7 @@ pandamovies.me,porcore.com,dbupload.co,fileru.me,mangoporn.net,pornkino.cc,watch
 pandamovies.me,porcore.com,dbupload.co,fileru.me,mangoporn.net,pornkino.cc,watchpornfree.info,imguur.pictures,xxxmoviestream.xyz,mangoporn.co,kickass.vc,pandavideo.pw,freshscat.com,playpornfree.xyz,kickass.love,desiupload.in,xopenload.me,streamporn.pw#%#//scriptlet("set-constant", "puShown", "true")
 !
 ! AdSupply clickunder
-mirrorcreator.com,fullmatchesandshows.com,tinypic.com,tube8.com,youporn.com,redtube.com,pornhub.com#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() { }; } });
+mirrorcreator.com,fullmatchesandshows.com,tinypic.com,tube8.com,youporn.com,redtube.com,pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() { }; } });
 vporn.com#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() {}; } });
 !
 spankwire.com#%#Object.defineProperty(document, 'onclick', { get: function() { return; } });
@@ -1012,7 +1012,7 @@ powvldeo.net#%#Object.defineProperty(window,"puOverlay",{get:function(){return f
 dailymotiontomp3.com#%#AG_setConstant('IsPopAd', 'false');
 dailymotiontomp3.com#%#(function() { window.open_ = window.open; var w_open = window.open, regex = /rotumal\.com/; window.open = function(a, b) { if (typeof a !== 'string' || !regex.test(a)) { w_open(a, b); } }; })();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33064
-pornhub.com#%#Object.defineProperty(Object.prototype, 'loadPopUnder', { get: function(){ return function() {}; }, set: function(){ return function() {}; }});
+pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(Object.prototype, 'loadPopUnder', { get: function(){ return function() {}; }, set: function(){ return function() {}; }});
 ! gosswatch.com - popunder when playing video
 goss.watch,gosswatch.com#%#AG_setConstant('pop', 'noopFunc'); 
 ! mediafire.com - ad redirect on download
@@ -1902,7 +1902,7 @@ pornhd.com#%#Object.defineProperty(window, 'smPop', { get: function() { return {
 ! https://github.com/AdguardTeam/AdguardFilters/issues/4874
 9to5google.com,9to5mac.com,9to5toys.com,electrek.co#%#window.canRunAds = true; window.OXHBConfig = {};
 ! pornhub.com
-pornhub.com#%#Object.defineProperty(window,'tj_ads',{get:function(){return[]}});
+pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(window,'tj_ads',{get:function(){return[]}});
 ! https://forum.adguard.com/index.php?threads/18375/
 openload.cz#%#window.addEventListener("load", function(){ var el = document.getElementById("videooverlay"); if(el){el.click();} });
 verystream.com,oladblock.me,oladblock.xyz,oladblock.services,oload.space,oload.live,oload.club,openload.pw,oload.fun,oload.icu,oload.cloud,oload.download,oload.stream,oload.info#%#window.addEventListener("load", function(){ var el = document.getElementById("videooverlay"); if(el){el.click();} });
@@ -2236,7 +2236,7 @@ zive.cz#%#AG_onLoad(function() { window.VIDEO_AD_ENABLED = false; } );
 ! filecore anti-adblock
 fcore.eu#%#AG_onLoad(function() { window.checkAds = function() {}; });
 ! pornhub.com -- it does not show popups in opera
-pornhub.com#%#window.opera = true;
+pornhub.com,pornhubthbh7ap3u.onion#%#window.opera = true;
 ! http://forum.adguard.com/showthread.php?3431
 secureupload.eu#%#window.open = function() {};
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/47
@@ -2415,9 +2415,9 @@ mysanantonio.com#$#header > nav#siteNav[class="site-nav menu-slide"] { transform
 mysanantonio.com#$#header > nav#siteNav[class^="site-nav menu-slide fixed"] { top: 0!important; }
 mysanantonio.com#$#header > #homepage-timestamp { position: relative!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31362
-nytimes.com#$#ol[data-testid="search-results"] > li[data-testid="search-add-result"] > div[class] { border-top:0!important; padding-top:0px!important;}
-nytimes.com#$#ol[data-testid="search-results"] > li[data-testid] + li:not([data-testid]) + li[data-testid="search-bodega-result"] > div[class] { border-top:0!important; padding-top:0px!important;}
-nytimes.com#$##stream-panel > .supplemental > aside[class] { border-top:0!important; }
+nytimes.com,nytimes3xbfgragh.onion#$#ol[data-testid="search-results"] > li[data-testid="search-add-result"] > div[class] { border-top:0!important; padding-top:0px!important;}
+nytimes.com,nytimes3xbfgragh.onion#$#ol[data-testid="search-results"] > li[data-testid] + li:not([data-testid]) + li[data-testid="search-bodega-result"] > div[class] { border-top:0!important; padding-top:0px!important;}
+nytimes.com,nytimes3xbfgragh.onion#$##stream-panel > .supplemental > aside[class] { border-top:0!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31215
 gamerant.com#$#.ezoic-ad { position: absolute!important; left: -3000px!important; }
 ! minecraftmaps.com - ads
@@ -2442,7 +2442,7 @@ brisbanetimes.com.au#$#div[id^="adspot-"] { position: absolute!important; left: 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27690
 limetorrents.asia#$#a[href^="/media.php?"][rel="nofollow"][style^="display: block !important"] { position: absolute!important; left: -3000px!important; }
 ! pornhub.com ad left-over on main page
-pornhub.com#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; } 
+pornhub.com,pornhubthbh7ap3u.onion#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; } 
 ! https://forum.adguard.com/index.php?threads/up-4-net.30856/
 up-4.net#$##btn_downloadLink { display:block!important; }
 up-4.net#$##btn_downloadPreparing { display:none!important; }
@@ -2848,8 +2848,8 @@ yeptube.com#$#div[class="thr-rcol"] > div[class="container mt15"] { visibility: 
 ! https://forum.adguard.com/index.php?threads/24651/
 youpornru.com#$#.column-flex { width: auto!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6510
-pornhub.com#$#.playerFlvContainer > div#pb_template[style] { position: absolute!important; left: -3000px!important; }
-pornhub.com#$#.video-wrapper > div#player~div[class$=" hd clear"] { position: absolute!important; left: -3000px!important; }
+pornhub.com,pornhubthbh7ap3u.onion#$#.playerFlvContainer > div#pb_template[style] { position: absolute!important; left: -3000px!important; }
+pornhub.com,pornhubthbh7ap3u.onion#$#.video-wrapper > div#player~div[class$=" hd clear"] { position: absolute!important; left: -3000px!important; }
 ! https://forum.adguard.com/index.php?threads/24633/
 perfectgirls.net#$#.list__item { margin-right: auto!important; }
 perfectgirls.net#$#.list__item { margin-left: auto!important; }
@@ -3147,7 +3147,7 @@ motherless.com$$script[tag-content="_ml_ads_ns"][min-length="4000"][max-length="
 ! viprow.net - ad reinject
 viprow.net$$script[tag-content="SEYfRO"][min-length="49000"][max-length="52000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33064
-pornhub.com$$script[tag-content="loadPopUnder"][min-length="30000"][max-length="60000"]
+pornhub.com,pornhubthbh7ap3u.onion$$script[tag-content="loadPopUnder"][min-length="30000"][max-length="60000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34622
 letmejerk.com$$script[tag-content="ExoLoader"][min-length="15000"][max-length="35000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33095

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -10,14 +10,14 @@ porn00.org##.fridaydesk
 |https://$image,script,stylesheet,subdocument,third-party,xmlhttprequest,domain=topeuropix.net,badfilter
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6470
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=123220#p123220
-pornhub.com##div > [style] iframe[width][height]:not(iframe[src^="https://www.google.com/recaptcha/"])
-pornhub.com##[style] > div > iframe[width]:first-child:not(iframe[src^="https://www.google.com/recaptcha/"])
+pornhub.com,pornhubthbh7ap3u.onion##div > [style] iframe[width][height]:not(iframe[src^="https://www.google.com/recaptcha/"])
+pornhub.com,pornhubthbh7ap3u.onion##[style] > div > iframe[width]:first-child:not(iframe[src^="https://www.google.com/recaptcha/"])
 ! https://forums.lanik.us/viewtopic.php?p=121479#p121479
 gelbooru.com##a[href*="/track/"]
 gelbooru.com#@#span[class]:last-child > a img[src]
 !##################
 !
-|ws*://$websocket,domain=fullmatchesandshows.com|1337x.to|allkpop.com|auroravid.to|bitvid.sx|boards2go.com|celebdirtylaundry.com|celebritymozo.com|collectivelyconscious.net|dailycaller.com|destructoid.com|dumpaday.com|firstrowau.eu|firstrowus1.eu|flash-x.tv|flashsx.tv|flashx.me|flashx.run|flashx.tv|flashx1.tv|flashxx.tv|fmovies.to|free-torrent.org|free-torrents.org|gamenguide.com|gofirstrow.eu|gorillavid.in|gsmarena.com|health-weekly.net|i4u.com|ifirstrow.eu|ifirstrowit.eu|img24.org|instanonymous.com|itechpost.com|izismile.com|jpost.com|lifehacklane.com|livescience.com|mobilenapps.com|mobipicker.com|natureworldnews.com|navbug.com|ncscooper.com|newsarama.com|noslocker.com|nowfeed2all.eu|nowvideo.ag|nowvideo.co|nowvideo.li|nowvideo.sx|nowvideo.to|okceleb.com|omgwhut.com|opensubtitles.org|parentherald.com|pornhub.com|postimg.org|prnt.sc|putlocker9.com|pwinsider.com|snoopfeed.com|sportsmole.co.uk|stream-tv-series.net|stream-tv2.to|stream2watch.cc|streamgaroo.com|technobuffalo.com|the-watch-series.to|thevideo.me|thinkinghumanity.com|todayshealth.buzz|tomsguide.com|tomshardware.co.uk|tomshardware.com|toptenz.net|torrentino.me|tribune.com.pk|uberhavoc.com|universityherald.com|vidmax.com|vidzi.tv|viewmixed.com|viralands.com|wccftech.com|webfirstrow.eu|whydontyoutrythis.com|wrestlinginc.com|wrestlingnews.co|xilfy.com|yourtango.com
+|ws*://$websocket,domain=fullmatchesandshows.com|1337x.to|allkpop.com|auroravid.to|bitvid.sx|boards2go.com|celebdirtylaundry.com|celebritymozo.com|collectivelyconscious.net|dailycaller.com|destructoid.com|dumpaday.com|firstrowau.eu|firstrowus1.eu|flash-x.tv|flashsx.tv|flashx.me|flashx.run|flashx.tv|flashx1.tv|flashxx.tv|fmovies.to|free-torrent.org|free-torrents.org|gamenguide.com|gofirstrow.eu|gorillavid.in|gsmarena.com|health-weekly.net|i4u.com|ifirstrow.eu|ifirstrowit.eu|img24.org|instanonymous.com|itechpost.com|izismile.com|jpost.com|lifehacklane.com|livescience.com|mobilenapps.com|mobipicker.com|natureworldnews.com|navbug.com|ncscooper.com|newsarama.com|noslocker.com|nowfeed2all.eu|nowvideo.ag|nowvideo.co|nowvideo.li|nowvideo.sx|nowvideo.to|okceleb.com|omgwhut.com|opensubtitles.org|parentherald.com|pornhub.com|pornhubthbh7ap3u.onion|postimg.org|prnt.sc|putlocker9.com|pwinsider.com|snoopfeed.com|sportsmole.co.uk|stream-tv-series.net|stream-tv2.to|stream2watch.cc|streamgaroo.com|technobuffalo.com|the-watch-series.to|thevideo.me|thinkinghumanity.com|todayshealth.buzz|tomsguide.com|tomshardware.co.uk|tomshardware.com|toptenz.net|torrentino.me|tribune.com.pk|uberhavoc.com|universityherald.com|vidmax.com|vidzi.tv|viewmixed.com|viralands.com|wccftech.com|webfirstrow.eu|whydontyoutrythis.com|wrestlinginc.com|wrestlingnews.co|xilfy.com|yourtango.com
 !
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/997
 google.ad,google.ae,google.al,google.am,google.as,google.at,google.az,google.ba,google.be,google.bf,google.bg,google.bi,google.bj,google.bs,google.bt,google.by,google.ca,google.cat,google.cd,google.cf,google.cg,google.ch,google.ci,google.cl,google.cm,google.cn,google.co.ao,google.co.bw,google.co.ck,google.co.cr,google.co.id,google.co.il,google.co.in,google.co.jp,google.co.ke,google.co.kr,google.co.ls,google.co.ma,google.co.mz,google.co.nz,google.co.th,google.co.tz,google.co.ug,google.co.uk,google.co.uz,google.co.ve,google.co.vi,google.co.za,google.co.zm,google.co.zw,google.com,google.com.af,google.com.ag,google.com.ai,google.com.ar,google.com.au,google.com.bd,google.com.bh,google.com.bn,google.com.bo,google.com.br,google.com.bz,google.com.co,google.com.cu,google.com.cy,google.com.do,google.com.ec,google.com.eg,google.com.et,google.com.fj,google.com.gh,google.com.gi,google.com.gt,google.com.hk,google.com.jm,google.com.kh,google.com.kw,google.com.lb,google.com.ly,google.com.mm,google.com.mt,google.com.mx,google.com.my,google.com.na,google.com.nf,google.com.ng,google.com.ni,google.com.np,google.com.om,google.com.pa,google.com.pe,google.com.pg,google.com.ph,google.com.pk,google.com.pr,google.com.py,google.com.qa,google.com.sa,google.com.sb,google.com.sg,google.com.sl,google.com.sv,google.com.tj,google.com.tr,google.com.tw,google.com.ua,google.com.uy,google.com.vc,google.com.vn,google.cv,google.cz,google.de,google.dj,google.dk,google.dm,google.dz,google.ee,google.es,google.fi,google.fm,google.fr,google.ga,google.ge,google.gg,google.gl,google.gm,google.gp,google.gr,google.gy,google.hn,google.hr,google.ht,google.hu,google.ie,google.im,google.iq,google.is,google.it,google.je,google.jo,google.kg,google.ki,google.kz,google.la,google.li,google.lk,google.lt,google.lu,google.lv,google.md,google.me,google.mg,google.mk,google.ml,google.mn,google.ms,google.mu,google.mv,google.mw,google.ne,google.nl,google.no,google.nr,google.nu,google.pl,google.pn,google.ps,google.pt,google.ro,google.rs,google.ru,google.rw,google.sc,google.se,google.sh,google.si,google.sk,google.sm,google.sn,google.so,google.sr,google.st,google.td,google.tg,google.tk,google.tl,google.tm,google.tn,google.to,google.tt,google.vg,google.vu,google.ws###taw #tvcap ._hsi.mnr-c
@@ -1767,7 +1767,7 @@ leechall.com,wi.cr###overly
 ||vidbob.com/player*/vast.js
 ||cdn.cloudfrale.com/Managed/*.mp4
 xhamster.com##.video-view-ads
-pornhub.com###hd-rightColVideoPage > .clearfix:first-child
+pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage > .clearfix:first-child
 msn.com##div[aria-label="property by domain"]
 msn.com##div[aria-label="from our partners"]
 cracksmod.com##.affiliate_download_imagebutton_container
@@ -1980,7 +1980,7 @@ xda-developers.com##.bravetwig-top
 file-up.org##.page-wrap > .dareaname ~ .text-center
 pcsteps.com##a[href^="https://www.pcsteps.com/cyberghost-pcsteps-deal"]
 speed4up.com##.adstop > center > a > img
-pornhub.com##.adWrapper
+pornhub.com,pornhubthbh7ap3u.onion##.adWrapper
 ||sxyprn.com/mth^
 ||ckk.ai/sw.js
 ups.com##.ups-tracking_banner_img
@@ -2169,7 +2169,7 @@ zikjkh4d.site###player_wrappe a[href][target="_blank"] > img
 mylust.com##.content > .cs-bnr
 coub.com##.viewer__sad
 ibizaglobalradio.com##.banner-publi
-facebook.com###megamall_rhc_ssfy_pagelet
+facebook.com,facebookcorewwwi.onion###megamall_rhc_ssfy_pagelet
 ||readcomiconline.to/Ads/$important
 ||bc.vc^$domain=multileech.net
 sexu.com###nv_ads
@@ -2208,8 +2208,8 @@ flashx.pw##iframe[src*="flashx.pw/"][src*=".php?treqn="]
 ||flashx.pw/*.php?treqn=*&runauction=*&crr=*&cbrandom=$subdocument,important
 ||fmovies.cab/asdfasgdUUy
 ||loadshare.org/custom/*/fmovies_480p.mp4$domain=fmovies.cab
-nytimes.com###story > div#bottom-wrapper[class^="css-"]
-nytimes.com###stream-panel ol > div[id^="mid"][type="supplemental"]
+nytimes.com,nytimes3xbfgragh.onion###story > div#bottom-wrapper[class^="css-"]
+nytimes.com,nytimes3xbfgragh.onion###stream-panel ol > div[id^="mid"][type="supplemental"]
 uploadev.com##form #downloadBtnClick ~ a[target="blank"][rel="nofollow"]
 uploadev.com###direct_link > a[target="blank"][rel="nofollow"]:not(.directl)
 agar.io###mainui-ads
@@ -2220,7 +2220,7 @@ epaper.timesgroup.com##.GoogleDFP
 europixhd.net###MyImageId
 ||europixhd.net/js/propadbl
 ||hdeuropix.io/hdm*.js
-nytimes.com##body > #app > div[class^="css-rpp"][class*=" "] > div[class^="css-"][class*=" "]
+nytimes.com,nytimes3xbfgragh.onion##body > #app > div[class^="css-rpp"][class*=" "] > div[class^="css-"][class*=" "]
 forum.xda-developers.com##.page > div#posts > div[id]:not([id^="edit"]):not([id^="lastpost"])[class="postbit-wrapper"][style]
 nzbindex.com##.main > #search + div#i.hide > .inner >a[href][target="_blank"] > img
 otakunation.org##div[id$="MessageOverlay"]
@@ -2295,12 +2295,12 @@ adultlook.com###ad_pb
 ||xaoutchouc.live/await/notwithstanding.php
 ||soonbigo.com/vast/*.xml$domain=nudogram.com
 uii.io,short.pe,clik.pw,szs.pw,chrt.pw##div[style="z-index:99999;position:fixed;bottom:10px;left:50%;transform: translateX(-50%)"]
-nytimes.com##.eaca97t1v
-nytimes.com###bottom-wrapper > div#bottom-slug
-nytimes.com###mktg-wrapper.eaca97t0
-nytimes.com###mid2-wrapper.eaca97t0
-nytimes.com###mid1-wrapper.eaca97t0
-nytimes.com##.css-1yvwzdo
+nytimes.com,nytimes3xbfgragh.onion##.eaca97t1v
+nytimes.com,nytimes3xbfgragh.onion###bottom-wrapper > div#bottom-slug
+nytimes.com,nytimes3xbfgragh.onion###mktg-wrapper.eaca97t0
+nytimes.com,nytimes3xbfgragh.onion###mid2-wrapper.eaca97t0
+nytimes.com,nytimes3xbfgragh.onion###mid1-wrapper.eaca97t0
+nytimes.com,nytimes3xbfgragh.onion##.css-1yvwzdo
 ||afletedly.info^$popup
 1001tracklists.com##.img15ad
 1001tracklists.com##.bannerFP
@@ -3037,7 +3037,7 @@ op.gg##.vm-placement
 formula1.com##.f1-DFP--banner
 uploadedpremiumlink.xyz##body > center > div[style="width: 728px; height: 90px; border: 1px solid #b9b7b7;"]:not([class]):not([id])
 uploadedpremiumlink.xyz##body > center > div[style="width: 300px; height: 250px; border: 1px solid #b9b7b7;"]:not([class]):not([id])
-pornhub.com##.sectionWrapper > .videos[id] > li[class^="sniper"]:not(.videoblock):not(.videobox):not([id^="playlist_"])
+pornhub.com,pornhubthbh7ap3u.onion##.sectionWrapper > .videos[id] > li[class^="sniper"]:not(.videoblock):not(.videobox):not([id^="playlist_"])
 ||xxxdan.com/aa474eaa.js
 drtuber.com##body[style^="height: 100%;"] a.drt-pause-link[target="_blank"]
 supercheats.com###titlebar_banner
@@ -3239,7 +3239,7 @@ yespornplease.com##div[class^="col-"] > .well:not([class*=" "])
 ||imgsmarts.info/bast^
 ||mangoporn.net/125_125.php
 ||mangoporn.net/125_125.js
-pornhub.com###main-container > .abovePlayer
+pornhub.com,pornhubthbh7ap3u.onion###main-container > .abovePlayer
 indiatoday.in##div[id^="block-itg-ads-ads"]
 scroll.in##.in-article-adx
 bgr.in##.essel_logo_div
@@ -3720,7 +3720,7 @@ fpo.xxx##.fp-player > .fp-ui > div[style^="position: absolute; overflow: hidden;
 ||fpo.xxx/player/html.php?aid=pause_html&video_id=*&*referer=
 ndtv.com##.newins_widget > div[id][data-wdgt][class^="__pcwgt"]
 anyporn.com##.content > noindex
-pornhub.com##.realsex
+pornhub.com,pornhubthbh7ap3u.onion##.realsex
 gay1080.com###boxzilla-overlay
 gay1080.com##.boxzilla-container
 javwhores.com##.table > .opt
@@ -4672,7 +4672,7 @@ av8x.com,pornqd.net##.row div[style="width: 300px; height: 250px;"]
 homewhores.net##.media_spot
 /homewhores.net\/[a-z]{1,2}[1-9]{1,4}[a-z]{1,2}[1-9]{1,4}[\s\S]*.js/$domain=homewhores.net
 homewhores.net##body > .top[style="text-align:center;font-size:16px;"]
-touch.facebook.com##article[data-sigil*="AdStory"]
+touch.facebook.com,m.facebookcorewwwi.onion##article[data-sigil*="AdStory"]
 ||ikhedmah.com/images/ref-banners/
 ||evtubescms.phncdn.com/videos/*/mp4_480.mp4$important
 ||evtubescms.phncdn.com/pre_videos^$important
@@ -6616,11 +6616,11 @@ thepiratebay.org##a[href^="http://www.bitlord.me/share/"]
 elsfile.org##.adsbygoogle
 ||mediapalmtree.com/pu-placer.js
 greatdaygames.com##.advertismentLabel
-pornhub.com##.video-wrapper > div#player~div[class$=" hd clear"]
+pornhub.com,pornhubthbh7ap3u.onion##.video-wrapper > div#player~div[class$=" hd clear"]
 imzog.com##.videos > div.vda-item
 moviefone.com###atwAdFrame0EAN
 ||ugplay.com^$popup,domain=mp3fiber.com
-pornhub.com##.playerFlvContainer > div#pb_template[style]
+pornhub.com,pornhubthbh7ap3u.onion##.playerFlvContainer > div#pb_template[style]
 nmac.to##.nmac-before-content
 nmac.to##.nmac-after-content
 time.com##.column > .tWo0WoSf
@@ -7297,7 +7297,7 @@ tgpdog.com,freepornhq.xxx##.aside-itempage-col
 tgpdog.com##.aff-content-col
 gadgetsnow.com##.nativecontent
 ||gaana.com/ajax/loaddfp^
-pornhub.com##.nonesuch
+pornhub.com,pornhubthbh7ap3u.onion##.nonesuch
 csgosquad.com##.takeover
 onlinemoviescinema.com##a[href^="http://t2lgo.com/"]
 veteranstoday.com##a[href="http://www.hireveterans.com"]
@@ -7558,8 +7558,8 @@ gamesofdesire.com##object[name="vghd"]
 ||217.23.12.240/files/flash/*-side.swf
 ||gamesofdesire.com/files/flash/*-side.swf
 ||beeg.com/xmlrpc.php^
-pornhub.com###customSkin.backgroundImg
-pornhub.com###customSkinCTA
+pornhub.com,pornhubthbh7ap3u.onion###customSkin.backgroundImg
+pornhub.com,pornhubthbh7ap3u.onion###customSkinCTA
 animeid.tv###player > div#ap
 up-4ever.com##.adsbygoogle
 ||wp.com/*sadeem*.com^$image,domain=computerworm.net
@@ -7848,7 +7848,7 @@ kaskus.co.id,kaskus.com,kaskus.us###ab712af0
 pastebin.com###abrpm2
 soompi.com###ad-med-rect
 byetv.org,castfree.me,freelive365.com###ad300
-pornhub.com###adBlockAlert
+pornhub.com,pornhubthbh7ap3u.onion###adBlockAlert
 myfxbook.com###adPopUpContainer
 giveaway-club.com###adPopup
 ah-me.com###ad_banner
@@ -7971,8 +7971,8 @@ cnet.com###globalSocialPromoWrap
 economictimes.indiatimes.com###googleadhp
 economictimes.indiatimes.com###googleshowbtm
 imagetwist.com###grip
-pornhub.com###hd-rightColVideoPage div[id^="f"]
-pornhub.com###hd-rightColVideoPage iframe
+pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage div[id^="f"]
+pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage iframe
 sexxx.cc###headerBanner
 qip.ro###hellobar-wrapper
 myp2p.biz,realstreamunited.tv,sportcategory.tv###hiddenBannerCanvas
@@ -8208,14 +8208,14 @@ theatlantic.com##.ad-wrapper
 patient.info##.ad.widget
 castfree.me##.ad300
 widestream.io##.adBlockDetected + div[class]
-pornhub.com##.adContainer
+pornhub.com,pornhubthbh7ap3u.onion##.adContainer
 epicbundle.com##.adExtraContentSuperBanner
 simple-adblock.com##.ad_300x250
 filehorse.com##.ad_970x250_dl
 phimsk.com##.ad_location
 inoreader.com##.ad_stripe
-pornhub.com##.ad_title + div
-pornhub.com##.ad_title + iframe
+pornhub.com,pornhubthbh7ap3u.onion##.ad_title + div
+pornhub.com,pornhubthbh7ap3u.onion##.ad_title + iframe
 gameskinny.com##.ad_universal_ondemand
 hqporner.com##.ad_video
 tubesex.me,xxxadd.com##.adban1
@@ -8312,7 +8312,7 @@ hltv.org##.boxBodyFadeDark:last-child > a[href^="https://goo.gl"] > img
 nv.ua##.brand_banner
 blic.rs##.brand_left
 blic.rs##.brand_right
-pornhub.com##.browse-ad-container + div[style*="float:right"]
+pornhub.com,pornhubthbh7ap3u.onion##.browse-ad-container + div[style*="float:right"]
 solidfiles.com##.buttons > a[class="btn btn-success btn-sm"]
 overclock.net##.buynow
 onwatchseries.to##.category-item-ad
@@ -8535,7 +8535,7 @@ mensfitness.com##.rr-zergnet-wrapper
 economictimes.indiatimes.com##.rtAdContainer
 ebay.co.uk,ebay.com,ebay.de##.rtmCss
 filepuma.com##.screenshots_ads
-pornhub.com##.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
+pornhub.com,pornhubthbh7ap3u.onion##.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 onwatchseries.to##.shd_button
 siliconera.com##.show-ads div.t-footer-curseNetwork
 cubuffs.com##.sidearm-ad-blocker-message-container
@@ -8978,11 +8978,11 @@ mcfucker.com##iframe[src^="/mcfucker_html/video_right.php"]
 imgwallet.com##iframe[src^="frame.php"]
 clipconverter.cc##iframe[src^="http://a.clipconverter.cc/www/d/"]
 debridnet.com##iframe[style$="width: 300px; height: 250px;"]
-pornhub.com##iframe[style*="height: 60px;"]
+pornhub.com,pornhubthbh7ap3u.onion##iframe[style*="height: 60px;"]
 pcmag.com##iframe[title="3rd party ad content"]
 biggestplayer.me##iframe[width="300"][height="250"]:not([id^="adblock"])
-pornhub.com##iframe[width="315"]
-pornhub.com##iframe[width="950"]
+pornhub.com,pornhubthbh7ap3u.onion##iframe[width="315"]
+pornhub.com,pornhubthbh7ap3u.onion##iframe[width="950"]
 techrapid.co.uk##img[alt$="Sponsored Links"]
 javhotgirl.com##img[alt="JavHD Premium"]
 bdsmvb.org,pornvb.org##img[alt="filejoker"]
@@ -9060,7 +9060,7 @@ youtube.com##ytd-search-pyv-renderer
 |http*://$third-party,domain=raw.senmanga.com
 |http*://*.js$third-party,domain=linx.2ddl.ag
 |http*://*.xyz^$script,domain=doyki.com|spashopaz.com
-|http://$image,third-party,domain=pornhub.com|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+|http://$image,third-party,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 |http://$script,third-party,xmlhttprequest,domain=oogh8ot0el.com
 |https://$script,third-party,xmlhttprequest,domain=oogh8ot0el.com
 ||0torrent.com^

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -4672,7 +4672,7 @@ av8x.com,pornqd.net##.row div[style="width: 300px; height: 250px;"]
 homewhores.net##.media_spot
 /homewhores.net\/[a-z]{1,2}[1-9]{1,4}[a-z]{1,2}[1-9]{1,4}[\s\S]*.js/$domain=homewhores.net
 homewhores.net##body > .top[style="text-align:center;font-size:16px;"]
-touch.facebook.com,m.facebookcorewwwi.onion##article[data-sigil*="AdStory"]
+touch.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion##article[data-sigil*="AdStory"]
 ||ikhedmah.com/images/ref-banners/
 ||evtubescms.phncdn.com/videos/*/mp4_480.mp4$important
 ||evtubescms.phncdn.com/pre_videos^$important

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -598,7 +598,7 @@ bestporncomix.com#@#.adsbar
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=rapidvideo.com|rapidvid.to
 @@||rapidvid.to/assets/js/videojs-contrib-ads.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38260
-@@||menrec.com^$csp=script-src 'self' *.gstatic.com *.google.com *.googleapis.com *.facebook.com *.bootstrapcdn.com *.twitter.com *.spot.im
+@@||menrec.com^$csp=script-src 'self' *.gstatic.com *.google.com *.googleapis.com *.facebook.com *.facebookcorewwwi.onion *.bootstrapcdn.com *.twitter.com *.spot.im
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29939 - fixing image gallery
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$domain=gamespot.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38235
@@ -2418,7 +2418,7 @@ domodedovo.ru#@##adLink1
 ! https://forum.adguard.com/index.php?threads/16819/
 @@||publisher.adservice.com^$document
 ! Unblock a control panel for FB advertisers
-@@||scontent.xx.fbcdn.net/hads-ak-prn2/*.png$domain=facebook.com
+@@||scontent.xx.fbcdn.net/hads-ak-prn2/*.png$domain=facebook.com|facebookcorewwwi.onion
 @@https://business.facebook.com^$document,~third-party
 ! https://forum.adguard.com/index.php?threads/13738/
 @@||themes.googleusercontent.com/static/fonts/$domain=tweaktown.com
@@ -3106,7 +3106,7 @@ msn.com#@#[id^="-"]
 @@||sexgalaxy.net/wp-content/themes^
 @@||sexgalaxy.net/wp-includes/js^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18506
-m.facebook.com,touch.facebook.com#@##m_newsfeed_stream article[data-ft*="\"ei\":\""]
+m.facebook.com,touch.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion#@##m_newsfeed_stream article[data-ft*="\"ei\":\""]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33754
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26998
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15940

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -133,8 +133,8 @@ swatchseries.to##.download_link_sponsored
 @@||ssgdfm.com^$extension
 ! https://github.com/easylist/easylist/issues/1912
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22746
-|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
-@@||phncdn.com^$domain=pornhub.com,image
+|https://$image,xmlhttprequest,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+@@||phncdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion,image
 @@||pornhub.com/comment^
 @@||pornhub.com/front^
 @@||pornhub.com/user^
@@ -420,7 +420,7 @@ sony.com#@#.ad-index
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43913
 @@||horriblesubs.info/static/hs.js
 ! pornhub.com - webcams not working
-@@||naiadsystems.com/*/hls/live$domain=pornhub.com
+@@||naiadsystems.com/*/hls/live$domain=pornhub.com|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43750
 @@||static.vidgyor.com/live/dai/js/videojs.ads.min.js
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=zeebiz.com
@@ -434,7 +434,7 @@ redtube.com#@#[src*="data:"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43292
 @@||coolmathgames.com/*/img/ads/Spinner.png$domain=coolmathgames.com
 ! pornhub.com - player is broken
-@@||dl.phncdn.com/pics/$domain=pornhub.com
+@@||dl.phncdn.com/pics/$domain=pornhub.com|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43226
 mac-torrent-download.net#@#.adbanner
 mac-torrent-download.net#@#.google_ads
@@ -943,7 +943,7 @@ thewirecutter.com#@#a[href^="https://www.amazon."][href*="tag="]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30177
 @@||imasdk.googleapis.com/pal/sdkloader/pal.js$domain=20min.ch
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27157
-nytimes.com#@##bottom-wrapper
+nytimes.com,nytimes3xbfgragh.onion#@##bottom-wrapper
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30037
 @@||imgrock.net^$image,domain=imgrock.pw
 @@||imgdew.com^$image,domain=imgdew.pw
@@ -1065,8 +1065,8 @@ app.appvalley.vip#@##ad-overlay
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26098
 @@||logsss.com/*.css$domain=zaful.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25448
-pornhub.com#@#[style*="base64"]
-pornhub.com#@#[src*="base64"]
+pornhub.com,pornhubthbh7ap3u.onion#@#[style*="base64"]
+pornhub.com,pornhubthbh7ap3u.onion#@#[src*="base64"]
 ! comedycentral.tv - broken video
 @@||googletagmanager.com/gtm.js^$domain=comedycentral.tv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25446
@@ -1497,8 +1497,8 @@ playbb.me,easyvideo.me#@#div[style^="width:"]
 @@||odnoklassniki.ru/videoembed/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6470
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=123220#p123220
-pornhub.com#@#div > [style] iframe[width][height]
-pornhub.com#@#[style] > div > iframe[width]:first-child
+pornhub.com,pornhubthbh7ap3u.onion#@#div > [style] iframe[width][height]
+pornhub.com,pornhubthbh7ap3u.onion#@#[style] > div > iframe[width]:first-child
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6044
 ! https://forums.lanik.us/viewtopic.php?f=64&t=37759
 @@||loginradius.com^$domain=voot.com
@@ -1523,7 +1523,7 @@ pornhub.com#@#[style] > div > iframe[width]:first-child
 !+ PLATFORM(ext_edge)
 @@||docs.google.com^$document
 ! Reported: https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=117720#p117720
-pornhub.com#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
+pornhub.com,pornhubthbh7ap3u.onion#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/1273
 @@||southpark.cc.com^$jsinject
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/2063
@@ -2276,7 +2276,7 @@ gelbooru.com#@##paginator
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35469
 1337x.to#@#.box-info-detail > .torrent-category-detail + div[class]
 ! https://forum.adguard.com/index.php?threads/16846/
-@@||phubcdn.com^$domain=pornhub.com
+@@||phubcdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion
 ! https://forum.adguard.com/index.php?threads/22108/
 @@||googletagservices.com/tag/js/gpt.js$domain=askmen.com
 @@||securepubads.g.doubleclick.net/gpt/pubads_impl_$domain=askmen.com
@@ -2931,7 +2931,7 @@ multiup.org#@#.adbar
 ! http://forum.adguard.com/showthread.php?6257
 @@||invodo.com^$domain=crutchfield.com
 ! pornhub etc - broken player
-@@||pornhub.phncdn.com^$image,domain=pornhub.com|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+@@||pornhub.phncdn.com^$image,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 ! web.mention.com - broken cabinet
 @@||web.mention.com^$document
 ! http://forum.adguard.com/showthread.php?6219
@@ -3067,7 +3067,7 @@ fb.eset.com#@##header-banner
 ! JRO-840-86973
 @@||bankofamerica.com^*?adx=
 ! http://forum.adguard.com/showthread.php?3007-Problem-with-linkbucks&p=36199#post36199
-@@/videos/*$domain=pornhub.com
+@@/videos/*$domain=pornhub.com|pornhubthbh7ap3u.onion
 @@||linkbucks.com^$third-party,domain=goneviral.com
 @@||redtubefiles.com/_videos_
 @@||web.any.do^$document
@@ -3185,7 +3185,7 @@ destructoid.com#@#[style*="background-image:"]
 @@||fruithosts.net/embed/$popup
 @@||mp4upload.com/embed-*.html$popup
 @@||streamhunter.top^$popup
-@@||pornhublive.com/bio.php?$popup,domain=pornhub.com
+@@||pornhublive.com/bio.php?$popup,domain=pornhub.com|pornhubthbh7ap3u.onion
 @@||streamiptvonline.com/streams^$popup
 @@||cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls^
 @@||vjs.zencdn.net^$domain=stream2watch.org

--- a/MobileFilter/sections/css_extended.txt
+++ b/MobileFilter/sections/css_extended.txt
@@ -93,7 +93,7 @@ nbcmontana.com,mynews4.com,nbc16.com,turnto10.com,news4sanantonio.com,nbc24.com,
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29888
 obozrevatel.com#?#div[style^="position:"][style*="relative"]:has(> [src^="https://i.obozrevatel.com/banners/"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29451
-nytimes.com#?##site-content > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"][-ext-has='> div[class^="css-"] > div[class^="css-"]:contains(Advertisement) + div[class*="dfp-ad-"]'] 
+nytimes.com,nytimes3xbfgragh.onion#?##site-content > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"] > div[class^="css-"][-ext-has='> div[class^="css-"] > div[class^="css-"]:contains(Advertisement) + div[class*="dfp-ad-"]'] 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24411
 bunshun.jp#?#.sp-list-thumb > li[-ext-has='.pr']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24412

--- a/MobileFilter/sections/general_extensions.txt
+++ b/MobileFilter/sections/general_extensions.txt
@@ -3,7 +3,7 @@
 !-------------------
 !### TEMPORARY ###
 ! https://forum.adguard.com/index.php?threads/12443/
-pornhub.com#%#AG_onLoad(function() { if (typeof redirect !== 'function') return; var str = redirect.toString(); var m = str.match(/\'(\/view.*)\'/); if (m.length != 2) return; var link = m[1]; window.location.href = m[1]; });
+pornhub.com,pornhubthbh7ap3u.onion#%#AG_onLoad(function() { if (typeof redirect !== 'function') return; var str = redirect.toString(); var m = str.match(/\'(\/view.*)\'/); if (m.length != 2) return; var link = m[1]; window.location.href = m[1]; });
 !#################
 !
 ! xhamster.com - popups
@@ -49,7 +49,7 @@ estream.nu,estream.to#%#var d=document.addEventListener;document.addEventListene
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9324
 youjizz.com#%#AG_defineProperty('config.ads.mobilePopunder', {value: false});
 ! https://forum.adguard.com/index.php?threads/20737/
-pornhub.com#%#Object.defineProperty(window, 'initPopUnderLinks', { get: function() { return function() { }; } });
+pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(window, 'initPopUnderLinks', { get: function() { return function() { }; } });
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6895
 m.iceporn.com#%#document.cookie = "adv_show=3";
 m.iceporn.com#%#Object.defineProperty(window, 'mobilePop', { get: function() { return ; } });

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -736,7 +736,7 @@ wasabisyrup.com##.top-group
 wasabisyrup.com##.article-gallery > .article-gallery-group > .content-group
 redtube.com###content_container > div[class]:not(.show_page_modals):not([id]):not([style]):not([class^="content"])
 youtube.com##ytm-promoted-video-renderer
-b-m.facebook.com,iphone.facebook.com,m.facebook.com,touch.facebook.com###m_newsfeed_stream article[data-ft*='"ei\":']
+b-m.facebook.com,iphone.facebook.com,m.facebook.com,touch.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion###m_newsfeed_stream article[data-ft*='"ei\":']
 m.voyeurhit.com##.container > .section--normal[style*="margin-top: -15px"]
 avcanada.ca##.postbody > div[id^="post_content"] > .content ~ center
 xbabe.com###fltd

--- a/MobileFilter/sections/whitelist.txt
+++ b/MobileFilter/sections/whitelist.txt
@@ -208,7 +208,7 @@ timesofindia.indiatimes.com#@#style[type="text/css"] + div[class]:not([id]):not(
 ! https://github.com/AdguardTeam/AdguardFilters/issues/3755
 @@||m.haberturk.com/adscbg/mdet.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/3616
-pornhub.com#@#div > [style*="width: 100%;"]:first-child
+pornhub.com,pornhubthbh7ap3u.onion#@#div > [style*="width: 100%;"]:first-child
 ! https://forum.adguard.com/index.php?threads/16921/
 m.veporn.net#@#.advertisment
 m.veporn.net#@##topAds
@@ -309,6 +309,7 @@ deviantart.com#@#.mobile-ad
 @@||market.viber.com^$elemhide
 ! Fixing pornhub.com
 @@||pornhub.com^$subdocument
+@@||pornhubthbh7ap3u.onion^$subdocument
 ! http://www.reddit.com/r/Android/comments/3422vw/a_quick_fix_for_everyone_having_mms_issues_with/
 @@||mms.vtext.com^$document
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/310


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***: 

Much like I've done for uAssets and EasyList in the past couple weeks, I've now amended almost all entries for `Pornhub`, `Facebook` and `New York Times` to also include their Tor domains, as most sites' Tor versions have identical GUIs compared to their regular versions.

Details worth mentioning:
* I have not actually looked into whether entries like `||facebook.com/exampletext^` would need to be amended as well, so I've skipped them for now.
* `m.facebookcorewwwi.onion` is considered functionally equivalent to `m.facebook.com` and `touch.facebook.com`, but I personally doubt it's equivalent to `mobile.facebook.com` or `mbasic.facebook.com`. I haven't looked into `x.facebook.com` at the time of writing.
* Although `DuckDuckGo`, `Buzzfeed News` and `ProPublica` (among a tiny handful of other major sites) also have Tor versions, I couldn't find any entries for their regular versions in these two most important English-language AdGuard lists.
* The "Allow edits from maintainers" button is of course turned on, as I always do for all PRs to all projects of all kinds.

Screenshot: N/A

* **Expected behaviour**: 

N/A

***Steps to reproduce the problem***:

1) Open Tor Browser.
2) Visit e.g. `pornhubthbh7ap3u.onion`; as although it's NSFW, it's got the most uncovered entries by far, in part due to only having its Tor version go live less than a month ago.
3) See that `pornhub.com`-specific entries aren't being applied for pretty obvious reasons.

***System configuration***

**Filters:**

![image](https://user-images.githubusercontent.com/22780683/74618712-37d35480-5133-11ea-9018-21fa7b2c428e.png)

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10 November 2019 Update
Operating system version (Android/iOS) | N/A
Browser:                               | Tor Browser 9.0.5
AdGuard version:                       | uBlock Origin 1.24.2
Filters enabled:                       | See screenshot above
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | N/A
HTTPS filtering (Android only):        | N/A
Simplified filters (iOS only)          | N/A
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | N/A
Helpdesk ID (if exists):               | N/A

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
