### PR TITLE
Improved Facebook/Pornhub entry domain coverage even more

### DIFF
--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -7743,7 +7743,7 @@ envatostuff.rocks##.adblock_detector
 ! http://forum.adguard.com/showthread.php?7001
 zippymoviez.cc###h97e
 ! http://forum.adguard.com/showthread.php?6948
-pornhub.com,pornhubthbh7ap3u.onion###abAlert
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###abAlert
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/774
 dayt.se#$##synpit { height:1px!important; }
 ! http://forum.adguard.com/showthread.php?6916

--- a/EnglishFilter/sections/content_blocker.txt
+++ b/EnglishFilter/sections/content_blocker.txt
@@ -2113,7 +2113,7 @@ fxporn.net#@#.video_ads
 @@||ahcdn.com/*.mp4$domain=xhamster.com
 @@||xhcdn.com/*.mp4$domain=xhamster.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7211
-@@||google.com/recaptcha/$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||google.com/recaptcha/$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6731
 @@||cdnjs.cloudflare.com/ajax/libs/$domain=xmoviesforyou.com
 @@||fruithosted.net/dl/*.mp4
@@ -2291,7 +2291,7 @@ cari.com.my###cvidloader
 ! finn.no - fixing advertisement, which opens in the new tab
 @@||finn.no/*/ad.html?
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1142
-@@||static.pornhub.phncdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||static.pornhub.phncdn.com^$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 ! http://forum.adguard.com/showthread.php?7751
 ! Fixing endless loading
 @@||b.kavanga.ru/exp?sid=$domain=deita.ru

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -997,8 +997,8 @@ audiobookbay.me,audiobookbay.la,audiobookeo.com#?##page > div#rsidebar > ul > li
 audiobookbay.me,audiobookbay.la,audiobookeo.com#?##page > div#rsidebar > ul > li[-ext-has="> h2:contains(Sponsor Links)"]
 audiobookbay.me,audiobookbay.la,audiobookeo.com#?#.torrent_info > tbody > tr[-ext-has='> td[valign="top"]:contains(Ads:)']
 ! https://github.com/uBlockOrigin/uAssets/issues/471
-pornhub.com,pornhubthbh7ap3u.onion#?#.sectionWrapper > div[class*=" "][-ext-has='> div[class]:only-child > a.removeAdLink']
-pornhub.com,pornhubthbh7ap3u.onion#?#body > .wrapper + div[class][-ext-has='> .removeAdLink']
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#?#.sectionWrapper > div[class*=" "][-ext-has='> div[class]:only-child > a.removeAdLink']
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#?#body > .wrapper + div[class][-ext-has='> .removeAdLink']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5454
 csgosquad.com#?#.col-xs-6 > .panel[-ext-has='>.panel-heading>.panel-title:contains(Advertisement)']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5403
@@ -1099,7 +1099,7 @@ listoffreeware.com#?#div[class$="post excerpt"][-ext-has='ins[class$="adsbygoogl
 ! https://forum.adguard.com/index.php?threads/13471/
 cnn.com#?#div[class^="column zn__column--idx-"][-ext-has='h2[data-analytics$="Paid Partner Content_list-xs_"]']
 ! https://forum.adguard.com/index.php?threads/13479/
-pornhub.com,pornhubthbh7ap3u.onion#?#.sectionWrapper > div.psWrapper[-ext-has="a.removeAdsStyle"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#?#.sectionWrapper > div.psWrapper[-ext-has="a.removeAdsStyle"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7912
 thedailybeast.com#?#.HomePage__two-columns-wrapper .Card[-ext-has='.AdSlot']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8377

--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -150,7 +150,7 @@ pandamovies.me,porcore.com,dbupload.co,fileru.me,mangoporn.net,pornkino.cc,watch
 pandamovies.me,porcore.com,dbupload.co,fileru.me,mangoporn.net,pornkino.cc,watchpornfree.info,imguur.pictures,xxxmoviestream.xyz,mangoporn.co,kickass.vc,pandavideo.pw,freshscat.com,playpornfree.xyz,kickass.love,desiupload.in,xopenload.me,streamporn.pw#%#//scriptlet("set-constant", "puShown", "true")
 !
 ! AdSupply clickunder
-mirrorcreator.com,fullmatchesandshows.com,tinypic.com,tube8.com,youporn.com,redtube.com,pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() { }; } });
+mirrorcreator.com,fullmatchesandshows.com,tinypic.com,tube8.com,youporn.com,redtube.com,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() { }; } });
 vporn.com#%#Object.defineProperty(window, 'UAParser', { get: function() { return function() {}; } });
 !
 spankwire.com#%#Object.defineProperty(document, 'onclick', { get: function() { return; } });
@@ -1098,7 +1098,7 @@ powvldeo.net#%#Object.defineProperty(window,"puOverlay",{get:function(){return f
 dailymotiontomp3.com#%#AG_setConstant('IsPopAd', 'false');
 dailymotiontomp3.com#%#(function() { window.open_ = window.open; var w_open = window.open, regex = /rotumal\.com/; window.open = function(a, b) { if (typeof a !== 'string' || !regex.test(a)) { w_open(a, b); } }; })();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33064
-pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(Object.prototype, 'loadPopUnder', { get: function(){ return function() {}; }, set: function(){ return function() {}; }});
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#%#Object.defineProperty(Object.prototype, 'loadPopUnder', { get: function(){ return function() {}; }, set: function(){ return function() {}; }});
 ! gosswatch.com - popunder when playing video
 goss.watch,gosswatch.com#%#AG_setConstant('pop', 'noopFunc'); 
 ! mediafire.com - ad redirect on download
@@ -1987,7 +1987,7 @@ pornhd.com#%#Object.defineProperty(window, 'smPop', { get: function() { return {
 ! https://github.com/AdguardTeam/AdguardFilters/issues/4874
 9to5google.com,9to5mac.com,9to5toys.com,electrek.co#%#window.canRunAds = true; window.OXHBConfig = {};
 ! pornhub.com
-pornhub.com,pornhubthbh7ap3u.onion#%#Object.defineProperty(window,'tj_ads',{get:function(){return[]}});
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#%#Object.defineProperty(window,'tj_ads',{get:function(){return[]}});
 ! https://forum.adguard.com/index.php?threads/18375/
 openload.cz#%#window.addEventListener("load", function(){ var el = document.getElementById("videooverlay"); if(el){el.click();} });
 verystream.com,oladblock.me,oladblock.xyz,oladblock.services,oload.space,oload.live,oload.club,openload.pw,oload.fun,oload.icu,oload.cloud,oload.download,oload.stream,oload.info#%#window.addEventListener("load", function(){ var el = document.getElementById("videooverlay"); if(el){el.click();} });
@@ -2319,7 +2319,7 @@ zive.cz#%#AG_onLoad(function() { window.VIDEO_AD_ENABLED = false; } );
 ! filecore anti-adblock
 fcore.eu#%#AG_onLoad(function() { window.checkAds = function() {}; });
 ! pornhub.com -- it does not show popups in opera
-pornhub.com,pornhubthbh7ap3u.onion#%#window.opera = true;
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#%#window.opera = true;
 ! http://forum.adguard.com/showthread.php?3431
 secureupload.eu#%#window.open = function() {};
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/47
@@ -2554,7 +2554,7 @@ brisbanetimes.com.au#$#div[id^="adspot-"] { position: absolute!important; left: 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27690
 limetorrents.asia#$#a[href^="/media.php?"][rel="nofollow"][style^="display: block !important"] { position: absolute!important; left: -3000px!important; }
 ! pornhub.com ad left-over on main page
-pornhub.com,pornhubthbh7ap3u.onion#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; } 
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; } 
 ! https://forum.adguard.com/index.php?threads/up-4-net.30856/
 up-4.net#$##btn_downloadLink { display:block!important; }
 up-4.net#$##btn_downloadPreparing { display:none!important; }
@@ -2960,8 +2960,8 @@ yeptube.com#$#div[class="thr-rcol"] > div[class="container mt15"] { visibility: 
 ! https://forum.adguard.com/index.php?threads/24651/
 youpornru.com#$#.column-flex { width: auto!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6510
-pornhub.com,pornhubthbh7ap3u.onion#$#.playerFlvContainer > div#pb_template[style] { position: absolute!important; left: -3000px!important; }
-pornhub.com,pornhubthbh7ap3u.onion#$#.video-wrapper > div#player~div[class$=" hd clear"] { position: absolute!important; left: -3000px!important; }
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#$#.playerFlvContainer > div#pb_template[style] { position: absolute!important; left: -3000px!important; }
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#$#.video-wrapper > div#player~div[class$=" hd clear"] { position: absolute!important; left: -3000px!important; }
 ! https://forum.adguard.com/index.php?threads/24633/
 perfectgirls.net#$#.list__item { margin-right: auto!important; }
 perfectgirls.net#$#.list__item { margin-left: auto!important; }
@@ -3259,7 +3259,7 @@ motherless.com$$script[tag-content="_ml_ads_ns"][min-length="4000"][max-length="
 ! viprow.net - ad reinject
 viprow.net$$script[tag-content="SEYfRO"][min-length="49000"][max-length="52000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33064
-pornhub.com,pornhubthbh7ap3u.onion$$script[tag-content="loadPopUnder"][min-length="30000"][max-length="60000"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion$$script[tag-content="loadPopUnder"][min-length="30000"][max-length="60000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34622
 letmejerk.com$$script[tag-content="ExoLoader"][min-length="15000"][max-length="35000"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33095

--- a/EnglishFilter/sections/replace.txt
+++ b/EnglishFilter/sections/replace.txt
@@ -23,9 +23,7 @@
 ||ssaiplayback.prod.boltdns.net/playback/once/v*/vmap/hls/$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/,domain=news.com.au
 ||ssaiplayback.*.boltdns.net/playback/once/v*/hls/*.m3u8$replace=/(#EXT-X-TARGETDURATION:[\S]*?)\n[\s\S]*?#EXT-X-DISCONTINUITY/\$1/,domain=news.com.au
 ! pornhub.com - preroll
-||pornhub.com/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
-||pornhub.org/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
-||pornhub.net/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
+||pornhub.*/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important,~third-party
 ! Injecting style to the pages with invalid HTML
 ||4ustream.com/*/*.html$replace=/<\/iframe>\n/<\/iframe><style>#ads-wrap { display: none; }<\/style>/,important
 ||pasiondeportiva.me/sports/embed/$replace=/<\/iframe>/<\/iframe><style>#ada { display: none; }<\/style>/,important

--- a/EnglishFilter/sections/replace.txt
+++ b/EnglishFilter/sections/replace.txt
@@ -24,6 +24,8 @@
 ||ssaiplayback.*.boltdns.net/playback/once/v*/hls/*.m3u8$replace=/(#EXT-X-TARGETDURATION:[\S]*?)\n[\s\S]*?#EXT-X-DISCONTINUITY/\$1/,domain=news.com.au
 ! pornhub.com - preroll
 ||pornhub.com/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
+||pornhub.org/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
+||pornhub.net/view_video.php?viewkey=$replace=/vastXml/_vastXml/,important
 ! Injecting style to the pages with invalid HTML
 ||4ustream.com/*/*.html$replace=/<\/iframe>\n/<\/iframe><style>#ads-wrap { display: none; }<\/style>/,important
 ||pasiondeportiva.me/sports/embed/$replace=/<\/iframe>/<\/iframe><style>#ada { display: none; }<\/style>/,important

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -10,8 +10,8 @@ porn00.org##.fridaydesk
 |https://$image,script,stylesheet,subdocument,third-party,xmlhttprequest,domain=topeuropix.net,badfilter
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6470
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=123220#p123220
-pornhub.com,pornhubthbh7ap3u.onion##div > [style] iframe[width][height]:not([src^="https://www.google.com/recaptcha/"])
-pornhub.com,pornhubthbh7ap3u.onion##[style] > div > iframe[width]:first-child:not([src^="https://www.google.com/recaptcha/"])
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##div > [style] iframe[width][height]:not([src^="https://www.google.com/recaptcha/"])
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##[style] > div > iframe[width]:first-child:not([src^="https://www.google.com/recaptcha/"])
 ! https://forums.lanik.us/viewtopic.php?p=121479#p121479
 gelbooru.com##a[href*="/track/"]
 gelbooru.com#@#span[class]:last-child > a img[src]
@@ -1982,7 +1982,7 @@ leechall.com,wi.cr###overly
 ||vidbob.com/player*/vast.js
 ||cdn.cloudfrale.com/Managed/*.mp4
 xhamster.com##.video-view-ads
-pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage > .clearfix:first-child
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###hd-rightColVideoPage > .clearfix:first-child
 msn.com##div[aria-label="property by domain"]
 msn.com##div[aria-label="from our partners"]
 cracksmod.com##.affiliate_download_imagebutton_container
@@ -2195,7 +2195,7 @@ xda-developers.com##.bravetwig-top
 file-up.org##.page-wrap > .dareaname ~ .text-center
 pcsteps.com##a[href^="https://www.pcsteps.com/cyberghost-pcsteps-deal"]
 speed4up.com##.adstop > center > a > img
-pornhub.com,pornhubthbh7ap3u.onion##.adWrapper
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.adWrapper
 ||sxyprn.com/mth^
 ||ckk.ai/sw.js
 ups.com##.ups-tracking_banner_img
@@ -3251,7 +3251,7 @@ op.gg##.vm-placement
 formula1.com##.f1-DFP--banner
 uploadedpremiumlink.xyz##body > center > div[style="width: 728px; height: 90px; border: 1px solid #b9b7b7;"]:not([class]):not([id])
 uploadedpremiumlink.xyz##body > center > div[style="width: 300px; height: 250px; border: 1px solid #b9b7b7;"]:not([class]):not([id])
-pornhub.com,pornhubthbh7ap3u.onion##.sectionWrapper > .videos[id] > li[class^="sniper"]:not(.videoblock):not(.videobox):not([id^="playlist_"])
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.sectionWrapper > .videos[id] > li[class^="sniper"]:not(.videoblock):not(.videobox):not([id^="playlist_"])
 ||xxxdan.com/aa474eaa.js
 drtuber.com##body[style^="height: 100%;"] a.drt-pause-link[target="_blank"]
 supercheats.com###titlebar_banner
@@ -3453,7 +3453,7 @@ yespornplease.com##div[class^="col-"] > .well:not([class*=" "])
 ||imgsmarts.info/bast^
 ||mangoporn.net/125_125.php
 ||mangoporn.net/125_125.js
-pornhub.com,pornhubthbh7ap3u.onion###main-container > .abovePlayer
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###main-container > .abovePlayer
 indiatoday.in##div[id^="block-itg-ads-ads"]
 scroll.in##.in-article-adx
 bgr.in##.essel_logo_div
@@ -3933,7 +3933,7 @@ fpo.xxx##.fp-player > .fp-ui > div[style^="position: absolute; overflow: hidden;
 ||fpo.xxx/player/html.php?aid=pause_html&video_id=*&*referer=
 ndtv.com##.newins_widget > div[id][data-wdgt][class^="__pcwgt"]
 anyporn.com##.content > noindex
-pornhub.com,pornhubthbh7ap3u.onion##.realsex
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.realsex
 gay1080.com###boxzilla-overlay
 gay1080.com##.boxzilla-container
 javwhores.com##.table > .opt
@@ -4883,7 +4883,7 @@ av8x.com,pornqd.net##.row div[style="width: 300px; height: 250px;"]
 homewhores.net##.media_spot
 /homewhores.net\/[a-z]{1,2}[1-9]{1,4}[a-z]{1,2}[1-9]{1,4}[\s\S]*.js/$domain=homewhores.net
 homewhores.net##body > .top[style="text-align:center;font-size:16px;"]
-touch.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion##article[data-sigil*="AdStory"]
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##article[data-sigil*="AdStory"]
 ||ikhedmah.com/images/ref-banners/
 ||evtubescms.phncdn.com/videos/*/mp4_480.mp4$important
 ||evtubescms.phncdn.com/pre_videos^$important
@@ -6818,11 +6818,11 @@ thepiratebay.org##a[href^="http://www.bitlord.me/share/"]
 elsfile.org##.adsbygoogle
 ||mediapalmtree.com/pu-placer.js
 greatdaygames.com##.advertismentLabel
-pornhub.com,pornhubthbh7ap3u.onion##.video-wrapper > div#player~div[class$=" hd clear"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.video-wrapper > div#player~div[class$=" hd clear"]
 imzog.com##.videos > div.vda-item
 moviefone.com###atwAdFrame0EAN
 ||ugplay.com^$popup,domain=mp3fiber.com
-pornhub.com,pornhubthbh7ap3u.onion##.playerFlvContainer > div#pb_template[style]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.playerFlvContainer > div#pb_template[style]
 nmac.to##.nmac-before-content
 nmac.to##.nmac-after-content
 time.com##.column > .tWo0WoSf
@@ -7499,7 +7499,7 @@ tgpdog.com,freepornhq.xxx##.aside-itempage-col
 tgpdog.com##.aff-content-col
 gadgetsnow.com##.nativecontent
 ||gaana.com/ajax/loaddfp^
-pornhub.com,pornhubthbh7ap3u.onion##.nonesuch
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.nonesuch
 csgosquad.com##.takeover
 onlinemoviescinema.com##a[href^="http://t2lgo.com/"]
 veteranstoday.com##a[href="http://www.hireveterans.com"]
@@ -7760,8 +7760,8 @@ gamesofdesire.com##object[name="vghd"]
 ||217.23.12.240/files/flash/*-side.swf
 ||gamesofdesire.com/files/flash/*-side.swf
 ||beeg.com/xmlrpc.php^
-pornhub.com,pornhubthbh7ap3u.onion###customSkin.backgroundImg
-pornhub.com,pornhubthbh7ap3u.onion###customSkinCTA
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###customSkin.backgroundImg
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###customSkinCTA
 animeid.tv###player > div#ap
 up-4ever.com##.adsbygoogle
 ||wp.com/*sadeem*.com^$image,domain=computerworm.net
@@ -8050,7 +8050,7 @@ kaskus.co.id,kaskus.com,kaskus.us###ab712af0
 pastebin.com###abrpm2
 soompi.com###ad-med-rect
 byetv.org,castfree.me,freelive365.com###ad300
-pornhub.com,pornhubthbh7ap3u.onion###adBlockAlert
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###adBlockAlert
 myfxbook.com###adPopUpContainer
 giveaway-club.com###adPopup
 ah-me.com###ad_banner
@@ -8173,8 +8173,8 @@ cnet.com###globalSocialPromoWrap
 economictimes.indiatimes.com###googleadhp
 economictimes.indiatimes.com###googleshowbtm
 imagetwist.com###grip
-pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage div[id^="f"]
-pornhub.com,pornhubthbh7ap3u.onion###hd-rightColVideoPage iframe
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###hd-rightColVideoPage div[id^="f"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###hd-rightColVideoPage iframe
 sexxx.cc###headerBanner
 qip.ro###hellobar-wrapper
 myp2p.biz,realstreamunited.tv,sportcategory.tv###hiddenBannerCanvas
@@ -8409,14 +8409,14 @@ theatlantic.com##.ad-wrapper
 patient.info##.ad.widget
 castfree.me##.ad300
 widestream.io##.adBlockDetected + div[class]
-pornhub.com,pornhubthbh7ap3u.onion##.adContainer
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.adContainer
 epicbundle.com##.adExtraContentSuperBanner
 simple-adblock.com##.ad_300x250
 filehorse.com##.ad_970x250_dl
 phimsk.com##.ad_location
 inoreader.com##.ad_stripe
-pornhub.com,pornhubthbh7ap3u.onion##.ad_title + div
-pornhub.com,pornhubthbh7ap3u.onion##.ad_title + iframe
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.ad_title + div
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.ad_title + iframe
 gameskinny.com##.ad_universal_ondemand
 hqporner.com##.ad_video
 tubesex.me,xxxadd.com##.adban1
@@ -8511,7 +8511,7 @@ hltv.org##.boxBodyFadeDark:last-child > a[href^="https://goo.gl"] > img
 nv.ua##.brand_banner
 blic.rs##.brand_left
 blic.rs##.brand_right
-pornhub.com,pornhubthbh7ap3u.onion##.browse-ad-container + div[style*="float:right"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.browse-ad-container + div[style*="float:right"]
 solidfiles.com##.buttons > a[class="btn btn-success btn-sm"]
 overclock.net##.buynow
 onwatchseries.to##.category-item-ad
@@ -8731,7 +8731,7 @@ mensfitness.com##.rr-zergnet-wrapper
 economictimes.indiatimes.com##.rtAdContainer
 ebay.co.uk,ebay.com,ebay.de##.rtmCss
 filepuma.com##.screenshots_ads
-pornhub.com,pornhubthbh7ap3u.onion##.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 onwatchseries.to##.shd_button
 siliconera.com##.show-ads div.t-footer-curseNetwork
 cubuffs.com##.sidearm-ad-blocker-message-container
@@ -9170,11 +9170,11 @@ mcfucker.com##iframe[src^="/mcfucker_html/video_right.php"]
 imgwallet.com##iframe[src^="frame.php"]
 clipconverter.cc##iframe[src^="http://a.clipconverter.cc/www/d/"]
 debridnet.com##iframe[style$="width: 300px; height: 250px;"]
-pornhub.com,pornhubthbh7ap3u.onion##iframe[style*="height: 60px;"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[style*="height: 60px;"]
 pcmag.com##iframe[title="3rd party ad content"]
 biggestplayer.me##iframe[width="300"][height="250"]:not([id^="adblock"])
-pornhub.com,pornhubthbh7ap3u.onion##iframe[width="315"]
-pornhub.com,pornhubthbh7ap3u.onion##iframe[width="950"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[width="315"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[width="950"]
 techrapid.co.uk##img[alt$="Sponsored Links"]
 javhotgirl.com##img[alt="JavHD Premium"]
 bdsmvb.org,pornvb.org##img[alt="filejoker"]

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -144,7 +144,7 @@ swatchseries.to##.download_link_sponsored
 @@||ssgdfm.com^$extension
 ! https://github.com/easylist/easylist/issues/1912
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22746
-|https://$image,xmlhttprequest,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
 @@||phncdn.com^$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion,image
 @@||pornhub.*/comment^
 @@||pornhub.*/front^

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -144,11 +144,11 @@ swatchseries.to##.download_link_sponsored
 @@||ssgdfm.com^$extension
 ! https://github.com/easylist/easylist/issues/1912
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22746
-|https://$image,xmlhttprequest,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
-@@||phncdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion,image
-@@||pornhub.com/comment^
-@@||pornhub.com/front^
-@@||pornhub.com/user^
+|https://$image,xmlhttprequest,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+@@||phncdn.com^$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion,image
+@@||pornhub.*/comment^
+@@||pornhub.*/front^
+@@||pornhub.*/user^
 @@||nsimg.net/biopic^
 ! https://github.com/AdguardTeam/CoreLibs/issues/495
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22363
@@ -490,7 +490,7 @@ sony.com#@#.ad-index
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43913
 @@||horriblesubs.info/static/hs.js
 ! pornhub.com - webcams not working
-@@||naiadsystems.com/*/hls/live$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||naiadsystems.com/*/hls/live$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43750
 @@||static.vidgyor.com/live/dai/js/videojs.ads.min.js
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=zeebiz.com
@@ -504,7 +504,7 @@ redtube.com#@#[src*="data:"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43292
 @@||coolmathgames.com/*/img/ads/Spinner.png$domain=coolmathgames.com
 ! pornhub.com - player is broken
-@@||dl.phncdn.com/pics/$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||dl.phncdn.com/pics/$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43226
 mac-torrent-download.net#@#.adbanner
 mac-torrent-download.net#@#.google_ads
@@ -1133,8 +1133,8 @@ app.appvalley.vip#@##ad-overlay
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26098
 @@||logsss.com/*.css$domain=zaful.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25448
-pornhub.com,pornhubthbh7ap3u.onion#@#[style*="base64"]
-pornhub.com,pornhubthbh7ap3u.onion#@#[src*="base64"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#[style*="base64"]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#[src*="base64"]
 ! comedycentral.tv - broken video
 @@||googletagmanager.com/gtm.js^$domain=comedycentral.tv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25446
@@ -1234,7 +1234,7 @@ twitch.tv#@#.pl-overlay
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24081
 @@||mangatail.me/sites/default/files/*adsense
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23709
-@@||pornhub.com/recommended/ajax_rate?$~third-party,xmlhttprequest
+@@||pornhub.*/recommended/ajax_rate?$~third-party,xmlhttprequest
 ! https://forum.adguard.com/index.php?threads/putlockers-fm.29693/
 @@||entervideo.net/watch^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23798
@@ -1561,8 +1561,8 @@ playbb.me,easyvideo.me#@#div[style^="width:"]
 @@||odnoklassniki.ru/videoembed/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6470
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=123220#p123220
-pornhub.com,pornhubthbh7ap3u.onion#@#div > [style] iframe[width][height]
-pornhub.com,pornhubthbh7ap3u.onion#@#[style] > div > iframe[width]:first-child
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#div > [style] iframe[width][height]
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#[style] > div > iframe[width]:first-child
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6044
 ! https://forums.lanik.us/viewtopic.php?f=64&t=37759
 @@||loginradius.com^$domain=voot.com
@@ -1587,7 +1587,7 @@ pornhub.com,pornhubthbh7ap3u.onion#@#[style] > div > iframe[width]:first-child
 !+ PLATFORM(ext_edge)
 @@||docs.google.com^$document
 ! Reported: https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=117720#p117720
-pornhub.com,pornhubthbh7ap3u.onion#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/1273
 @@||southpark.cc.com^$jsinject
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/2063
@@ -2153,7 +2153,7 @@ monova.org#@#script + [class] > [class]:first-child
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@/advertising-$~script,~image,domain=forums.macrumors.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6756
-@@||pornhub.com/signup
+@@||pornhub.*/signup
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6591
 @@||static.cz.prg.cmestatic.com/static/shared/app/videojs/plugins/ads/videojs.ads.js$domain=nova.cz
 @@||static.cz.prg.cmestatic.com/static/shared/app/videojs/plugins/ads/ads.integration.*.js$domain=nova.cz
@@ -2321,7 +2321,7 @@ gelbooru.com#@##paginator
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35469
 1337x.to#@#.box-info-detail > .torrent-category-detail + div[class]
 ! https://forum.adguard.com/index.php?threads/16846/
-@@||phubcdn.com^$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||phubcdn.com^$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 ! https://forum.adguard.com/index.php?threads/22108/
 @@||googletagservices.com/tag/js/gpt.js$domain=askmen.com
 @@||securepubads.g.doubleclick.net/gpt/pubads_impl_$domain=askmen.com
@@ -2588,8 +2588,8 @@ topserver.ru#@##ads1
 ! https://github.com/AdguardTeam/AdguardFilters/issues/3133
 @@||sh.st$generichide
 ! https://forum.adguard.com/index.php?threads/14480/
-@@||pornhub.com/*?ajax=*&$xmlhttprequest
-@@||pornhub.com/*?*&ajax=$xmlhttprequest
+@@||pornhub.*/*?ajax=*&$xmlhttprequest
+@@||pornhub.*/*?*&ajax=$xmlhttprequest
 ! https://forum.adguard.com/index.php?threads/14493/
 inddir.com#@#.ad_336
 ! https://forum.adguard.com/index.php?threads/14431/
@@ -2974,7 +2974,7 @@ multiup.org#@#.adbar
 ! http://forum.adguard.com/showthread.php?6257
 @@||invodo.com^$domain=crutchfield.com
 ! pornhub etc - broken player
-@@||pornhub.phncdn.com^$image,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+@@||pornhub.phncdn.com^$image,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 ! web.mention.com - broken cabinet
 @@||web.mention.com^$document
 ! http://forum.adguard.com/showthread.php?6219
@@ -3053,7 +3053,7 @@ forum.pac-rom.com#@#.banner_ads
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/396
 @@/s1600/banner.png$domain=googlechromereleases.blogspot.ru
 ! Fixing video player
-@@||pornhub.com/devices/wankband^$document
+@@||pornhub.*/devices/wankband^$document
 ! Fixing an issue with /download/ads filter
 @@||bleepingcomputer.com/download/ads-spy/
 ! http://forum.adguard.com/showthread.php?4482 (fixing videos on cnn.com)
@@ -3110,7 +3110,7 @@ fb.eset.com#@##header-banner
 ! JRO-840-86973
 @@||bankofamerica.com^*?adx=
 ! http://forum.adguard.com/showthread.php?3007-Problem-with-linkbucks&p=36199#post36199
-@@/videos/*$domain=pornhub.com|pornhubthbh7ap3u.onion
+@@/videos/*$domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 @@||linkbucks.com^$third-party,domain=goneviral.com
 @@||redtubefiles.com/_videos_
 @@||web.any.do^$document
@@ -3149,7 +3149,7 @@ msn.com#@#[id^="-"]
 @@||sexgalaxy.net/wp-content/themes^
 @@||sexgalaxy.net/wp-includes/js^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18506
-m.facebook.com,touch.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion#@##m_newsfeed_stream article[data-ft*="\"ei\":\""]
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion#@##m_newsfeed_stream article[data-ft*="\"ei\":\""]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33754
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26998
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15940
@@ -3213,7 +3213,7 @@ destructoid.com#@#[style*="background-image:"]
 @@||fruithosts.net/embed/$popup
 @@||mp4upload.com/embed-*.html$popup
 @@||streamhunter.top^$popup
-@@||pornhublive.com/bio.php?$popup,domain=pornhub.com|pornhubthbh7ap3u.onion
+@@||pornhublive.com/bio.php?$popup,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion
 @@||streamiptvonline.com/streams^$popup
 @@||cdnjs.cloudflare.com/ajax/libs/videojs-contrib-hls^
 @@||vjs.zencdn.net^$domain=stream2watch.org

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -437,7 +437,7 @@ m.megafonpro.ru##div[class="v y m"]
 mamibai.com##.content-ad-spa
 mobil.ksta.de##.is-ad
 sueddeutsche.de##power-stories-embed
-mbasic.facebook.com##div[role="article"][data-ft*='"originated_from_recommendation":"1"']
+mbasic.facebook.com,d.facebook.com,free.facebook.com,free.facebookcorewwwi.onion,mbasic.facebookcorewwwi.onion,d.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##div[role="article"][data-ft*='"originated_from_recommendation":"1"']
 mobil.macwelt.de,mobil.pcwelt.de##.mobile_mpu
 noticias.uol.com.br##.text > div[style*="height: 20px!important;line-height: 20px!important;"]
 hochu.ua##.exp_300x250
@@ -774,13 +774,13 @@ wasabisyrup.com##.top-group
 wasabisyrup.com##.article-gallery > .article-gallery-group > .content-group
 redtube.com###content_container > div[class]:not(.show_page_modals):not([id]):not([style]):not([class^="content"])
 youtube.com##ytm-promoted-video-renderer
-b-m.facebook.com,iphone.facebook.com,m.facebook.com,touch.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion###m_newsfeed_stream article[data-ft*='"ei\":']
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion###m_newsfeed_stream article[data-ft*='"ei\":']
 m.voyeurhit.com##.container > .section--normal[style*="margin-top: -15px"]
 avcanada.ca##.postbody > div[id^="post_content"] > .content ~ center
 xbabe.com###fltd
 vikiporn.com##.under_player_adv
-iphone.facebook.com,x.facebook.com,mobile.facebook.com##article[data-store*="is_sponsored.1"]
-x.facebook.com,mobile.facebook.com##.storyStream > .fullwidth.carded
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##article[data-store*="is_sponsored.1"]
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##.storyStream > .fullwidth.carded
 m.allboxing.ru##.arcticmodal-container
 m.delmagyar.hu##.closable-ad
 m.delmagyar.hu###block___frappe_mobil
@@ -1241,7 +1241,7 @@ reshil.org###trr
 rg.ru###yandex_ads_hor_pda
 apkmirror.com##.OUTBRAIN
 4g.co.uk##.ad4
-redtube.com,pornhub.com##.adContainer
+redtube.com,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.adContainer
 bhaskar.com,divyabhaskar.co.in,fashion101.in##.ad_320
 m.delfi.lt##.ad_atop
 seclub.org##.ad_block

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -437,7 +437,7 @@ m.megafonpro.ru##div[class="v y m"]
 mamibai.com##.content-ad-spa
 mobil.ksta.de##.is-ad
 sueddeutsche.de##power-stories-embed
-mbasic.facebook.com,d.facebook.com,free.facebook.com,free.facebookcorewwwi.onion,mbasic.facebookcorewwwi.onion,d.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##div[role="article"][data-ft*='"originated_from_recommendation":"1"']
+mbasic.facebook.com,d.facebook.com,free.facebook.com,free.facebookcorewwwi.onion,mbasic.facebookcorewwwi.onion,d.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion,0.facebook.com,0.facebookcorewwwi.onion##div[role="article"][data-ft*='"originated_from_recommendation":"1"']
 mobil.macwelt.de,mobil.pcwelt.de##.mobile_mpu
 noticias.uol.com.br##.text > div[style*="height: 20px!important;line-height: 20px!important;"]
 hochu.ua##.exp_300x250


### PR DESCRIPTION
It has reached my attention that `Pornhub` has made `pornhub.org` and `pornhub.net` for some non-Western countries (incl. India) to bypass exceptionally weak DNS censorship efforts, and the domains are *only* available in those countries. That's at least what https://github.com/easylist/easylist/issues/5065 explained to me pretty well.

Additionally [I did some research three weeks ago](https://github.com/DandelionSprout/adfilt/blob/master/Wiki/Facebook%20domain%20functionality%20tiers.md) about which `Facebook` GUIs that are used by which ones of their many, many domains.

So as a result, here I am once again to improve the entries for those two sites.
