### PR TITLE
old.reddit.com - sign up banner

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -1,6 +1,8 @@
 !
 !######### Annoying elements (not ads)
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/55002
+old.reddit.com##.listingsignupbar
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54566
 zombie-film.club#%#//scriptlet("remove-class", "isBranding", "body")
 ! remove these rules after new app's release


### PR DESCRIPTION
#55002

***Description***: old.reddit.com useless sign up banner (can sign up anyway at the top right)
* **Current behaviour**: can't remove if combined with other filters

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![spam](https://user-images.githubusercontent.com/15199675/81182530-6bd54d80-8f9d-11ea-95e1-8bbe524f2587.png)

</details><br/>

* **Expected behaviour**: 

<details><summary>Screenshot:</summary>

![want](https://user-images.githubusercontent.com/15199675/81182661-9fb07300-8f9d-11ea-8562-6c3e83787984.png)

</details><br/>

***Steps to reproduce the problem***:

clear cookies, go to [old.reddit.com](https://old.reddit.com)

***System configuration***

**Filters:**

AdGuard Social Media, Anti-Facebook, EasyList Cookie, Fanboy’s Annoyance, Fanboy’s Social, uBlock filters – Annoyances, uBlock filters, uBlock filters – Badware risks, uBlock filters – Privacy, uBlock filters – Resource abuse, uBlock filters – Unbreak

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | linux
Operating system version (Android/iOS) | -
Browser:                               | firefox
AdGuard version:                       | ?
Filters enabled:                       | all
AdGuard mode (Android only):           | -
Filtering quality (Android only):      | -
HTTPS filtering (Android only):        | -
Simplified filters (iOS only)          | -
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | -
Helpdesk ID (if exists):               | -