### PR TITLE
fix #54041 t.myvisualiq.net

### DIFF
--- a/EnglishFilter/sections/content_blocker.txt
+++ b/EnglishFilter/sections/content_blocker.txt
@@ -992,6 +992,8 @@ topbusiness24.ru,mydomsam.ru,hubuhu.ru,moysadinfo.ru,mybusinessplus.ru,dukand.ru
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57085
 @@||lapumia.org/wp-content/*/js/adblock.js
+! https://github.com/AdguardTeam/AdguardFilters/issues/54041
+@@thalia.de/shop/*.html?pid=*&group_id=0&banner_id=
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57096
 @@||cataspboa.site/*/$script,domain=torrent-download.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/56992


### PR DESCRIPTION
#54041
On brickmerge.de affiliate links to thalia.de is blocked in Safari because of `&banner_id=` rule from the base filter.

<a href="https://www.brickmerge.de/42083-1_lego-technic-bugatti-chiron">brickmerge.de example page</a>
<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/18536328/82227568-a2617f80-9930-11ea-8857-0c0857da41a6.png">
</details>