### PR TITLE
fix #56320 xn--59jtb317n5pap61gg67d.com

### DIFF
--- a/SocialFilter/sections/general_elemhide.txt
+++ b/SocialFilter/sections/general_elemhide.txt
@@ -85,6 +85,7 @@
 ##.hatena-bookmark-button
 ##.article-line
 ##.article-mixicheck
+~mixi.jp##.mixi-check-button
 ##.article-hatena
 ##.m-social > ul > li[class^="m-social--"]:not(.m-social--comment)
 ##.socials-share

--- a/SocialFilter/sections/general_url.txt
+++ b/SocialFilter/sections/general_url.txt
@@ -1,6 +1,7 @@
 !
-! Contains usorted urls
+! Contains unsorted urls
 !
+||static.mixi.jp/js/share.js$domain=~mixi.jp
 /wp-content/plugins/cool-image-share/*
 ||s3.feedly.com/img/follows/$third-party
 /wp-content/plugins/wpupper-share-buttons/*

--- a/SocialFilter/sections/general_url.txt
+++ b/SocialFilter/sections/general_url.txt
@@ -1,7 +1,7 @@
 !
 ! Contains unsorted urls
 !
-||static.mixi.jp/js/share.js$domain=~mixi.jp
+||static.mixi.jp/js/share.js$third-party
 /wp-content/plugins/cool-image-share/*
 ||s3.feedly.com/img/follows/$third-party
 /wp-content/plugins/wpupper-share-buttons/*


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/56320
Fixed a supposed typo too. An example the exclusion is needed: `http://mixi.jp/word/`