### PR TITLE
Update placeholder rules for itest.5ch.net

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -256,6 +256,12 @@ winfuture.mobi##iframe[src^="//j.wfcdn.de/j/iframes/outbrain_"]
 9to5google-com.cdn.ampproject.org,9to5mac-com.cdn.ampproject.org##.ad-disclaimer-container
 setfilmizle.vip##.menu_alti_reklam_mobil
 m.imdb.com##.cornerstone_slot
+itest.5ch.net###instant_ad
+itest.5ch.net###js-bottom-ad-300x250
+itest.5ch.net###js-bottom-ad-320x250
+itest.5ch.net###js-cardview_ad
+itest.5ch.net##.js-cardview_ad-320x180 > iframe
+itest.5ch.net##.js-cardview_ad-320x50
 itest.5ch.net##.js-overlay_ad
 itest.5ch.net##.ad_320x50
 itest.5ch.net##div[class^="sproutad_"]


### PR DESCRIPTION
Placeholders, some are only seen when you searched something.

<details>

![5ch-1](https://user-images.githubusercontent.com/58900598/91311719-5e62fe00-e7ee-11ea-8db9-3fc8d71d0a01.png)

![5ch-2](https://user-images.githubusercontent.com/58900598/91311724-5efb9480-e7ee-11ea-9f5a-8431bb223c4e.png)

![5ch-3](https://user-images.githubusercontent.com/58900598/91311726-602cc180-e7ee-11ea-82fb-7214e0114d3f.png)

![5ch-4](https://user-images.githubusercontent.com/58900598/91311729-60c55800-e7ee-11ea-8341-f3c40e716f50.png)

![5ch-5](https://user-images.githubusercontent.com/58900598/91311735-628f1b80-e7ee-11ea-9d8d-c16c4a7e2ebb.png)

![5ch-6](https://user-images.githubusercontent.com/58900598/91311751-6753cf80-e7ee-11ea-8948-1b866a396dbe.png)

</details>

Hiding `##.js-cardview_ad-320x180` causes a layout problem, so limited to its child iframe. Given such a problem, I prefer not to consolidate them to fewer rules using `^=` or `*=`.