### PR TITLE
fix #61074 stack.com

### DIFF
--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -234,6 +234,8 @@ copypastecharacter.com#$##contents { visibility: visible!important; }
 @@||storage.googleapis.com/loadermain.appspot.com/main.js$domain=watchfreenet.org
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60511
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=nuke.zone
+! https://github.com/AdguardTeam/AdguardFilters/issues/61074
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=stack.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60457
 danishfamilysearch.com#@#iframe[width="300"][height="250"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/59975


### PR DESCRIPTION
#61074

There are A LOT of rules whitelisting 
`@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=DOMAIN_NAME`
shouldn't we group it somewhere?