### PR TITLE
fix #61419 kodomonokagaku.com

### DIFF
--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -24,6 +24,8 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 !#################
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/61419
+@@||kodomonokagaku.com/images/bnr/$image,domain=kodomonokagaku.com
 ! wylecz.to - incorrect blocking with generic rule
 wylecz.to#@#.adi
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60692

--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -25,7 +25,7 @@ ut-1.alexbranding.com,unitheme.net#@#[class^="adv-"]
 !
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61419
-@@||kodomonokagaku.com/images/bnr/$image,domain=kodomonokagaku.com
+@@||kodomonokagaku.com/images/bnr/$image,~third-party
 ! wylecz.to - incorrect blocking with generic rule
 wylecz.to#@#.adi
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60692


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/61419

Although Japanese site, caused by Russina filter's rule `/images/bnr/`.