### PR TITLE
fix #57490 ponta.abstractpainting.work ;update4

### DIFF
--- a/JapaneseFilter/sections/general_extensions.txt
+++ b/JapaneseFilter/sections/general_extensions.txt
@@ -4,6 +4,10 @@
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57490
 ponta.abstractpainting.work#%#//scriptlet('adjust-setTimeout', 'visibility', '4000')
+ponta.abstractpainting.work#%#//scriptlet('adjust-setTimeout', '[native code]', '2000')
+ponta.abstractpainting.work#%#//scriptlet('adjust-setTimeout', '[native code]', '3000')
+ponta.abstractpainting.work#%#//scriptlet('set-constant', 'FIRST_DELAY', '0')
+ponta.abstractpainting.work#%#//scriptlet('set-constant', 'NEXT_DELAY', '0')
 ! 'PopJSLock'
 mhometheater.com#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "constructor")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54943


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/57490

@Alex-302 It's another game under the same domain. Could you please take a look at `http://ponta.abstractpainting.work/sp/sp-highlow/js/game.js` to confirm my rules are okay, though they work on my end?

@krystian3w Or could you possibly test it (only if you have time, ofc)? It's geo-restricted AND the number of trials is limited, however, you can just slightly modify query parameter in the URL to bypass it.