### PR TITLE
fix: blocks annoyance popup only

### DIFF
--- a/SocialFilter/sections/general_extensions.txt
+++ b/SocialFilter/sections/general_extensions.txt
@@ -53,7 +53,7 @@ freundin.de#$#.item-content__content { padding-top: 0px !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/47027
 dailywire.com#$#.SocialMediaShareButton { visibility: hidden!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44288
-simplywall.st#$#div[data-cy-id^="modal-"] { display: none!important; }
+simplywall.st#$#div[data-cy-id="modal-ModalPortal-0-"] { display: none!important; } 
 simplywall.st#$##root { filter: none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43225
 namobilu.com#$#.adsbygoogle { height: 1px !important; width: 1px !important; }

--- a/SocialFilter/sections/general_extensions.txt
+++ b/SocialFilter/sections/general_extensions.txt
@@ -53,7 +53,7 @@ freundin.de#$#.item-content__content { padding-top: 0px !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/47027
 dailywire.com#$#.SocialMediaShareButton { visibility: hidden!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44288
-simplywall.st#$#div[data-cy-id="modal-ModalPortal-0-"] { display: none!important; } 
+simplywall.st#$#div[data-cy-id="modal-ModalPortal-0-"] { display: none!important; }
 simplywall.st#$##root { filter: none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43225
 namobilu.com#$#.adsbygoogle { height: 1px !important; width: 1px !important; }


### PR DESCRIPTION

***Description***:
* **Current behaviour**: 

All popups are blocked, including news.

* **Expected behaviour**: 

Only blocks annoyance popup, but allows other normal content popups.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/5896343/83527730-14fd5e00-a4e0-11ea-8fe7-628b57f6c907.png)

</details><br/>

