### PR TITLE
Migrated many entries from "Adguard Annoyances Filter - Remains" to ad-specific lists.

### DIFF
--- a/AnnoyancesFilter/sections/remains.txt
+++ b/AnnoyancesFilter/sections/remains.txt
@@ -3,51 +3,34 @@
 !
 voxc.org###link-view > p ~ hr
 voxc.org##.box-main > .banner ~ hr
-abhala.de##.hotinfo_top
 unlockapk.com##.StlyeSocial
 uploadrar.com#%#AG_onLoad(function() { document.getElementsByClassName('download2page')[0].innerHTML = document.getElementsByClassName('download2page')[0].innerHTML.replace(/ads[\s]*\d*/g, ''); });
 business-class.su##.remove
-ichip.ru##.code-block
 hronika.info##.full-story > div.sb
 diffnow.com###root > div[style="margin: 20px 72px;"] > div[style^="position: relative; display: flex; margin-top: 20px; margin-bottom: 20px; justify-content: center; align-items: center; border:"][style$="height: 100px; overflow: hidden;"]
 frkn64modding.com##.flexia-sidebar-inner > #ai_widget-3
 frkn64modding.com##.flexia-sidebar-inner > #ai_widget-4
-greatpicture.ru###before-post-content-sidebar-wrap
 vremenno.net###sidebar-banners
-incrussia.ru##.inner-title > div.inner-title_col-2.fixed
-filehorse.com##.big-sidebar
 briian.com###content > div[style="width:100%;margin:0 10px 5px; padding:3px 12px; background:#FFFFFF;"]
 briian.com##.entry-data-wrapper-single-mobile > div[style^="float: right; margin:"][style*="height: 325px; width: 170px; background: #FFFFFF;"]
 vividscreen.info##.page > .buddies
 vanar.io##.frame-data
-slain.io##.slain-adslot
-t-online.de##.Tvideosearch ~ #Tcontbox > #Tcontboxi > div[class]:not([id]):not([onfocus]):not(.Tinfinitlayer)
-t-online.de##div[data-dy-embedded-object]
 vivud.com##.closeContainer
-videam.party##.ads
 fmovies.is###movie > .widget > .widget > div[style*="height:166px;overflow:hidden"]
 fmovies.is##div[id^="MarketGidScriptRoot"]
 fmovies.is##iframe[src^="//creative.wwwpromoter.com"]
-chip.com.tr##.altsayfalisting.lastscroll:not(.mostreadnews):not(.hidemobile)
 investingnote.com##.dianomi-ads
 investingnote.com##iframe[src^="//www.dianomi.com"]
 brainly.ro,brainly.lat##div[class^="brn-ads-"]
-majorgeeks.com###ypaAdWrapper-mjgeeksUnitTop
 webhakim.com##.td-g-rec
 xxxfatclips.com##.SHBotBl > div[style*="height:150px;width:300px;"]:not([class]):not([id])
 xxxfatclips.com##.SAbnsBotBl
 xxxfatclips.com##.SHVidBlock > .SHVidBlockR
+eurogamer.net,eurogamer.de,eurogamer.cz,eurogamer.es,eurogamer.it,eurogamer.nl,eurogamer.pl,eurogamer.pt##.mobile-mpu-wrapper
 bigtitsxxxsex.com##.bnrba
-eurogamer.de##.mobile-mpu-wrapper
-t-online.de###T-Shopping
 memurlar.net##.NewsDetail > div[style*="width:580px; height:430px"]
-rtlnext.rtl.de##.rtli-master-morecontent__items > div.rtli-master-morecontent__teaser
-rtlnext.rtl.de#$#.rtli-master-section {margin-top: 0!important; }
-latimes.com##ark-ad-right
-latimes.com##ark-top-ad
 semprot.com##.semprotnenenmontok_adalah_pujaan_hatiku > div[style]:not([id]):not([class])
 semprot.com###semprotnenenmontok_f
-autobild.de###pagewrapper > #spacerElem
 aeroport-de-tunis-carthage.com##ins[id^="aswift_"]
 ashemaletube.com#$##site-wrapper {padding-top: 0!important; }
 ashemaletube.com#$##site {min-width: calc(100%)!important; max-width: calc(100%)!important;}
@@ -55,38 +38,23 @@ ashemaletube.com#$##site-wrapper {min-height: calc(100%)!important;}
 getandroidstuff.com##.td-header-rec-wrap
 modelsxxxtube.com##div[class^="adx-"]
 shindan-apps.net##div[class^="ad-box"]
-playnation.de##.playcontainer > .row > div > .play-text + div.marg-t-10[style*="padding-left:0px"]
 off-soft.net##.contents-usual > div[style] > .adsbygoogle
 off-soft.net##.right_sidebar > .adsbygoogle
-anipo.jp##.adbanner > div[style]
 babesource.com##.gallery-content > .sidebar
 babesource.com##.addthis
 babesource.com##.corner-ad
 palimas.tv##[class^="ad-ind"]
-transfermarkt.com.tr##div[id^="home-rectangle-"]
 lolalytics.com##body > div[class] > div[style^="width:728px; font-size:0px; height:90px;"]:not([id]):not([class])
 lolalytics.com##.right_1_3 > div:not([class]):not([id]):not([style])
 bursa.com##.bg--gri[style="padding: 10px 0;"]
-m.pornxs.com###im_scroll_close_button
-m.smutty.com##.ui-content .center[style*="margin-"]:not([id])
-m.empflix.com##.bannerBlock
-t-online.de##div[data-dy^="Partner:"]:not([data-dy^="Partner:Telekom"])
-emlakkulisi.com##article > div[class*="mobils"].mobilw:not([id])
 teknolojioku.com##.row > div.justify-content-center.d-flex.align-items-center[style*="px"]:not([id])
-m.posta.com.tr##div[ng-app="appFotoGallery"] > div[ng-controller="demo"] > .row > div[style="text-align:center;height:100px;"]
-m.posta.com.tr##div[class^="in-view-banner"]
 gaytiger.com##.content-inner-col > .aside-itempage-col
 wildgay.com##div[class^="line"][class*="ad"]
 wildgay.com###main > table td[width="520"] + td[bgcolor="#191919"]
-m.flyordie.com###content > .margin10
-startspiele.de###dascwh
-startspiele.de###right > div[style^="text-align:center; margin: 0"]:not([class]):not([id])
 wapbestmovie.biz##iframe[src^="http://iictguj.com"]
-log.com.tr###masthead-wrapper
 enjoyfuck.com,fuckgonzo.com##.advmnt
 youflix.is##div[id^="ad_tsuibi"]
 youflix.is##div[style*="width:"][style*="margin:"][style*="overflow:"]
-mobile.donanimhaber.com##.yorumlar > article + .ondabir
 bitmakler.com###coins_table td[colspan="10"]
 bitmakler.com##body > center > div[class][style*="height: 60px; width: 1250px;"]
 bitmakler.com###sidebar > div[style*="padding: 5px; width: 188px;"]
@@ -96,7 +64,6 @@ xgaytube.tv##.js-mobile-spots
 goldgay.tv,gayfuckporn.tv,xlgaytube.tv##.b-video-columns > .b-random-column
 xgaytube.com##.PlayPageBanners
 xgaytube.com##.videoPlayer > .uwrap
-m.boyfriendtv.com##.adblock-big
 sexhoundlinks.com##.banner
 gittigidiyor.com###rightBannerBox
 1diziizle.com###single-sag
@@ -104,42 +71,21 @@ fragman-tv.com##body > div[style*="float:left;margin:"]:not([class]):not([id])
 fragman-tv.com##.reklamliste
 fragman-tv.com##.sol_blok > .dizi_video > .dizi_video
 tempr.email###Menu > #MenuInbox:not([class])
-waz.de#%#AG_onLoad(function() { setTimeout(function() {var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();}; var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();};}, 300); });
-krone.at##.row > .c_retresco-story-tags + .box.c_label
-20min.ch##div[data-ana-click*="werbemittel"]
-20min.ch##iframe[src*="cloudfront.net/anprebid/"]
-derwesten.de##.ad
 youjizz.com###onPausePrOverlay
-az-online.de##div[data-id-advertdfpconf]
 streamcherry.com###videooverlay
-ndtv.com###ad100
-ndtv.com##div[id^="div-gpt-ad-"]
 zgaytube.com##.gal_body > .right > h3
 gaymaletube.name,gayporn.fm,boy18tube.com,goldgay.tv,gayfuckporn.tv,xlgaytube.tv##.js-b-mobile-spots
-autobild.de##.adsbygoogle
-autobild.de##.adsense
-filmarenasi.org##div[id^="reklamkapat"]
 youjizz.com##.top_pr
 youjizz.com###desktopRecoPr
 youjizz.com###desktopFooterPr
 bonusbitcoin.co##[style*="width:468px"][style*="height"][style*="0px"]:not([id]):not([class])
 bonusbitcoin.co##div[style*="width:500px;height:402px;"]
-m.mangafox.la##.adv-here
 foxgay.com##body > .pb_footer
 youporngay.com##.container .eight-column[data-track]
 gayporno.fm,gaymaletube.name,gayporn.fm,gaysuperman.com##.b-uvb-spot
-sport-news-streams.info###video-container > div[id^="over-"]
 streamsfinder.com###bannerInCenter
 streamsfinder.com###hiddenBannerCanvas
 hollaforums.com###sidebar .sidebar-rc
-5min.at##div[class^="frontpage_ad_"]
-5min.at###google_ad_footer
-5min.at##.anzeige_footer
-l-iz.de##.liz-banner-content
-l-iz.de##.sidebar_list > #text-10
-l-iz.de##.sidebar_list > #text-2
-l-iz.de##.sidebar_list > #text-11
-l-iz.de##.sidebar_list > #text-64
 fbstreams.me##.container-fluid div[style="min-width:300px;max-with:600px;height:347px;right:50px;"]
 123movieshub.to##.main-content > .content-kusss
 btconity.com##.holder-main > #bottom_banner
@@ -150,95 +96,54 @@ menshealth.com##.iab-adcontent
 opensnow.com##.recommend-blocks > .col-md-4[style="text-align:center"]
 slipstick.com##.entry-content > div[style^="width:100%;padding: 10px 10%;height:100px;"]
 slipstick.com##.entry-footer > .lastone
-kartaslov.ru##.split-info-section > div.split-info-sub-section+div[style^="margin-top: 15px; background-color: #F7F7F7;"]
-flashgames.ru##.game-page-sidebar
 edirneaktuel.com##table[width="632"] > tbody > tr > td[height="40"]:empty
 radarbox24.com##.remove-pub
 link.tl##.fly_head_bottom
-m.sz-online.de##[id^="ctl00_m_ctrlMainContentPlaceHolder_ctl00_"][id$="_m_ctrlEditContainer"] > .szoHtmlModuleContent
 extramovies.tv##.theiaStickySidebar > div[id^="ai_widget"]
 animev.net###siteContent > div.cAlign > div#sidebarGeral
-distrowatch.com##td[style="width: 19%; vertical-align: top; border: none"] > table[class="News"]+br+table[width="100%"]
-distrowatch.com##td[style^="width: 20%; vertical-align: top; border: none;"] > table[class="News"]+br+table[class="Info"]
-prizyv.ru###text-10.widget_text
-prizyv.ru###text-9.widget_text
 xtreme.rip##.topBorder > table[border="0"][width="100%"][height="205"]+div.separator
 porno720p.org##.side > .side-box > br
 porno720p.org#$#.side { padding: 0px!important; }
 mos.news##article.white-block-text > p[style="text-align: center;"] > br+b
-a.pr-cy.ru##.analysis-head-box+div.announce
 agravery.com##figure.text-center > figcaption
 gooool.org##.socialb+div.block_d
 newsoboz.org##.widget_center > div.articl ~ br
-russian7.ru##aside#sidebar
-fullhdfilm.gen.tr###film-ek-tab
-gamestar.de##.pv-teaser-pricecompare + .elemCont
 cont.ws##body > div.header2
 moscow.regnews.info##a.sidebar-toggle+div.sidebar-content > div[class="widget widget_text"]
-rksports.info##.col-lg-4 > div > div[class$="panel-heading"]
 trainbit.com###Adv2
 koddostu.com###HTML2
-willhaben.at###adition_ContentAd
-hdfilmkanali.org###alt
 marktplaats.nl###bottom-listings-divider
 ilf.at.ua###carousel-container
-studieren.de###colContents > div#colService
 top100arena.com###container3 > div[style="padding:20px; position:relative"] > div[style="overflow:auto"] > div[style="float:right; text-align:center"]
 bilgiustam.com###content_box > div[style$="min-height:100px; clear:both; width:100%;"]
 download3k.com###dl_main_container_content > div[class="space"][style]
-cwer.me,cwer.ru###footer
-wiesentbote.de###footer-widgets
-programmersforum.ru###header_right_cell strong
 diziizlep.com###kendisi > div[style="min-height:23px;border: 1px solid #294887; background: #3b5998;text-align:center;padding:10px; margin-bottom:10px; color: #fff; font-size: 14px;"]
 cafefernando.com###l_sidebarwidgeted > #text-20
 glav.su###layoutContent > table.frameTable[style*="height: 100px;"]
 wowjp.net###main-container-inner > div#slideshow
 imageweb.ws###mainc > div[style^="height:"][style*="position: absolute;"]
-n-tv.de###ntv_ligatus_680
-gelbeseiten.de###offgrid_iframe
 torrenthound.com###pcontent > #direct2
 sportlive.me###player > div > div[style$="text-align: center;"]
-stimme.de###plista_widget_underArticle
 diakov.net###rbar > div.blocklite.blc2:last-child
 diakov.net###rbar > div.blocklite.blc2[align="center"]
-aksam.com.tr###reklam_center
 sadeempc.com###secondary > aside#text-15
 diakov.net###sidebar > div.blocklite:last-child
 mobafire.com###sidebar-free-champs + div.box-shadow.mb10
 beycan.net###site > #menu + .left
-chinamobilemag.de###sp-user3
-xhamster.com###swectrqw
-softpedia.com###swipebox-top
 gamegpu.com###tm-top-a
 webrazzi.com###topheadMaindiv
-willhaben.at###tower
 kayzen.az##.CustomBlock.Blocksmaster
-winfuture-forum.de##.ExtraPostBlock > div[class$="post_block hentry clear"]
 ||softportal.com/img/adg_rnb.png
-t-online.de##.Tmcc1.Tmcc1a.Tmccm
 acunn.com##.acunn-push
-forum.atvclub.ru##.adTabs
-internetsorunlari.com##.adsWidgetSidebar
 spankwire.com##.align-center
 gecid.com##.alogo > td.lcenter > div.band
 loading.az##.banlog
-hi-fi.ru##.banner
-vedtver.ru##.banner > a[rel="nofollow"] > img
-simtimes.de##.banner-end-news
-hi-fi.ru##.banner-first
 teknomobil.org##.banner_box
-extra-radio.de##.bc_right div.box_right:last-child
-nordbayerischer-kurier.de##.billboard
-movies.ndtv.com##.cnAdzerkDiv
 l2topzone.com##.col-md-6 > .panel
-zoon.ru##.contents > div.box-padding
 feat.az,loading.az##.counts
 thedaretelly.com##.details_img > span
-filehorse.com##.dx-sb-1
-efirde.az##.fban
 gazeteciler.com##.fr
 unian.info,unian.net,unian.ua##.gallery-item.wide-3
-handelsblatt.com##.hcf-sponsoring
 sansursuzhaber.com##.headline_side > .viewport
 hidden247.com##.igraR
 winphonehub.org##.inner-wrapper > center > div[style]
@@ -246,19 +151,11 @@ zonasports.be##.jumbotron > tbody > tr > td > font
 remote.12dt.com##.left_rail > div.pad
 ren.tv##.main-with-sidebar > div[class="block block-block"]
 aktifhaber.com##.middle_content > div[style^="padding:"]
-movies.ndtv.com##.ndmv-ad-wrapper
-movies.ndtv.com##.ndmv-inner-ad-wrapper
-sports.ru##.news-item__footer > h3
 sansursuzhaber.com##.news_detail > .side_detail
 hidden247.com##.oglSve
-turkcebilgi.com##.panel-body > .pull-left[style="width: 346px; height: 290px"]
-lvz.de##.pda-addart
-volksstimme.de##.ph-ah-ad-icon
-irecommend.ru##.product-half-teaser > div.text > div#bigright
 relink.to##.right > div[class$="paddingTBhighlight"] > center
 hronika.info##.row-600 > div[class^="col-"]
 sanalbasin.com##.row-reklam
-rtl.de##.rtlde-octopus-related
 smitefire.com##.self-clear div.caroufredsel_wrapper
 thedaretelly.com##.show_page_des > span
 thedaretelly.com##.show_page_img > .center > span
@@ -272,58 +169,34 @@ small-games.info##.top-ban
 tureng.com##.tureng-ad-horizontal-responsive
 tureng.com##.tureng-index.hidden-print > div[style$="min-height: 130px;"]
 thedaretelly.com##.video_dtls_sec > span
-ign.com##.video_supplement > div#queen
-deutschland-in-zahlen.de##.werbung_oben
-deutschland-in-zahlen.de##.werbung_oben + div[style="position:absolute;top:15px;left:2px"]
-windowsarea.de##.widgetized.w-3 > aside.clearfix.widget_text
-efirde.az##a[href="http://just.az"]
 lyngsat.com##a[href="http://www.lyngsat.com/advert.html"]
 ~smi2.net##a[href^="http://smi2.net/"]
-nzz.ch##aside[class$="resor resor--billboard"]
-tagesspiegel.de##aside[id^="plista_widget_"]
 xtreme.ws##aside[role="complementary"] > div.newss
-m.comic.naver.com##body > div.viewer.cuttoon > div[class^=ly_dim].on
 comparegames.com.au$$span[tag-content="Advert"]
 anrufer.info##div[class$="box_small"]
 yookartik.com##div[class$="last-add"] > .main-head
 superhaber.tv##div[class$="tema_1 module module_301"]
-mmovote.ru##div[class="header"] + div.sidebar
-m.comic.naver.com##div[class="ly_wrap viewer_da_ly"]
 olke.az##div[class="mom_visibility_desktop center"][style="padding-left: 4px"]
 gottabemobile.com##div[class^="code-block code-block-"][style]:not([class$="code-block code-block-16 ai-desktop-tablet"])
 maclarizle.com##div[class^="sidebar-"] > div[id^="text-"]
-helpster.de##div[data-engagement*="click-advertisement"]
 porndoe.com##div[data-subscript="Advertising"]
-porndoe.com##div[data-supscript="Advertising"]
 uppit.com##div[id="336"]
 filescloud.co##div[id="box-left"][style]
 zonasports.be##div[id^="MarketGid"]
-vwcorrado.de##div[id^="edit"] > div.vbmenu_popup + table[style="margin-top:6px;"]
-cyberforum.ru##div[id^="edit"][style="padding:0px 0px 3px 0px"] > table ~ div[style^="background-color"]
-x.epidemz.co,x.epidemz.com##div[id^="smile_teaser"]
+x.epidemz.com##div[id^="smile_teaser"]
 rivx8.me.la##div[itemprop*="articleBody"] > span
-zonasports.ch,zonasports.be##div[style$="position:relative"] > center > table
+zonasports.be##div[style$="position:relative"] > center > table
 zonasports.be##div[style$="position:relative"] > table > tbody > tr > td
-deutschland-in-zahlen.de##div[style*="font-size:10px;margin-top:1px"]
-thefreedictionary.com##div[style="border:1px solid #e8e8e9;font-weight:600"]
 audiotube.org##div[style="color:black;background-color:white;line-height: 11px;"] + hr
 torrentdownloads.me##div[style="float:left"] > a[rel="nofollow"] + br + br + font[style="color: grey"]
 webaslan.com##div[style="float:right; margin-right:4px; width:300px;"] div[style="min-height: 255px;"]
 gurubanks.com##div[style="margin-top: 10px; margin-bottom: 20px; border: 1px solid #b6e2e2; padding: 10px 5px;"]
-transfermarkt.de##div[style="margin-top:20px;"] > div.fl
-2whois.ru##div[style="overflow:hidden; padding-bottom:0px; height:80px;"]
-softpedia.com##div[style^="font-size:13px; margin: 0 0 5px 0; color: #002873;"]
-movies.ndtv.com#$##footer-ads { height: 0!important; }
 discuss.com.hk##form[method="post"] > table > tbody[id] + tbody:not([id]) > tr > td[colspan="6"]
 hidden247.com#$#.igraL { visibility: hidden!important; }
 ilf.at.ua##img[width="70"][height="40"]
-ndtv.com#$#.ad300 { position: absolute!important; top: -2000px!important; }
-ndtv.com#$#.ad_300.section { position: absolute!important; top: -2000px!important; }
 xvideos.com##p.mobile-only-hide
 pcreview.co.uk#%#AG_onLoad(function() { $('div[class$="messageAdvertising"]').closest('ol[class*="messageList"]').remove(); });
 gottabemobile.com##section[class$="cb-entry-content clearfix"] > center
-n-tv.de##section[id^="ntv_plista_"]
-thefreedictionary.com##span[class] > div[style="float:right;display:inline-block;margin-left:20px"]
 sportsfan.com.au#%#AG_onLoad(function() { $('div[class^="module adSlider"]').closest('div[class^="DnnModule"]').remove(); });
 softpedia.com#$##swipebox-right:before { content: none!important; }
 zonasports.be##td[align$="left"][width="300"]
@@ -333,10 +206,8 @@ xtreme.ws##aside[role="complementary"] > div.gid
 !+ NOT_OPTIMIZED
 ensonhaber.com##div[class^="detayAd"]
 ! hdrezka - timeout before video(in Russia)
-@@||neutralen.nl/html5/moon/$script,third-party
 @@||streamguard.cc/html5/moon/$script,third-party
 @@||streamguard.cc/assets/video-*.js
-||neutralen.nl^$script,third-party
 !||streamguard.cc^$script,third-party
 ! https://forum.adguard.com/index.php?threads/14124/
 avxhome.in##.news > center
@@ -344,33 +215,17 @@ avxhome.in##.news > center
 ! benchmarkreviews.com - remains of ads
 benchmarkreviews.com###content > div#sidebar2 > div
 sd-company.su#%#AG_onLoad(function() { $('div[class$="sdc-box-sdads"]').closest('div[class$="sdc-box-i"]').remove(); });
-! http://forum.adguard.com/showthread.php?10839
-samathalemonseio.com##body > a[href^="http://"]
 ! http://forum.adguard.com/showthread.php?9995
 04stream.com##body > table
 !
-ultra-warez.net##a[href="http://www.i.ua/"]
 weekendnotes.com##div[style="font-size: 80%; padding-bottom: 1px; text-align: left;"]
 rus-linux.net##td[valign="top"][align="center"][width="195"]
-! glaz.tv - удаление сообщения о пропуске рекламы
-m.glaz.tv###stream > div[style]
-! http://forum.adguard.com/showthread.php?9614
-t-online.de##div[itemprop$="articleBody"] > div[id$="Ttub1"]
 ! http://forum.adguard.com/showthread.php?9540
 avxhome.in,avxhome.se##.col-md-12 > center > b
 avxhome.in,avxhome.se##.news > center > div > b
-avxhome.se,avxhome.in$$div[tag-content="Best Internet Links"]
-! http://forum.adguard.com/showthread.php?9480
-zdnet.de##div[id$="articleContent"] > div[class$="highlight clearfix"]
-! http://forum.adguard.com/showthread.php?9439
-reich-der-spiele.de##section[class$="region region-sidebar-second column sidebar"]
-! http://forum.adguard.com/showthread.php?9446
-kidsweb.de##div[align="center"] > span[class$="Stil36"]
+avxhome.in,avxhome.se$$div[tag-content="Best Internet Links"]
 ! http://forum.adguard.com/showthread.php?8438
 free-torrent.org,free-torrents.org##table[class="attach bordered med"] td[width="15%"] > div[id][class]
-! http://forum.adguard.com/showthread.php?8654
-heilpraxisnet.de##div[id$="primary-sidebar"][role$="complementary"]
-heilpraxisnet.de##span[style$="font-size: xx-small;"]
 ! http://forum.adguard.com/showthread.php?9290
 semprot.com###yayaya_footer
 semprot.com###yayaya_nav > div[style="margin-bottom:0.3em"]
@@ -379,8 +234,6 @@ armyrecognition.com##div[class="sidebar_module sidebar_module_"] > .sidebar_modu
 armyrecognition.com##header#header > div[id^="position"]
 armyrecognition.com##section#content > div[id^="position"]
 !
-! stranded-deep.ru - удаление брендированного фона, отступа сверху
-stranded-deep.ru#$#body {background:none;padding: 0px 0;}
 ! ifresh.ws - уменьшение отступа сверху
 ifresh.ws##body > section[id="main-preview"][class="width hide320"]
 ifresh.ws#$##h-wrapper { min-height: 80px!important; }
@@ -392,45 +245,16 @@ mp3.cc#$#body > #xx1 { margin: 70px auto 0 auto !important; }
 malina.am#$##content{ padding-top: 83px!important; }
 ! http://forum.adguard.com/showthread.php?8656
 freshideen.com##footer[class$="single-elements"] > div[style$="width: auto; margin: 0px auto;  margin-bottom: 20px; border-bottom: 1px solid #CFCFD0; border-top: 1px solid #CFCFD0; padding-bottom: 10px; padding-top: 5px; text-align: center; margin-right: 10px;"]
-! http://forum.adguard.com/showthread.php?8531
-kn-online.de##.included-uri > div[class="maindiv"][style]
-!
-yaplakal.com,yap.ru##td[align="center"] > noindex
 ! nadavi.com.ua - top and bottom margins
 nadavi.com.ua##body > center > div[style="width: 100%; height: 32px;"][class]
 nadavi.com.ua##body > div > div[style="width: 100%; height: 80px;"][class]
 nadavi.com.ua##div[style="width: 100%; height: 90px;"]
 ! wmasteru.org - top padding
 wmasteru.org##body > div[class$="wrapper"] > div[style*="height: 100px"]
-! http://forum.adguard.com/showthread.php?7646
-wowlol.ru##html > body > div#wrapper > div#topbox
 ! http://forum.adguard.com/showthread.php?7290
 meduza.io##.MaterialTopBar
-! http://forum.adguard.com/showthread.php?4311
-bezformata.ru##body > div[style^="clear:both;width:100%;height:90px;"]
-! http://forum.adguard.com/showthread.php?5604
-max.de##div[style$="padding: 15px; height: 90px;"]
-max.de##div[style$="padding:15px; height:90px; "]
 ! di.fm - remains of ads
 di.fm##.secondary > .bare
-! http://forum.adguard.com/showthread.php?6154
-business-gazeta.ru##.left-colum > div.box > div.ctext.ctext_2
-! http://forum.adguard.com/showthread.php?9444
-weser-kurier.de##table[class$="main-content adobj publication"]
-! film.ru - удаление отступа сверху
-film.ru##body > div[style="height: 269px;"]
-! oper.ru - удаление пустоты от баннеров
-oper.ru###container > div[style="width: 100%; height: 290px; min-width: 1000px; text-align: center;"]
-! rankw.ru - удаление пустоты от баннеров
-rankw.ru###headerFrame > div[style*="width: 1170px; height: 90px;"]
-rankw.ru##section#sideBarFrame > section[style="margin:15px;height:90px;"]
-rankw.ru##section[style="margin-left:0;margin-right:0;margin-top:0;margin-bottom:10px; height: 160px;"]
-! http://forum.adguard.com/showthread.php?4360
-sysadmins.ru##table[background="/images/header.gif"] td[align="right"] a img
-||sysadmins.ru/iq-powered.png
-||sysadmins.ru/samag.gif
-! http://forum.adguard.com/showthread.php?5875
-fast-torrent.ru##.no-mobile > div > h1 > span[style="font-size: small;"]
 ! footballtransfer.com.ua - удаление нижнего отступа
 footballtransfer.com.ua##noindex > a#back-screen
 ! http://forum.adguard.com/showthread.php?4895
@@ -438,10 +262,6 @@ ufolabs.net###bullet_energy > center > a > img
 ! forum.adguard.com/showthread.php?4882
 android.mobportal.net##body > div.site > table > tbody > tr[align="center"] > td[height="310px"][align="left"]
 android.mobportal.net#$#body > div.site > table > tbody > tr[align="center"] > td[align="right"] > div.header_text {height: inherit!important;}
-! http://forum.adguard.com/showthread.php?4763
-opennet.ru##form[method="get"] td[align="RIGHT"][width="470"][height="70"]
-opennet.ru##form[method="get"] td[valign="TOP"][align="RIGHT"][width="130"][bgcolor="#E9EAD6"]
-opennet.ru##form[method="get"] td[width="40"][style="background: #E9EAD6 url('/back.gif') repeat-x bottom left"]
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/393#issuecomment-77358450
 vseverske.info##.floating.righ
 vseverske.info##.left_column div[class^="place left_"]
@@ -449,63 +269,26 @@ vseverske.info##.right_column div[class^="place right_"]
 vseverske.info##div.place.top > a > img
 ! sat-expert.com - ads placeholders
 sat-expert.com##div[style="overflow: hidden; height: 65px; padding: 5px;"]
-! http://forum.adguard.com/showthread.php?5366-*-http-vp-news-ru&p=50285&viewfull=1#post50285
-vp-news.ru##.box.nomargin
 ! http://forum.adguard.com/showthread.php?4525
 baibako.tv##td[valign="top"] > div[style="padding-bottom:15px;margin-bottom:15px;border-bottom:1px solid #dfdfdf;"]
 ! http://forum.adguard.com/showthread.php?4687
 domenforum.net##.page > div[style="padding:0px 25px 0px 25px"] > table[class="tborder"][cellpadding="6"][cellspacing="0"][border="0"][width="100%"][align="center"]
 domenforum.net##.page center > a > img
-! forum.na-svyazi.ru - empty rectangles
-forum.na-svyazi.ru##td#user2s
-! http://forum.adguard.com/showthread.php?4360
-sysadmins.ru##body > table > tbody table[width="240"][align="left"]
-sysadmins.ru##td.row2 > a > img
-! http://forum.adguard.com/showthread.php?4101
-imageban.ru###cboxOverlay
-imageban.ru###colorbox
 ! http://forum.adguard.com/showthread.php?4323
 ps4news.com##font[face="Verdana,Arial,Tahoma,Calibri,Geneva,sans-serif;"]
 ! http://forum.adguard.com/showthread.php?4147
 allcrimea.net##.foto2i
-! yarportal.ru - empty rectangles
-yarportal.ru##div[style="font-size: 0; border: 1px solid #1b4786; background-color: #1b4786; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
-yarportal.ru##div[style="font-size: 0; border: 1px solid #67FDFB; background-color: #67FDFB; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
-yarportal.ru##div[style="font-size: 0; border: 1px solid #FFE500; background-color: #FFE500; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
-||zerx.tv/templates/zerxnew/images/utorrent.png
-! http://forum.adguard.com/showthread.php?4311
-bezformata.ru##div[style^="clear:both;width:100%;height:90px;clear:both;margin:0px;padding:0px;"]
-||tugmed.ru^$domain=bezformata.ru
-! lotr.ru - advert in right borrom
-||lotr.ru/images/logo.png
-! http://forum.adguard.com/showthread.php?3890
-fast-torrent.ru##.wrap > div > h1 > span[style="font-size: small;"]
-! http://forum.adguard.com/showthread.php?3754
-pozdrav.ru##.conteiner.purple
-moikolodets.ru##noindex > #slidebox
-! http://forum.adguard.com/showthread.php?3775
-stost.ru##.tosts
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/164
 free-torrents.org##noindex > center > div[style="border: 2px solid red;"]
-! http://forum.adguard.com/showthread.php?2045
-||yarportal.ru/zagl.gif
-! http://forum.adguard.com/showthread.php?3384
-echo.msk.ru##div[style="padding-bottom:40px;"]
-echo.msk.ru##iframe[src="http://vz.ru/inc/b/vz_block_echomsk.html"]
 ! i.ua - блоки, в которых возможно появление рекламы
 i.ua##.clear.logo_container
 i.ua##.header_adv
 ! http://forum.adguard.com/showthread.php?6378
 skatay.com#%#AG_onLoad(function() { $('a[href^="http://goload.do.am/"]').closest('table').remove(); });
-! http://forum.adguard.com/showthread.php?6213
-nordbayern.de##div[style="width:310px; margin:0 0 0 12px;"]
 ! http://forum.adguard.com/showthread.php?6520
 epidemz.co,epidemz.com##body > div.wrappperrr > div.footer
 ! http://forum.adguard.com/showthread.php?6367
 go.guidants.com#%#AG_onLoad(function() {  $("#sidereklame").remove(); $(".reklameflaechen#activity").css({ 'right': '0px' }); $("#activity").css({ 'right': '0px' }); });
-! http://forum.adguard.com/showthread.php?6049
-@@||mmgp.ru/images/shapka/logo_
-||mmgp.ru/images/shapka/
 ! http://forum.adguard.com/showthread.php?6669
 epidemz.co,epidemz.com##a[rel="nofollow"][target="_blank"] > font
 ! http://forum.adguard.com/showthread.php?6802
@@ -520,7 +303,6 @@ teknobeyin.com##.post.no-bg > center > div[style$="font-size:12px;font-family: a
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1453#event-538412025
 kitguru.net##.wrapper > div#b-4
 !
-motorpage.ru##.bannerplace
 championat.com##.hitman
 xtreme.ws##.topBorder > table[width="100%"][height="205"]
 gta.com.ua##div[style*="width:240px;height:400px;"]

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -9985,6 +9985,29 @@ foxbaltimore.com,foxchattanooga.com,foxillinois.com,foxlexington.com,foxnebraska
 /^https?:\/\/([a-z0-9]{8,10}\.)?[a-z0-9]{5,14}\.(com|bid|online|top|club)\/([a-z0-9]{2}\/){3}[a-f0-9]{32}\.js$/$script,third-party
 /^http?:\/\/[a-z]{8,14}\.(bid|club|co|com|me|pro|info)\/[a-z]{1,12}\.(aspx|php|html|htm)\?r=[0-9]{1}[\s\S]*v=/$script,third-party,domain=realtimetv.me|seelive.me
 !
+! Carried over from "AdGuard Annoyances - Remains"
+distrowatch.com##td[style="width: 19%; vertical-align: top; border: none"] > table[class="News"]+br+table[width="100%"]
+distrowatch.com##td[style^="width: 20%; vertical-align: top; border: none;"] > table[class="News"]+br+table[class="Info"]
+filehorse.com##.big-sidebar
+filehorse.com##.dx-sb-1
+ign.com##.video_supplement > div#queen
+latimes.com##ark-ad-right
+latimes.com##ark-top-ad
+majorgeeks.com###ypaAdWrapper-mjgeeksUnitTop
+movies.ndtv.com##.cnAdzerkDiv
+movies.ndtv.com##.ndmv-ad-wrapper
+movies.ndtv.com##.ndmv-inner-ad-wrapper
+movies.ndtv.com#$##footer-ads { height: 0!important; }
+ndtv.com###ad100
+ndtv.com##div[id^="div-gpt-ad-"]
+ndtv.com#$#.ad300 { position: absolute!important; top: -2000px!important; }
+ndtv.com#$#.ad_300.section { position: absolute!important; top: -2000px!important; }
+softpedia.com###swipebox-top
+softpedia.com##div[style^="font-size:13px; margin: 0 0 5px 0; color: #002873;"]
+thefreedictionary.com##div[style="border:1px solid #e8e8e9;font-weight:600"]
+thefreedictionary.com##span[class] > div[style="float:right;display:inline-block;margin-left:20px"]
+xhamster.com###swectrqw
+!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53553
 !+ NOT_OPTIMIZED
 www-pocket--lint-com.cdn.ampproject.org##.content > div.block-inline

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2071,3 +2071,74 @@ ruhr24.de,wetterauer-zeitung.de,giessener-allgemeine.de,fr.de,wlz-online.de,da-i
 wallstreet-online.de##body > #siteteaser
 wallstreet-online.de##.newsFlagSlider
 wallstreet-online.de###mooTickerContainer
+5min.at###google_ad_footer
+5min.at##.anzeige_footer
+5min.at##div[class^="frontpage_ad_"]
+abhala.de##.hotinfo_top
+autobild.de###pagewrapper > #spacerElem
+autobild.de##.adsbygoogle
+autobild.de##.adsense
+az-online.de##div[data-id-advertdfpconf]
+chinamobilemag.de###sp-user3
+derwesten.de##.ad
+deutschland-in-zahlen.de##.werbung_oben
+deutschland-in-zahlen.de##.werbung_oben + div[style="position:absolute;top:15px;left:2px"]
+deutschland-in-zahlen.de##div[style*="font-size:10px;margin-top:1px"]
+extra-radio.de##.bc_right div.box_right:last-child
+gamestar.de##.pv-teaser-pricecompare + .elemCont
+gelbeseiten.de###offgrid_iframe
+helpster.de##div[data-engagement*="click-advertisement"]
+krone.at##.row > .c_retresco-story-tags + .box.c_label
+l-iz.de##.liz-banner-content
+l-iz.de##.sidebar_list > #text-10
+l-iz.de##.sidebar_list > #text-11
+l-iz.de##.sidebar_list > #text-2
+l-iz.de##.sidebar_list > #text-64
+lvz.de##.pda-addart
+n-tv.de###ntv_ligatus_680
+n-tv.de##section[id^="ntv_plista_"]
+nordbayerischer-kurier.de##.billboard
+playnation.de##.playcontainer > .row > div > .play-text + div.marg-t-10[style*="padding-left:0px"]
+rtl.de##.rtlde-octopus-related
+rtlnext.rtl.de##.rtli-master-morecontent__items > div.rtli-master-morecontent__teaser
+rtlnext.rtl.de#$#.rtli-master-section {margin-top: 0!important; }
+simtimes.de##.banner-end-news
+startspiele.de###dascwh
+startspiele.de###right > div[style^="text-align:center; margin: 0"]:not([class]):not([id])
+stimme.de###plista_widget_underArticle
+studieren.de###colContents > div#colService
+t-online.de###T-Shopping
+t-online.de##.Tmcc1.Tmcc1a.Tmccm
+t-online.de##.Tvideosearch ~ #Tcontbox > #Tcontboxi > div[class]:not([id]):not([onfocus]):not(.Tinfinitlayer)
+t-online.de##div[data-dy-embedded-object]
+t-online.de##div[data-dy^="Partner:"]:not([data-dy^="Partner:Telekom"])
+tagesspiegel.de##aside[id^="plista_widget_"]
+transfermarkt.de##div[style="margin-top:20px;"] > div.fl
+volksstimme.de##.ph-ah-ad-icon
+vwcorrado.de##div[id^="edit"] > div.vbmenu_popup + table[style="margin-top:6px;"]
+waz.de#%#AG_onLoad(function() { setTimeout(function() {var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();}; var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();};}, 300); });
+wiesentbote.de###footer-widgets
+willhaben.at###adition_ContentAd
+willhaben.at###tower
+windowsarea.de##.widgetized.w-3 > aside.clearfix.widget_text
+winfuture-forum.de##.ExtraPostBlock > div[class$="post_block hentry clear"]
+! http://forum.adguard.com/showthread.php?9614
+t-online.de##div[itemprop$="articleBody"] > div[id$="Ttub1"]
+! http://forum.adguard.com/showthread.php?9480
+zdnet.de##div[id$="articleContent"] > div[class$="highlight clearfix"]
+! http://forum.adguard.com/showthread.php?9439
+reich-der-spiele.de##section[class$="region region-sidebar-second column sidebar"]
+! http://forum.adguard.com/showthread.php?9446
+kidsweb.de##div[align="center"] > span[class$="Stil36"]
+! http://forum.adguard.com/showthread.php?8654
+heilpraxisnet.de##div[id$="primary-sidebar"][role$="complementary"]
+heilpraxisnet.de##span[style$="font-size: xx-small;"]
+! http://forum.adguard.com/showthread.php?8531
+kn-online.de##.included-uri > div[class="maindiv"][style]
+! http://forum.adguard.com/showthread.php?5604
+max.de##div[style$="padding: 15px; height: 90px;"]
+max.de##div[style$="padding:15px; height:90px; "]
+! http://forum.adguard.com/showthread.php?9444
+weser-kurier.de##table[class$="main-content adobj publication"]
+! http://forum.adguard.com/showthread.php?6213
+nordbayern.de##div[style="width:310px; margin:0 0 0 12px;"]

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2122,6 +2122,10 @@ willhaben.at###adition_ContentAd
 willhaben.at###tower
 windowsarea.de##.widgetized.w-3 > aside.clearfix.widget_text
 winfuture-forum.de##.ExtraPostBlock > div[class$="post_block hentry clear"]
+20min.ch##div[data-ana-click*="werbemittel"]
+20min.ch##iframe[src*="cloudfront.net/anprebid/"]
+nzz.ch##aside[class$="resor resor--billboard"]
+handelsblatt.com##.hcf-sponsoring
 ! http://forum.adguard.com/showthread.php?9614
 t-online.de##div[itemprop$="articleBody"] > div[id$="Ttub1"]
 ! http://forum.adguard.com/showthread.php?9480

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1495,3 +1495,19 @@ livejournal.com##div[id^="billboard_mobile_"]
 livejournal.com##.mdspost-aside__item--banner
 !
 ! END: Livejournal.com
+! START: Carried over from "AdGuard Annoyances - Remains"
+m.boyfriendtv.com##.adblock-big
+m.flyordie.com###content > .margin10
+m.posta.com.tr##div[ng-app="appFotoGallery"] > div[ng-controller="demo"] > .row > div[style="text-align:center;height:100px;"]
+m.posta.com.tr##div[class^="in-view-banner"]
+m.pornxs.com###im_scroll_close_button
+m.smutty.com##.ui-content .center[style*="margin-"]:not([id])
+m.empflix.com##.bannerBlock
+m.mangafox.la##.adv-here
+m.sz-online.de##[id^="ctl00_m_ctrlMainContentPlaceHolder_ctl00_"][id$="_m_ctrlEditContainer"] > .szoHtmlModuleContent
+m.comic.naver.com##body > div.viewer.cuttoon > div[class^=ly_dim].on
+m.comic.naver.com##div[class="ly_wrap viewer_da_ly"]
+mobile.donanimhaber.com##.yorumlar > article + .ondabir
+! glaz.tv - удаление сообщения о пропуске рекламы
+m.glaz.tv###stream > div[style]
+! END: Carried over from "AdGuard Annoyances - Remains"

--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -9347,3 +9347,89 @@ dtf.ru##.daily-promo-unit
 spark.ru##.jobs--layout
 vc.ru###kryptonite-startup-challenge
 ! End: vc.ru, dtf.ru, tjournal.ru, spark.ru
+! START: Carried over from "AdGuard Annoyances - Remains"
+ichip.ru##.code-block
+greatpicture.ru###before-post-content-sidebar-wrap
+incrussia.ru##.inner-title > div.inner-title_col-2.fixed
+kartaslov.ru##.split-info-section > div.split-info-sub-section+div[style^="margin-top: 15px; background-color: #F7F7F7;"]
+flashgames.ru##.game-page-sidebar
+prizyv.ru###text-10.widget_text
+prizyv.ru###text-9.widget_text
+a.pr-cy.ru##.analysis-head-box+div.announce
+russian7.ru##aside#sidebar
+cwer.me,cwer.ru###footer
+programmersforum.ru###header_right_cell strong
+forum.atvclub.ru##.adTabs
+hi-fi.ru##.banner
+vedtver.ru##.banner > a[rel="nofollow"] > img
+hi-fi.ru##.banner-first
+zoon.ru##.contents > div.box-padding
+sports.ru##.news-item__footer > h3
+irecommend.ru##.product-half-teaser > div.text > div#bigright
+mmovote.ru##div[class="header"] + div.sidebar
+cyberforum.ru##div[id^="edit"][style="padding:0px 0px 3px 0px"] > table ~ div[style^="background-color"]
+2whois.ru##div[style="overflow:hidden; padding-bottom:0px; height:80px;"]
+yaplakal.com,yap.ru##td[align="center"] > noindex
+! stranded-deep.ru - удаление брендированного фона, отступа сверху
+stranded-deep.ru#$#body {background:none;padding: 0px 0;}
+! http://forum.adguard.com/showthread.php?7646
+wowlol.ru##html > body > div#wrapper > div#topbox
+! http://forum.adguard.com/showthread.php?4311
+bezformata.ru##body > div[style^="clear:both;width:100%;height:90px;"]
+! http://forum.adguard.com/showthread.php?6154
+business-gazeta.ru##.left-colum > div.box > div.ctext.ctext_2
+! film.ru - удаление отступа сверху
+film.ru##body > div[style="height: 269px;"]
+! oper.ru - удаление пустоты от баннеров
+oper.ru###container > div[style="width: 100%; height: 290px; min-width: 1000px; text-align: center;"]
+! rankw.ru - удаление пустоты от баннеров
+rankw.ru###headerFrame > div[style*="width: 1170px; height: 90px;"]
+rankw.ru##section#sideBarFrame > section[style="margin:15px;height:90px;"]
+rankw.ru##section[style="margin-left:0;margin-right:0;margin-top:0;margin-bottom:10px; height: 160px;"]
+! http://forum.adguard.com/showthread.php?4360
+sysadmins.ru##table[background="/images/header.gif"] td[align="right"] a img
+||sysadmins.ru/iq-powered.png
+||sysadmins.ru/samag.gif
+! http://forum.adguard.com/showthread.php?5875
+fast-torrent.ru##.no-mobile > div > h1 > span[style="font-size: small;"]
+! http://forum.adguard.com/showthread.php?4763
+opennet.ru##form[method="get"] td[align="RIGHT"][width="470"][height="70"]
+opennet.ru##form[method="get"] td[valign="TOP"][align="RIGHT"][width="130"][bgcolor="#E9EAD6"]
+opennet.ru##form[method="get"] td[width="40"][style="background: #E9EAD6 url('/back.gif') repeat-x bottom left"]
+! http://forum.adguard.com/showthread.php?5366-*-http-vp-news-ru&p=50285&viewfull=1#post50285
+vp-news.ru##.box.nomargin
+! forum.na-svyazi.ru - empty rectangles
+forum.na-svyazi.ru##td#user2s
+! http://forum.adguard.com/showthread.php?4360
+sysadmins.ru##body > table > tbody table[width="240"][align="left"]
+sysadmins.ru##td.row2 > a > img
+! http://forum.adguard.com/showthread.php?4101
+imageban.ru###cboxOverlay
+imageban.ru###colorbox
+! yarportal.ru - empty rectangles
+yarportal.ru##div[style="font-size: 0; border: 1px solid #1b4786; background-color: #1b4786; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
+yarportal.ru##div[style="font-size: 0; border: 1px solid #67FDFB; background-color: #67FDFB; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
+yarportal.ru##div[style="font-size: 0; border: 1px solid #FFE500; background-color: #FFE500; margin: 0; padding: 0px; display: block; overflow: hidden; height: 60px;"]
+||zerx.tv/templates/zerxnew/images/utorrent.png
+! http://forum.adguard.com/showthread.php?4311
+bezformata.ru##div[style^="clear:both;width:100%;height:90px;clear:both;margin:0px;padding:0px;"]
+||tugmed.ru^$domain=bezformata.ru
+! lotr.ru - advert in right borrom
+||lotr.ru/images/logo.png
+! http://forum.adguard.com/showthread.php?3890
+fast-torrent.ru##.wrap > div > h1 > span[style="font-size: small;"]
+! http://forum.adguard.com/showthread.php?3754
+pozdrav.ru##.conteiner.purple
+moikolodets.ru##noindex > #slidebox
+! http://forum.adguard.com/showthread.php?3775
+stost.ru##.tosts
+! http://forum.adguard.com/showthread.php?2045
+||yarportal.ru/zagl.gif
+! http://forum.adguard.com/showthread.php?3384
+echo.msk.ru##div[style="padding-bottom:40px;"]
+echo.msk.ru##iframe[src="http://vz.ru/inc/b/vz_block_echomsk.html"]
+! http://forum.adguard.com/showthread.php?6049
+@@||mmgp.ru/images/shapka/logo_
+||mmgp.ru/images/shapka/
+motorpage.ru##.bannerplace
+! END: Carried over from "AdGuard Annoyances - Remains"

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -3751,3 +3751,14 @@ mail.yandex.com.tr##.mail-DirectLine
 ! END: Yandex
 !
 !
+! START: Carried over from "AdGuard Annoyances - Remains"
+chip.com.tr##.altsayfalisting.lastscroll:not(.mostreadnews):not(.hidemobile)
+transfermarkt.com.tr##div[id^="home-rectangle-"]
+log.com.tr###masthead-wrapper
+fullhdfilm.gen.tr###film-ek-tab
+aksam.com.tr###reklam_center
+emlakkulisi.com##article > div[class*="mobils"].mobilw:not([id])
+filmarenasi.org##div[id^="reklamkapat"]
+internetsorunlari.com##.adsWidgetSidebar
+turkcebilgi.com##.panel-body > .pull-left[style="width: 346px; height: 290px"]
+! END: Carried over from "AdGuard Annoyances - Remains"


### PR DESCRIPTION
(This is an unusual kind of entry PR, so I'll disregard the repo's usual issue template this time.)

During while my various excursions deep into the thousands of lists out there, I've very slowly learned that AdGuard Filters have been placing ad placeholders in AdGuard Base **and** in AdGuard Annoyances Filter, with the distiction between them being far from obvious.

Eventually I remembered to ask about in the listmaker Slack group, and was told by Alex-302 that ad placeholders are to be treated the same way as ads, and that most of https://github.com/AdguardTeam/AdguardFilters/commits/master/AnnoyancesFilter/sections/remains.txt is just an ancient deprecated relic.

However, since a cleanup of that latter file did not seem to be high up on you guys' priorities, I decided to do a partial cleanup myself, to the degree it seemed feasible to do so without having to double-check every single one of the ~350 sites individually.

Edit: It has also been pointed out that the entries in the "Remains" file are usually really, really old and pointless. This PR assumes that the entire file won't simply be declared useless and deleted in one big sweep.