### PR TITLE
Block piwik on vivaldi.net too

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -272,7 +272,7 @@ dokonline.com###Counters + div[class="block"]
 ||ladesk.com/scripts/track.js
 ||s.kk-resources.com/ks.js
 ||s.kelkoogroup.net/st?
-||vivaldi.com/rep/rep.js
+||vivaldi.*/rep/rep.js
 ||app.call-tracking.by/scripts/calltracking.js
 ||techstage.de/ivw-bin/ivw/CP^
 ||app.compendium.com/js/stats_bundle.js


### PR DESCRIPTION
The same piwik script is also on `https://vivaldi.net/`.

![vivaldi-net](https://user-images.githubusercontent.com/58900598/90775846-4db91080-e334-11ea-9565-80ac958bf288.png)
