### PR TITLE
Fix #61255 detail.chiebukuro.yahoo.co.jp

### DIFF
--- a/JapaneseFilter/sections/whitelist.txt
+++ b/JapaneseFilter/sections/whitelist.txt
@@ -1,6 +1,8 @@
 !
 ! White list. Fixing filtration errors(false-positive)
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/61255
+@@||s.yimg.jp/images/listing/tool/yads/yads-timeline-ex.$script,domain=chiebukuro.yahoo.co.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58153
 @@||lacoste.com/on/demandware.static/*/js/dist-refit/framework/base/popin.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58022


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/61255

Although I can't reproduce, two user independently confirmed that the fix works.

[Update] Somehow I mistook it as a JP filter issue but actually Easylist one. Already made PR in EL so please ignore this if they fixed the issue earlier. However, IF they're slow it's worth being temporary added as the site is popular in Japan (even then better to be added to Base).