### PR TITLE
Update #58587 (fix uwl.weblio.jp layout)

### DIFF
--- a/JapaneseFilter/sections/general_extensions.txt
+++ b/JapaneseFilter/sections/general_extensions.txt
@@ -42,8 +42,8 @@ sp.jp.wazap.com#$#body[style="position: fixed;"] { position: static !important }
 tv-asahi.co.jp#$##common-header > div[class^="common-header-pc-"] { padding-top: 0 !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587
 uwl.weblio.jp#$##side { display: none !important; }
-uwl.weblio.jp#$##main { width:auto !important; padding-left:15px !important }
-uwl.weblio.jp#$#.tngMainT { width:100% !important }
+uwl.weblio.jp#$##main { width:auto !important; padding-left:15px !important; }
+uwl.weblio.jp#$#.tngMainT { width:100% !important; }
 buhidoh.net#$##center-left { height: auto !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58172
 punyu.com#$#.tblmain[width="900"] { height: auto !important; }

--- a/JapaneseFilter/sections/general_extensions.txt
+++ b/JapaneseFilter/sections/general_extensions.txt
@@ -42,7 +42,8 @@ sp.jp.wazap.com#$#body[style="position: fixed;"] { position: static !important }
 tv-asahi.co.jp#$##common-header > div[class^="common-header-pc-"] { padding-top: 0 !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587
 uwl.weblio.jp#$##side { display: none !important; }
-uwl.weblio.jp#$##main { width: 1325px !important; padding-left: 15px !important; }
+uwl.weblio.jp#$##main { width:auto !important; padding-left:15px !important }
+uwl.weblio.jp#$#.tngMainT { width:100% !important }
 buhidoh.net#$##center-left { height: auto !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58172
 punyu.com#$#.tblmain[width="900"] { height: auto !important; }


### PR DESCRIPTION
It turned out the rule I suggested in the issue now breaks layout of `https://uwl.weblio.jp/vocab-index;`. This commit fixes it.

<details>

![weblio](https://user-images.githubusercontent.com/58900598/93598836-40a54500-f9f8-11ea-88fd-c3077674b4e2.png)

</details>