### PR TITLE
Block social staff and tracking pixel at ad-ron.jp

### DIFF
--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -1621,6 +1621,8 @@ ganganonline.com##.gn_detail_header_sns
 m.bafrahaber.com##.sosyal-alan
 bafrahaber.com##.detay-sosyal-alan
 meduza.io##.Toolbar-root > ul.Toolbar-list > li:nth-child(-n+5)
+||ad-ron.jp/wp-content/themes/adron/images/line-share-
+ad-ron.jp###share2
 newsweekjapan.jp###likeTool
 autoturne.ru###sidebarSocial
 asahi.com###head-share

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -13,6 +13,7 @@
 !
 ! ||ensighten.com^$third-party - not a tracker
 !
+||tr.infopanel.jp^
 ||contentsquare.net^$third-party
 ||sys.refocus.ru^$third-party
 ||center.io^$third-party


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL `https://ad-ron.jp/?p=16196`

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![ad-ron](https://user-images.githubusercontent.com/58900598/80469921-35377b80-897c-11ea-85f6-51671d0f0240.png)

</details><br/>

* **Expected behaviour**: 

Social-share button and the leftover of social-bar should be blocked by Social filter, as well as tracking pixel by Tracking Protection filter.

***Steps to reproduce the problem***:

Just visit the site with according filter lists.

***System configuration***

**Filters:**

Base, Tracking, Social, Annoyances, & Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Firefox 75.0
AdGuard version:                       | 3.4.19
Filters enabled:                       | Above
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
