### PR TITLE
Remove digits.com from tracking servers (it isn't one)

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -1054,7 +1054,6 @@
 ||digidip.net^$third-party
 ||digitaloptout.com^$third-party
 ||digitaltarget.ru^$third-party
-||digits.com^$third-party
 ||dignow.org^$third-party
 ||dimestore.com^$third-party
 ||dimml.io^$third-party


### PR DESCRIPTION
In a prior life, digits.com was a spammy counter script, which is why it was added to this list. Here's the evidence from archive.org:

http://web.archive.org/web/20100715140703/http://digits.com/
![image](https://user-images.githubusercontent.com/80599/80110314-6571bb00-8533-11ea-9052-617e42b2ae1d.png)

**This is no longer the case.** 

Since early 2018, digits.com has been owned by Digits Financial, Inc., which is building modern financial reporting and expense monitoring tools for startups and small businesses. 

As the co-founder, I can promise you we have no interest in scammy tracking servers. We are the same team that built Crashlytics, and we deeply appreciate the comments on lines 6-12 of this file, thank you @ameshkov :) 

Our mission with Digits is to help small business owners run their companies better, and in case you are looking for further validation, here's the link announcing our recent funding: https://techcrunch.com/2019/11/06/stealth-fintech-startup-digits-raises-10-5-million-series-a-from-benchmark-and-others/

We have received reports from AdGuard users that they have to turn it off in order to load our dashboard. Please accept this PR to remove us from this list. Thank you!

Jeff Seibert
Co-founder, Digits
Former Co-founder & CEO, Crashlytics
