### PR TITLE
Went through most of the German entries in "Annoyances - Remains"

### DIFF
--- a/AnnoyancesFilter/sections/remains.txt
+++ b/AnnoyancesFilter/sections/remains.txt
@@ -25,7 +25,6 @@ vividscreen.info##.page > .buddies
 vanar.io##.frame-data
 slain.io##.slain-adslot
 t-online.de##.Tvideosearch ~ #Tcontbox > #Tcontboxi > div[class]:not([id]):not([onfocus]):not(.Tinfinitlayer)
-t-online.de##div[data-dy-embedded-object]
 vivud.com##.closeContainer
 videam.party##.ads
 fmovies.is###movie > .widget > .widget > div[style*="height:166px;overflow:hidden"]
@@ -44,13 +43,10 @@ bigtitsxxxsex.com##.bnrba
 eurogamer.de##.mobile-mpu-wrapper
 t-online.de###T-Shopping
 memurlar.net##.NewsDetail > div[style*="width:580px; height:430px"]
-rtlnext.rtl.de##.rtli-master-morecontent__items > div.rtli-master-morecontent__teaser
-rtlnext.rtl.de#$#.rtli-master-section {margin-top: 0!important; }
 latimes.com##ark-ad-right
 latimes.com##ark-top-ad
 semprot.com##.semprotnenenmontok_adalah_pujaan_hatiku > div[style]:not([id]):not([class])
 semprot.com###semprotnenenmontok_f
-autobild.de###pagewrapper > #spacerElem
 aeroport-de-tunis-carthage.com##ins[id^="aswift_"]
 ashemaletube.com#$##site-wrapper {padding-top: 0!important; }
 ashemaletube.com#$##site {min-width: calc(100%)!important; max-width: calc(100%)!important;}
@@ -73,7 +69,6 @@ bursa.com##.bg--gri[style="padding: 10px 0;"]
 m.pornxs.com###im_scroll_close_button
 m.smutty.com##.ui-content .center[style*="margin-"]:not([id])
 m.empflix.com##.bannerBlock
-t-online.de##div[data-dy^="Partner:"]:not([data-dy^="Partner:Telekom"])
 emlakkulisi.com##article > div[class*="mobils"].mobilw:not([id])
 teknolojioku.com##.row > div.justify-content-center.d-flex.align-items-center[style*="px"]:not([id])
 m.posta.com.tr##div[ng-app="appFotoGallery"] > div[ng-controller="demo"] > .row > div[style="text-align:center;height:100px;"]
@@ -109,11 +104,8 @@ fragman-tv.com##.sol_blok > .dizi_video > .dizi_video
 tempr.email###Menu > #MenuInbox:not([class])
 waz.de#%#AG_onLoad(function() { setTimeout(function() {var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();}; var elements = document.getElementsByClassName('swiper-ad');for(var i = 0 ; i < elements.length; i++){elements[i].remove();};}, 300); });
 krone.at##.row > .c_retresco-story-tags + .box.c_label
-20min.ch##div[data-ana-click*="werbemittel"]
-20min.ch##iframe[src*="cloudfront.net/anprebid/"]
 derwesten.de##.ad
 youjizz.com###onPausePrOverlay
-az-online.de##div[data-id-advertdfpconf]
 streamcherry.com###videooverlay
 ndtv.com###ad100
 ndtv.com##div[id^="div-gpt-ad-"]
@@ -135,14 +127,6 @@ sport-news-streams.info###video-container > div[id^="over-"]
 streamsfinder.com###bannerInCenter
 streamsfinder.com###hiddenBannerCanvas
 hollaforums.com###sidebar .sidebar-rc
-5min.at##div[class^="frontpage_ad_"]
-5min.at###google_ad_footer
-5min.at##.anzeige_footer
-l-iz.de##.liz-banner-content
-l-iz.de##.sidebar_list > #text-10
-l-iz.de##.sidebar_list > #text-2
-l-iz.de##.sidebar_list > #text-11
-l-iz.de##.sidebar_list > #text-64
 fbstreams.me##.container-fluid div[style="min-width:300px;max-with:600px;height:347px;right:50px;"]
 123movieshub.to##.main-content > .content-kusss
 btconity.com##.holder-main > #bottom_banner
@@ -158,7 +142,6 @@ flashgames.ru##.game-page-sidebar
 edirneaktuel.com##table[width="632"] > tbody > tr > td[height="40"]:empty
 radarbox24.com##.remove-pub
 link.tl##.fly_head_bottom
-m.sz-online.de##[id^="ctl00_m_ctrlMainContentPlaceHolder_ctl00_"][id$="_m_ctrlEditContainer"] > .szoHtmlModuleContent
 extramovies.tv##.theiaStickySidebar > div[id^="ai_widget"]
 animev.net###siteContent > div.cAlign > div#sidebarGeral
 distrowatch.com##td[style="width: 19%; vertical-align: top; border: none"] > table[class="News"]+br+table[width="100%"]
@@ -175,7 +158,6 @@ gooool.org##.socialb+div.block_d
 newsoboz.org##.widget_center > div.articl ~ br
 russian7.ru##aside#sidebar
 fullhdfilm.gen.tr###film-ek-tab
-gamestar.de##.pv-teaser-pricecompare + .elemCont
 cont.ws##body > div.header2
 moscow.regnews.info##a.sidebar-toggle+div.sidebar-content > div[class="widget widget_text"]
 rksports.info##.col-lg-4 > div > div[class$="panel-heading"]
@@ -185,22 +167,17 @@ willhaben.at###adition_ContentAd
 hdfilmkanali.org###alt
 marktplaats.nl###bottom-listings-divider
 ilf.at.ua###carousel-container
-studieren.de###colContents > div#colService
 top100arena.com###container3 > div[style="padding:20px; position:relative"] > div[style="overflow:auto"] > div[style="float:right; text-align:center"]
 bilgiustam.com###content_box > div[style$="min-height:100px; clear:both; width:100%;"]
 download3k.com###dl_main_container_content > div[class="space"][style]
 cwer.me,cwer.ru###footer
-wiesentbote.de###footer-widgets
 programmersforum.ru###header_right_cell strong
 diziizlep.com###kendisi > div[style="min-height:23px;border: 1px solid #294887; background: #3b5998;text-align:center;padding:10px; margin-bottom:10px; color: #fff; font-size: 14px;"]
 cafefernando.com###l_sidebarwidgeted > #text-20
 wowjp.net###main-container-inner > div#slideshow
 imageweb.ws###mainc > div[style^="height:"][style*="position: absolute;"]
-n-tv.de###ntv_ligatus_680
-gelbeseiten.de###offgrid_iframe
 torrenthound.com###pcontent > #direct2
 sportlive.me###player > div > div[style$="text-align: center;"]
-stimme.de###plista_widget_underArticle
 diakov.net###rbar > div.blocklite.blc2:last-child
 diakov.net###rbar > div.blocklite.blc2[align="center"]
 aksam.com.tr###reklam_center
@@ -208,14 +185,12 @@ sadeempc.com###secondary > aside#text-15
 diakov.net###sidebar > div.blocklite:last-child
 mobafire.com###sidebar-free-champs + div.box-shadow.mb10
 beycan.net###site > #menu + .left
-chinamobilemag.de###sp-user3
 xhamster.com###swectrqw
 softpedia.com###swipebox-top
 gamegpu.com###tm-top-a
 webrazzi.com###topheadMaindiv
 willhaben.at###tower
 kayzen.az##.CustomBlock.Blocksmaster
-winfuture-forum.de##.ExtraPostBlock > div[class$="post_block hentry clear"]
 ||softportal.com/img/adg_rnb.png
 t-online.de##.Tmcc1.Tmcc1a.Tmccm
 acunn.com##.acunn-push
@@ -226,11 +201,8 @@ gecid.com##.alogo > td.lcenter > div.band
 loading.az##.banlog
 hi-fi.ru##.banner
 vedtver.ru##.banner > a[rel="nofollow"] > img
-simtimes.de##.banner-end-news
 hi-fi.ru##.banner-first
 teknomobil.org##.banner_box
-extra-radio.de##.bc_right div.box_right:last-child
-nordbayerischer-kurier.de##.billboard
 movies.ndtv.com##.cnAdzerkDiv
 l2topzone.com##.col-md-6 > .panel
 zoon.ru##.contents > div.box-padding
@@ -254,8 +226,6 @@ sports.ru##.news-item__footer > h3
 sansursuzhaber.com##.news_detail > .side_detail
 hidden247.com##.oglSve
 turkcebilgi.com##.panel-body > .pull-left[style="width: 346px; height: 290px"]
-lvz.de##.pda-addart
-volksstimme.de##.ph-ah-ad-icon
 irecommend.ru##.product-half-teaser > div.text > div#bigright
 relink.to##.right > div[class$="paddingTBhighlight"] > center
 hronika.info##.row-600 > div[class^="col-"]
@@ -275,14 +245,10 @@ tureng.com##.tureng-ad-horizontal-responsive
 tureng.com##.tureng-index.hidden-print > div[style$="min-height: 130px;"]
 thedaretelly.com##.video_dtls_sec > span
 ign.com##.video_supplement > div#queen
-deutschland-in-zahlen.de##.werbung_oben
-deutschland-in-zahlen.de##.werbung_oben + div[style="position:absolute;top:15px;left:2px"]
-windowsarea.de##.widgetized.w-3 > aside.clearfix.widget_text
 efirde.az##a[href="http://just.az"]
 lyngsat.com##a[href="http://www.lyngsat.com/advert.html"]
 ~smi2.net##a[href^="http://smi2.net/"]
 nzz.ch##aside[class$="resor resor--billboard"]
-tagesspiegel.de##aside[id^="plista_widget_"]
 xtreme.ws##aside[role="complementary"] > div.newss
 m.comic.naver.com##body > div.viewer.cuttoon > div[class^=ly_dim].on
 comparegames.com.au$$span[tag-content="Advert"]
@@ -294,25 +260,21 @@ m.comic.naver.com##div[class="ly_wrap viewer_da_ly"]
 olke.az##div[class="mom_visibility_desktop center"][style="padding-left: 4px"]
 gottabemobile.com##div[class^="code-block code-block-"][style]:not([class$="code-block code-block-16 ai-desktop-tablet"])
 maclarizle.com##div[class^="sidebar-"] > div[id^="text-"]
-helpster.de##div[data-engagement*="click-advertisement"]
 porndoe.com##div[data-subscript="Advertising"]
 porndoe.com##div[data-supscript="Advertising"]
 uppit.com##div[id="336"]
 filescloud.co##div[id="box-left"][style]
 zonasports.be##div[id^="MarketGid"]
-vwcorrado.de##div[id^="edit"] > div.vbmenu_popup + table[style="margin-top:6px;"]
 cyberforum.ru##div[id^="edit"][style="padding:0px 0px 3px 0px"] > table ~ div[style^="background-color"]
 x.epidemz.co,x.epidemz.com##div[id^="smile_teaser"]
 rivx8.me.la##div[itemprop*="articleBody"] > span
 zonasports.ch,zonasports.be##div[style$="position:relative"] > center > table
 zonasports.be##div[style$="position:relative"] > table > tbody > tr > td
-deutschland-in-zahlen.de##div[style*="font-size:10px;margin-top:1px"]
 thefreedictionary.com##div[style="border:1px solid #e8e8e9;font-weight:600"]
 audiotube.org##div[style="color:black;background-color:white;line-height: 11px;"] + hr
 torrentdownloads.me##div[style="float:left"] > a[rel="nofollow"] + br + br + font[style="color: grey"]
 webaslan.com##div[style="float:right; margin-right:4px; width:300px;"] div[style="min-height: 255px;"]
 gurubanks.com##div[style="margin-top: 10px; margin-bottom: 20px; border: 1px solid #b6e2e2; padding: 10px 5px;"]
-transfermarkt.de##div[style="margin-top:20px;"] > div.fl
 2whois.ru##div[style="overflow:hidden; padding-bottom:0px; height:80px;"]
 softpedia.com##div[style^="font-size:13px; margin: 0 0 5px 0; color: #002873;"]
 movies.ndtv.com#$##footer-ads { height: 0!important; }
@@ -345,9 +307,6 @@ nadavi.com.ua##body > div > div[style="width: 100%; height: 80px;"][class]
 nadavi.com.ua##div[style="width: 100%; height: 90px;"]
 ! http://forum.adguard.com/showthread.php?4311
 bezformata.ru##body > div[style^="clear:both;width:100%;height:90px;"]
-! http://forum.adguard.com/showthread.php?5604
-max.de##div[style$="padding: 15px; height: 90px;"]
-max.de##div[style$="padding:15px; height:90px; "]
 !
 !######### Remains of counters ###############
 !

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2123,3 +2123,21 @@ ruhr24.de,wetterauer-zeitung.de,giessener-allgemeine.de,fr.de,wlz-online.de,da-i
 wallstreet-online.de##body > #siteteaser
 wallstreet-online.de##.newsFlagSlider
 wallstreet-online.de###mooTickerContainer
+! https://github.com/AdguardTeam/AdguardFilters/pull/6023*
+l-iz.de##.liz-banner-content
+l-iz.de##.sidebar_list > #text-10
+l-iz.de##.sidebar_list > #text-2
+l-iz.de##.sidebar_list > #text-11
+l-iz.de##.sidebar_list > #text-64
+5min.at##.anzeige_footer
+5min.at###google_ad_footer
+5min.at##div[class^="frontpage_ad_"]
+az-online.de##div[data-id-advertdfpconf]
+winfuture-forum.de##.ExtraPostBlock > div[class$="post_block hentry clear"]
+extra-radio.de##.bc_right div.box_right:last-child
+volksstimme.de##.ph-ah-ad-icon
+deutschland-in-zahlen.de##.werbung_oben
+deutschland-in-zahlen.de##.werbung_oben + div[style="position:absolute;top:15px;left:2px"]
+deutschland-in-zahlen.de##div[style*="font-size:10px;margin-top:1px"]
+vwcorrado.de##div[id^="edit"] > div.vbmenu_popup + table[style="margin-top:6px;"]
+transfermarkt.de##div[style="margin-top:20px;"] > div.fl

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2141,3 +2141,9 @@ deutschland-in-zahlen.de##.werbung_oben + div[style="position:absolute;top:15px;
 deutschland-in-zahlen.de##div[style*="font-size:10px;margin-top:1px"]
 vwcorrado.de##div[id^="edit"] > div.vbmenu_popup + table[style="margin-top:6px;"]
 transfermarkt.de##div[style="margin-top:20px;"] > div.fl
+autobild.de##.rectangle
+autobild.de##.partnerlabel
+||img.derwesten.de/img/incoming/*-315x80.jpg^
+||img.derwesten.de/img/*-140x53.jpg^
+||img.derwesten.de/img/incoming/*-315x80-$image
+tagesspiegel.de###urban-teaser1

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2123,7 +2123,6 @@ ruhr24.de,wetterauer-zeitung.de,giessener-allgemeine.de,fr.de,wlz-online.de,da-i
 wallstreet-online.de##body > #siteteaser
 wallstreet-online.de##.newsFlagSlider
 wallstreet-online.de###mooTickerContainer
-! https://github.com/AdguardTeam/AdguardFilters/pull/60233
 l-iz.de##.liz-banner-content
 l-iz.de##.sidebar_list > #text-10
 l-iz.de##.sidebar_list > #text-2

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -2123,7 +2123,7 @@ ruhr24.de,wetterauer-zeitung.de,giessener-allgemeine.de,fr.de,wlz-online.de,da-i
 wallstreet-online.de##body > #siteteaser
 wallstreet-online.de##.newsFlagSlider
 wallstreet-online.de###mooTickerContainer
-! https://github.com/AdguardTeam/AdguardFilters/pull/6023*
+! https://github.com/AdguardTeam/AdguardFilters/pull/60233
 l-iz.de##.liz-banner-content
 l-iz.de##.sidebar_list > #text-10
 l-iz.de##.sidebar_list > #text-2


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

I personally understand it as such that the "Remains" category in AdGuard Annoyances isn't really supposed to exist anymore, because such entries are nowadays meant be part of the regular anti-ad lists.

This time around I've actually browsed through the sites in question, one at a time, to see which entries I could reproduce (and move over to AdGuard German Filter), and which entries I couldn't reproduce (and thus were removed entirely).

I also stumbled across 6 new entries to add:
```
! https://www.autobild.de/artikel/audi-rs-4-vs.-rs-6-beschleunigung-0-100-v8-17086377.html
autobild.de##.rectangle
autobild.de##.partnerlabel
! https://www.derwesten.de/
||img.derwesten.de/img/incoming/*-315x80.jpg^
||img.derwesten.de/img/*-140x53.jpg^
||img.derwesten.de/img/incoming/*-315x80-$image
! https://www.tagesspiegel.de/
tagesspiegel.de###urban-teaser1
```

I suppose it deserves note that I had managed to forget that AdGuard had a German list, thus I only had EasyList Germany turned on during the testing... 😅 

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)

* **Expected behaviour**: 

The entries in the "Remains" category are gradually re-reviewed and processed, until eventually all entries have been re-assigned and the "Remains" category can be deleted.

***Steps to reproduce the problem***:

N/A

***System configuration***

**Filters:**

![image](https://user-images.githubusercontent.com/22780683/88525253-a5e14900-cffa-11ea-9c00-c4a6d8112bd9.png)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Operating system version (Android/iOS) | May 2020 Update
Browser:                               | Chrome x64
AdGuard version:                       | Nano Adblocker 1.0.0.152 + Nano Defender 15.0.0.201
Filters enabled:                       | See screenshot above
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | N/A
HTTPS filtering (Android only):        | On
Simplified filters (iOS only)          | Off
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
