### PR TITLE
Update #58587

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -2,7 +2,7 @@
 ! Popular on Japanese sites
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587#issuecomment-656098019
 ! Sample URL: ||js.passaro-de-fogo.biz/t/113/750/a1113750.js
-/^https?:\/\/js\.[-.0-9a-z]+\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{7}\.js$/$script
+/^https?:\/\/js\.[-.0-9a-z]+\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{7}\.js$/$script,third-party
 !
 ! Cloudflare
 /\/(public|resources|static|assets)\/([a-f0-9]){28,31}$/$script,xhr,~third-party

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -28,7 +28,7 @@
 ||nta1vb6cdlrl.com^$third-party
 ||js.rush-member.com^$third-party
 ||js.passaro-de-fogo.biz^$third-party
-||js.mediams.mb.softbank.jp^$third-party
+||mediams.mb.softbank.jp^$third-party
 ||js.monetize-ssp.com^$third-party
 ||minkatu.com^$third-party
 ||udkcrj.com^$third-party


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/58587

Almost nothing, just found the tracking scripts are always third-party so thought adding `$third-party` will slightly increase performance. Also I found `||bidder.mediams.mb.softbank.jp^` in EasyPrivacy which I actually see at `https://rtrp.jp` and with Publicwww this: `http://104614.mediams.mb.softbank.jp/t/017/079/a1017079.js` too though not sure where it's used,  so made `js.mediams.mb.softbank.jp` more generic.