### PR TITLE
Remove afl.rakuten.co.jp, used as a clickthrough

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -31,7 +31,6 @@
 !
 ! Rakuten.co.jp
 ||affiliate.rakuten.co.jp^$third-party
-||afl.rakuten.co.jp^
 ||ias.rakuten.co.jp^
 ||rd.rakuten.co.jp^$third-party
 ||ranking.rakuten.co.jp^


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***: `afl.rakuten.co.jp` is used a clickthrough, blocking this server causes issues
* **Current behaviour**: 

Was reported by a user: https://twitter.com/sakayu_h07ii/status/1254067699396653068

[//]: # (Please enter the correct values for your case to the table below)


**Using Adguard Japanese in Brave**

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)


Tested on 
`https://pt.afl.rakuten.co.jp/`
`https://partner.afl.rakuten.co.jp/af/a_link.cgi?cmd=shop&me_id=1262404&shop.x=29&shop.y=11`

More via `https://www.google.com/search?q=site:afl.rakuten.co.jp&filter=0&biw=2560&bih=1301`