### PR TITLE
fix #56282 blog.esuteru.com (and more)

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -228,6 +228,7 @@
 ||bandoo.com^$image,~image,popup
 ||banner.blogranking.net^$third-party
 ||banner.maido3.com^$third-party
+||blogroll.livedoor.net^
 ||blomoad.jp^$third-party
 ||clicktrack2.ziyu.net^$third-party
 ||colossal.jp^$third-party

--- a/JapaneseFilter/sections/general_elemhide.txt
+++ b/JapaneseFilter/sections/general_elemhide.txt
@@ -73,3 +73,4 @@
 ##.yahoo_ad
 ##a[href^="http://ad2.trafficgate.net/"]
 ##a[href^="http://www.rssad.jp/"]
+##[class^=blogroll_wrapper]

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -85,7 +85,6 @@ humoruniv.com##div[style^="width:300px;height:250px;"]
 gigaho.com##.box_drc
 gigaho.com##.amaw_box
 gigaho.com##.entry-content > span[style="display: block;"] > div[style="font-size:75%; color:#00BBDD;text-align: center;"]
-de-baystars.doorblog.jp##.blogroll_wrapper
 followcheck.itby.net##.mms.uk-margin-top
 japan.zdnet.com##.ad-bnr-rect
 forbesjapan.com##.pop2
@@ -149,8 +148,6 @@ hostlove.com###ad_fix
 hostlove.com###ad_mega
 channel-jk.com###fam_rectp
 channel-jk.com##.rss2-iframe
-channel-jk.com##.blogroll_wrapper
-channel-jk.com##.blogroll_wrapper_kizisita
 ||js.blozoo.info/js/rsstool/blogparts.js
 hosyusokuhou.jp##div.abox
 vippers.jp##a[href^="https://track.affiliate-b.com"]

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -85,6 +85,7 @@ humoruniv.com##div[style^="width:300px;height:250px;"]
 gigaho.com##.box_drc
 gigaho.com##.amaw_box
 gigaho.com##.entry-content > span[style="display: block;"] > div[style="font-size:75%; color:#00BBDD;text-align: center;"]
+de-baystars.doorblog.jp##.blogroll_wrapper
 followcheck.itby.net##.mms.uk-margin-top
 japan.zdnet.com##.ad-bnr-rect
 forbesjapan.com##.pop2

--- a/MobileFilter/sections/general_elemhide.txt
+++ b/MobileFilter/sections/general_elemhide.txt
@@ -1,6 +1,8 @@
 !
 ! Section contains list general hiding rules
 !
+! Livedoor blogroll
+##.plugin-blogroll
 !--- popular banner sizes ---
 ##img[width="320"][height="50"]
 ##iframe[width="320"][height="50"]

--- a/MobileFilter/sections/general_elemhide.txt
+++ b/MobileFilter/sections/general_elemhide.txt
@@ -2,6 +2,7 @@
 ! Section contains list general hiding rules
 !
 ! Livedoor blogroll
+###article-1_5
 ##.plugin-blogroll
 !--- popular banner sizes ---
 ##img[width="320"][height="50"]

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1,8 +1,6 @@
 !
 ! Section contains rules for specific websites
 !
-! https://github.com/AdguardTeam/AdguardFilters/issues/56282
-blog.esuteru.com,himasoku.com,jin115.com###article-list-style-none
 ! https://forum.adguard.com/index.php?threads/10464/
 ||images-*.ssl-images-amazon.com/images/*/ape/sf/MAsf-*_.js
 !

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1,6 +1,8 @@
 !
 ! Section contains rules for specific websites
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/56282
+blog.esuteru.com,himasoku.com,jin115.com###article-list-style-none
 ! https://forum.adguard.com/index.php?threads/10464/
 ||images-*.ssl-images-amazon.com/images/*/ape/sf/MAsf-*_.js
 !


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/56282

Also partly or fully fixes
https://github.com/AdguardTeam/AdguardFilters/issues/56273
https://github.com/AdguardTeam/AdguardFilters/issues/56274
https://github.com/AdguardTeam/AdguardFilters/issues/56279
https://github.com/AdguardTeam/AdguardFilters/issues/56281

Added `||blogroll.livedoor.net^` to Japanese filter and not Annoyances as the former already has many related rules (`##.blogroll-wrapper`,  `##blogroll_wrapper`, or `##.rss-blogroll` of kinds). ~~The reason `##.plugin-blogroll` is generic while `###article-list-style-none` not is because I'm sure the former is used by many unique domains while not sure about the latter.~~

Made `##[class^=blogroll_wrapper]` generic as it's used by various sites and doesn't cause false positive unlike `##.rss-blogroll`:
websites `##.blogroll_wrapper` is useful: `09ribit.blog.jp,baseballdays.officialblog.jp,btnk48.blog.jp,getgossip24.blog.jp,kaigai-nippon.com,keokeoblog.net,koisoku.ldblog.jp,llabtooflatot.blog.fc2.com,mens-fashion.blog.jp,netoraretaiken.com,nofootynolife.blog.fc2.com,samuraisoccer.doorblog.jp,scoopersokuhou.blog.fc2.com,www.manga-to-anime.net,xn--2ch-2d8eo32c60z.xyz`

websites it must be expanded to `##[class^=blogroll_wrapper]`: `baychannel.jp,keyakizaka46matomemory.net,tozanchannel.blog.jp,zapzapjp.com`