### PR TITLE
Expand *-siken.com anti-adb rules

### DIFF
--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -36,12 +36,12 @@ ad-contents.jp#$#.mid-rectangle { display: none !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51663
 @@||popjav.tv^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51076
-fe-siken.com,sc-siken.com#%#//scriptlet("prevent-setTimeout", "/(ad|_0x1ca67c)/")
+ap-siken.com,db-siken.com,fe-siken.com,itpassportsiken.com,nw-siken.com,pm-siken.com,sc-siken.com,sg-siken.com#%#//scriptlet("prevent-setTimeout", "/(ad|_0x)/")
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
-fe-siken.com,sc-siken.com#@#.adsbygoogle
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=fe-siken.com|sc-siken.com
-@@||googletagservices.com/tag/js/gpt.js$domain=fe-siken.com|sc-siken.com
-@@||securepubads.g.doubleclick.net/gpt/pubads_impl_*.js$domain=fe-siken.com|sc-siken.com
+ap-siken.com,db-siken.com,fe-siken.com,itpassportsiken.com,nw-siken.com,pm-siken.com,sc-siken.com,sg-siken.com#@#.adsbygoogle
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=ap-siken.com|db-siken.com|fe-siken.com|itpassportsiken.com|nw-siken.com|pm-siken.com|sc-siken.com|sg-siken.com
+@@||googletagservices.com/tag/js/gpt.js$domain=ap-siken.com|db-siken.com|fe-siken.com|itpassportsiken.com|nw-siken.com|pm-siken.com|sc-siken.com|sg-siken.com
+@@||securepubads.g.doubleclick.net/gpt/pubads_impl_*.js$domain=ap-siken.com|db-siken.com|fe-siken.com|itpassportsiken.com|nw-siken.com|pm-siken.com|sc-siken.com|sg-siken.com
 !#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50977
 server-setting.info#@#.adsbygoogle


### PR DESCRIPTION
These are all the same. Didn't add specific cosmetic filters but you can add
`ap-siken.com,db-siken.com,fe-siken.com,itpassportsiken.com,nw-siken.com,pm-siken.com,sc-siken.com,sg-siken.com##.ads300, .ads_bottom`
For desktop environment supporting scriptlet (haven't tested on mobile).