### PR TITLE
fix javix.net popunder [NSFW]

### DIFF
--- a/JapaneseFilter/sections/general_extensions.txt
+++ b/JapaneseFilter/sections/general_extensions.txt
@@ -2,6 +2,8 @@
 !-------JS----------
 !-------------------
 !
+! javix.net popunder
+javix.net#%#//scriptlet('abort-current-inline-script', 'document.querySelectorAll', 'popMagic')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57825
 sexpixbox.com#%#//scriptlet('prevent-setTimeout', 'affId', '2000')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57490


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL: `https://javix.net/`
Issue: popunder on clicking any video

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![javix](https://user-images.githubusercontent.com/58900598/94434366-a5b92180-01d4-11eb-8726-c60efb4b9cb9.png)

</details><br/>

* **Expected behaviour**: 

No popunder

<details><summary>Screenshot:</summary>

![javix2](https://user-images.githubusercontent.com/58900598/94434463-c71a0d80-01d4-11eb-8ba0-f90506ee6002.png)

</details><br/>

***Steps to reproduce the problem***:

Visit the page and click on any articles or images.

***System configuration***

**Filters:**

Base, TPL, and Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Brave 1.14.84
AdGuard version:                       | 3.5.12
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
