### PR TITLE
Remove bugsnag.com from tracking_servers.txt

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -760,7 +760,6 @@
 ||btttag.com^$third-party
 ||bubblestat.com^$third-party
 ||bugherd.com^$third-party
-||bugsnag.com^$third-party
 ||burstbeacon.com^$third-party
 ||burt.io^$third-party
 ||bux1le001.com^$third-party


### PR DESCRIPTION
The rationale for this change is the same as that expressed in https://github.com/AdguardTeam/AdguardFilters/commit/c395ebc750b0385cec4a0342a35be94b35f2dcdf which removed crashlytics from this list.