### PR TITLE
fix #61814 getintopc.com

### DIFF
--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -848,6 +848,10 @@ agxapks.com#%#//scriptlet("abort-on-property-read", "gothamBatAdblock")
 agxapks.com#$#.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55701
 th-jav.co#@#.afs_ads
+!https://github.com/AdguardTeam/AdguardFilters/issues/61814
+getintopc.com#%#//scriptlet("set-constant", "qckyta", "false")
+||getintopc.com/wp-content/cache/autoptimize/js/autoptimize_*.js
+getintopc.com#@#.adsbygoogle
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55676
 @@||awempt.com/embed/$script,domain=sexcamfreeporn.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55552

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -848,10 +848,6 @@ agxapks.com#%#//scriptlet("abort-on-property-read", "gothamBatAdblock")
 agxapks.com#$#.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55701
 th-jav.co#@#.afs_ads
-!https://github.com/AdguardTeam/AdguardFilters/issues/61814
-getintopc.com#%#//scriptlet("set-constant", "qckyta", "false")
-||getintopc.com/wp-content/cache/autoptimize/js/autoptimize_*.js
-getintopc.com#@#.adsbygoogle
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55676
 @@||awempt.com/embed/$script,domain=sexcamfreeporn.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55552
@@ -4138,7 +4134,9 @@ mega-debrid.eu#%#window.Advertisement = 1;
 file-upload.com$$script[tag-content="getElementById(""adblockinfo"")"][max-length="300"]
 file-upload.com#%#AG_abortInlineScript(/getElementById\("adblockinfo"\)/, 'document.getElementById');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58160
-tutorials-technology.info,unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#%#//scriptlet("abort-current-inline-script", "jQuery", "ai_get_cookie")
+! https://github.com/AdguardTeam/AdguardFilters/issues/61814
+tutorials-technology.info,unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#%#//scriptlet("abort-current-inline-script", "jQuery", "ai_")
+tutorials-technology.info,unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#@%#//scriptlet("abort-current-inline-script", "jQuery", "ai_get_cookie")
 !unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#%#//scriptlet("abort-on-property-write", "ai_front")
 !@@|http$script,domain=unique-tutorials.info|getintopc.com|solvetube.site|tech-platform.info
 !||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$important,domain=unique-tutorials.info|getintopc.com|solvetube.site|tech-platform.info

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -4136,7 +4136,6 @@ file-upload.com#%#AG_abortInlineScript(/getElementById\("adblockinfo"\)/, 'docum
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58160
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61814
 tutorials-technology.info,unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#%#//scriptlet("abort-current-inline-script", "jQuery", "ai_")
-tutorials-technology.info,unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#@%#//scriptlet("abort-current-inline-script", "jQuery", "ai_get_cookie")
 !unique-tutorials.info,getintopc.com,solvetube.site,tech-platform.info#%#//scriptlet("abort-on-property-write", "ai_front")
 !@@|http$script,domain=unique-tutorials.info|getintopc.com|solvetube.site|tech-platform.info
 !||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$important,domain=unique-tutorials.info|getintopc.com|solvetube.site|tech-platform.info


### PR DESCRIPTION
#61814

Правила не хотят работать на мобилке и сафари, хотя, например, на десктопе достаточно 
`getintopc.com#%#//scriptlet("set-constant", "qckyta", "false")`
либо
```
||getintopc.com/wp-content/cache/autoptimize/js/autoptimize_*.js
getintopc.com#@#.adsbygoogle
```

На целевую ссылку нужно заходить с главной страницы сайта, иначе сохраняется data.