### PR TITLE
Ran "Redundant Rule Checker" on AdGuard Base

### DIFF
--- a/EnglishFilter/sections/adservers.txt
+++ b/EnglishFilter/sections/adservers.txt
@@ -2975,6 +2975,7 @@ www.llllllllllll.net^$third-party
 @@||amgload.net/z|$domain=sinoptik.ua|gismeteo.ua
 !
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
+||analyticsq.com^
 ||tsastrmq.com^
 ||d71e6dd31a026d45.com$popup
 ||xdbwc.com^

--- a/EnglishFilter/sections/adservers.txt
+++ b/EnglishFilter/sections/adservers.txt
@@ -954,7 +954,6 @@
 ||thevpntrustzone.xyz^$third-party
 ||graivaik.com^
 ||fethungi.com^
-||pegloang.com^
 ||lcwfab2.com^$third-party
 ||superonclick.com^
 ||serconmp.com^$third-party
@@ -1128,7 +1127,6 @@
 ||zugnogne.com^
 ||phaihoaw.net^
 ||advsmedia.com^$third-party
-||bms.adjarabet.com^$third-party
 ||greetham.net^
 ||pushmono.com^
 ||salaure.pro^$third-party
@@ -1266,7 +1264,6 @@
 ||soagitet.net^$third-party
 ||togroltu.net^$third-party
 ||oupushee.com^$third-party
-||voastauz.net^$third-party
 ||pheergar.com^$third-party
 ||mybestdc.com^
 ||arkinhechershedt.info^
@@ -1279,10 +1276,8 @@
 ||getmyfreetraffic.com^
 ||pectors.info^$third-party
 ||afletedly.info^$third-party
-||waubasou.com^$third-party
 ||xcouj.com^$third-party
 ||yxtwx.cn^$third-party
-||xcouj.com^$third-party
 ||stoomeddert.info^$third-party
 ||pandanetwork.tk^$third-party
 ||pandanetwork.club^$third-party
@@ -1290,7 +1285,6 @@
 ||qiralei.xyz^
 ||tonsterandhantan.info^$third-party
 ||newsupdatedepot.info^$third-party
-||givirsou.net^$third-party
 ||pseelrou.net^$third-party
 ||denetsuk.com^$third-party
 ||jsfuz.com^$third-party
@@ -1442,11 +1436,9 @@
 ||uytestion.info^
 ||cultidifficient.info^
 ||mechangesee.club^
-||bestadbid.com^$third-party
 ||traffic.club^$third-party
 ||trafficclub-nde.netdna-ssl.com^$third-party
 ||lovacmar.click^$third-party
-||niltutch.com^$third-party
 ||gersairg.net^$third-party
 ||unknownads.com^$third-party
 ||adblox.net^$third-party
@@ -1567,7 +1559,6 @@
 ||bps.sysact.cn^$third-party
 ||ms.awqsaged.cn^$third-party
 ||778771.com^$third-party
-||show.g.mediav.com^$third-party
 ||fzxrjx.com^$third-party
 ||wsxxu.com^$third-party
 ||tabwl.com^$third-party
@@ -1591,7 +1582,6 @@
 ||e.qxfly.com^$third-party
 ||nvrentao8.com^$third-party
 ||js.69lm.com.cn^$third-party
-||dd.70yst.com^$third-party
 ||kuhou.com^$third-party
 ||youle55.com^$third-party
 ||dm.jinshasi.cn^$third-party
@@ -1701,7 +1691,6 @@ www.llllllllllll.net^$third-party
 ||ryllae.com^$third-party
 ||blastnotificationx.com^
 ||ynopkisq.com^$third-party
-||bodelen.com^$third-party
 ||graucoay.net^$third-party
 ||kaishist.top^$third-party
 ||ipreparty.info^$third-party
@@ -2061,7 +2050,6 @@ www.llllllllllll.net^$third-party
 ||niajmtjqexq.co^$third-party
 ||adkernel.com^$third-party
 ||dopor.info^$third-party
-||kurkizraka.com^$third-party
 ||yaranitsa.info^$third-party
 ||ovustav.ru^$third-party
 ||plutusads.com^$third-party
@@ -2277,7 +2265,6 @@ www.llllllllllll.net^$third-party
 ||aspgfx.org^$third-party
 ||leadzutw.com^$third-party
 ||uzekrs.com^
-||bfe4e6d364be199.com^$third-party
 ||kwunqjqntrnf.bid^$third-party
 ||vcgyhvgkcknlx.bid^$third-party
 ||advetvy.info^$third-party
@@ -2304,8 +2291,6 @@ www.llllllllllll.net^$third-party
 ||alkdmsxs.bid^$third-party
 ||hatchord.com^$third-party
 ||brightonclick.com^$third-party
-||superfastcdn.com^$third-party
-||velocecdn.com^$third-party
 ||pussl35.com^
 ||telllwrite.com^$third-party
 ||kdoraraq.com^
@@ -2636,7 +2621,6 @@ www.llllllllllll.net^$third-party
 ||bbcdn.go.evolutionmedia.bbelements.co
 ||bedebadum.net^$third-party
 ||bee7.com^$third-party
-||beglorena.com^$third-party
 ||best.infoiswhatwedo.com^$third-party
 ||bestevernews.com^$third-party
 ||bestevernews.net^$third-party
@@ -2658,7 +2642,6 @@ www.llllllllllll.net^$third-party
 ||bs.serving-sys.com^$third-party
 ||btdnav.com^$third-party
 ||bubblesmedia.ru^$popup
-||bubblesmedia.ru^$third-party,popup
 ||bundasnovinhas.com^
 ||butterideareligious.xyz^
 ||buy-banner.com^$third-party
@@ -2992,7 +2975,6 @@ www.llllllllllll.net^$third-party
 @@||amgload.net/z|$domain=sinoptik.ua|gismeteo.ua
 !
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
-||analyticsq.com^
 ||tsastrmq.com^
 ||d71e6dd31a026d45.com$popup
 ||xdbwc.com^

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -2594,7 +2594,6 @@ linksht.com#%#//scriptlet("prevent-setTimeout", "_$_")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35273
 !+ NOT_PLATFORM(windows, mac, android)
 @@||theseotools.net^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/19880
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35235
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||singingdalong.blogspot.com^$generichide

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -1240,8 +1240,6 @@ javtiful.com#%#//scriptlet("prevent-addEventListener", "DOMContentLoaded", "adsB
 hentai4.me#@#.afs_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52926
 soulreaperzone.com##body > div[id^="ai-adb-"][style^="position: fixed; top:"][style*="z-index: 9999"]
-! https://github.com/AdguardTeam/AdguardFilters/issues/52929
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=filmninja.ws
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52779
 androidpolice.com#%#//scriptlet("abort-on-property-write", "ai_adb")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52764
@@ -1257,8 +1255,6 @@ podu.me#%#//scriptlet("set-constant", "adsAreBlocked", "false")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52510
 @@||theblogcash.in/*/advertisement.js
 ||theblogcash.in/*/check.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/52562
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=shiroyasha.me
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52345
 @@||soup.io/ads.js
 soup.io#%#//scriptlet("set-constant", "canRunAds", "true")
@@ -1284,8 +1280,6 @@ thelayoff.com#%#//scriptlet("prevent-setTimeout", "AdBlockers")
 @@/ad.js$~third-party,domain=giveaway.su
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52117
 freecoursesonline.me#%#//scriptlet("abort-on-property-write", "adregain_wall")
-! https://github.com/AdguardTeam/AdguardFilters/issues/52062
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=daemon-hentai.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52020
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=nooptext,domain=sna3talaflam.com
 sna3talaflam.com#%#//scriptlet("abort-current-inline-script", "document.createElement", "adblock")
@@ -1321,8 +1315,6 @@ australianfrequentflyer.com.au#%#//scriptlet("set-constant", "adBlockDetected", 
 asianclub.nl#@#.afs_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51649
 moonbitcoin.cash#$##claimAd { display: block!important; position: absolute!important; left: -3000px!important; }
-! https://github.com/AdguardTeam/AdguardFilters/issues/51674
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=mega-hentai2.blogspot.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51646
 @@||magesy.blog/*/deblocker/js/ads.min.js
 @@||magesy.pro/*/deblocker/js/ads.min.js
@@ -1457,8 +1449,6 @@ sznlink.xyz#%#//scriptlet("abort-current-inline-script", "jQuery", "/ai_|ai-|det
 ! https://github.com/AdguardTeam/AdguardFilters/issues/49824
 ||release-apk.com/ext/*/AntiAdblock/
 release-apk.com#%#//scriptlet("prevent-addEventListener", "load", "adblocker")
-! https://github.com/AdguardTeam/AdguardFilters/issues/49594
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=ezbit.co.in
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50226
 @@||btcleets.xyz/static/ads/popunder.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50016
@@ -1489,8 +1479,6 @@ tecknity.com#%#//scriptlet("set-constant", "ads_b_test", "true")
 avforums.com#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/49261
 @@||bitearns.com/*/advertisement.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/49263
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=premium4ever.blogspot.com
 ! insideedition.com - antiadblock in video player
 insideedition.com#@#.adBanner
 ! https://github.com/AdguardTeam/AdguardFilters/issues/49176
@@ -1717,8 +1705,6 @@ freevocabulary.com#$##adWrap { display: block!important; height: 1px!important; 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45117
 @@||bagi.co.in/express/*/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/47063
-! https://github.com/AdguardTeam/AdguardFilters/issues/45861
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=uiz.io|uiz.app
 @@||uiz.io/_sw.js
 @@||ditds.xyz/sw*.js$domain=uiz.io
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45718
@@ -1726,11 +1712,7 @@ freevocabulary.com#$##adWrap { display: block!important; height: 1px!important; 
 @@||pandora.com/web-version/*/ads.json
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45688
 @@||seeitworks.com/advertisement.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/45588
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=televisiongratisenvivo.com
 televisiongratisenvivo.com###divadblock
-! donia2link.net,sqrible.com - antiadblock
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=donia2link.net|sqrible.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45465
 @@||c.yandexcdn.com/js/adv/ads.js$domain=yandexcdn.com
 @@||c.yandexcdn.com/js/adv/advert3.js$domain=yandexcdn.com
@@ -1804,8 +1786,6 @@ bing.com#$#.b_ad { position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44731
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44791
 @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=ac-mo.com|nfmovies.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/44623
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=tekloggers.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44634
 @@||androiddownload.net/themes/*/js/advertisement.js
 !+ NOT_PLATFORM(windows, mac, android)
@@ -1910,10 +1890,6 @@ adshrink.it#$#.adsbox.pub_300x250 { display:block!important; }
 ||saruch.co/ads/ad.xml$redirect=nooptext,important
 !+ NOT_PLATFORM(windows, mac, android, ext_chromium, ext_ff, ext_opera)
 @@||saruch.co/ads/ad.xml$domain=saruch.co
-! https://github.com/AdguardTeam/AdguardFilters/issues/43946
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=proapkmod.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/43932
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=c11.kr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43925
 zoom-link.com#@#.adsBox
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43791
@@ -1962,15 +1938,11 @@ mylink.sh#@#.adsbygoogle
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43245
 theshedend.com#@#.adsbygoogle
 theshedend.com#$#.adsbygoogle { height: 1px!important; display: block!important; }
-! https://github.com/AdguardTeam/AdguardFilters/issues/43321
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=voxc.org
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43231
 @@||static.teemo.gg/*/models/adsense/*.wasm
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,xmlhttprequest,redirect=nooptext,important,domain=teemo.gg
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42869
 @@||books-share.com/scripts/ads.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/42892
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=wikimotors.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42870
 @@||promods.net/ads.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42770
@@ -2063,8 +2035,6 @@ falkirkherald.co.uk#@#.textAd
 falkirkherald.co.uk#@#.text_ad
 falkirkherald.co.uk#@#.text_ads
 !#endif
-! https://github.com/AdguardTeam/AdguardFilters/issues/41759
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=faucetcrypto.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42081
 !+ PLATFORM(windows, mac, android, ext_chromium, ext_ff, ext_opera)
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=hindustantimes.com
@@ -2172,8 +2142,6 @@ gem021.com#%#AG_setConstant('document.bridCanRunAds', 'true');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40632
 @@||sombex.com/ads.js
 sombex.com#%#AG_abortInlineScript(/adblock-blocker-overlay/, 'document.getElementById');
-! https://github.com/AdguardTeam/AdguardFilters/issues/40510
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=okcaller.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40481
 @@||konstantinova.net/*/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40426
@@ -2197,8 +2165,6 @@ stellarkazan.com#%#AG_setConstant('adblock', '1');
 @@||xfaucet.net/*/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40399
 jpvideo.live#@#.afs_ads
-! https://github.com/AdguardTeam/AdguardFilters/issues/40370
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=onlineinterviewquestions.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40364
 24hd.be#@#.afs_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40260
@@ -2217,10 +2183,6 @@ mobinozer.com#%#AG_setConstant('noAdblock', 'true');
 @@/themes/v*/js/ads.js$domain=123movies.tf
 @@||static.moviescdn.live/themes/v*/js/ads.js
 123movies.tf#%#AG_setConstant('check_adblock', 'true');
-! https://github.com/AdguardTeam/AdguardFilters/issues/40036
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=comicspace.com.br
-! https://github.com/AdguardTeam/AdguardFilters/issues/40000
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=tv-onlinehd.com
 tv-onlinehd.com###divadblock
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39928
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=godmods.com
@@ -2262,8 +2224,6 @@ hightech.web.id$$script[tag-content="adback_configuration"][min-length="100000"]
 @@||cas.criteo.com/delivery/ajs.php^$domain=hightech.web.id
 @@||hightech.web.id^$generichide
 !#endif
-! https://github.com/AdguardTeam/AdguardFilters/issues/39553
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=yungeblog.xyz
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39508
 @@||getfreebit.xyz/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39507
@@ -2380,8 +2340,6 @@ wuxiaworld.com#%#AG_defineProperty('CHAPTER.adwallTag', {value: ""});
 @@||dropapk.to^$generichide
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 @@||dropapk.to/*.png#
-! https://github.com/AdguardTeam/AdguardFilters/issues/38073
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=marimo.me
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38075
 ||tikvid.com/js/ba.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37992
@@ -2419,8 +2377,6 @@ v7player.wostreaming.net#$##adblocker-test-ad { display: block!important; }
 @@||acloudfiles.com^$generichide
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 @@||acloudfiles.com/*.png#
-! https://github.com/AdguardTeam/AdguardFilters/issues/37685
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=jyra.online
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29454
 @@/smarttag.js$~third-party,domain=rte.ie
 @@/showads.$~third-party,domain=rte.ie
@@ -2697,8 +2653,6 @@ gametop.com##.adsbygoogle > *
 gametop.com#$#.adsbygoogle { height: 1px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35027
 ||imggram.org/js/ba.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/30536
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=wikiall.org
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||wikiall.org^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35060
@@ -2839,8 +2793,6 @@ yepi.com#%#//scriptlet("set-constant", "evitca_kcolbda", "false")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34176
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||myshorturls.blogspot.com^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/34175
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=pitbullofficial.com
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pitbullofficial.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34026
@@ -3199,8 +3151,6 @@ software-on.com#%#(function(){var b=window.setInterval;window.setInterval=functi
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32479
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||suarankri.me^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/32460
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=memoryhackers.org
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||memoryhackers.org^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32458
@@ -3712,8 +3662,6 @@ sonycrackle.com#$#.cracklePlayer > div > div { display: block!important; }
 ebonus.gg#$#.grey-area { position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28471
 @@||googletagmanager.com/gtag/js$domain=telerium.tv
-! https://github.com/AdguardTeam/AdguardFilters/issues/28720
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=getpaidtoshare.money
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||getpaidtoshare.money^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27408
@@ -3880,8 +3828,6 @@ filegage.com#$##blockblockA { display: none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27506
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||nooyul.co^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/27435
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=giga74.com
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||giga74.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27398
@@ -4114,8 +4060,6 @@ thoptv.info#%#AG_onLoad(function() { var el=document.querySelector('ins.adsbygoo
 @@||cdnjs.cloudflare.com/ajax/libs/blockadblock/*/blockadblock.js$domain=clk.ink
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||clk.ink^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/26242
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=upost.info
 !+ PLATFORM(ios, ext_android_cb)
 @@||upost.info^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26336
@@ -4125,8 +4069,6 @@ thoptv.info#%#AG_onLoad(function() { var el=document.querySelector('ins.adsbygoo
 @@||mc-premium.org/assets/js/fuckadblock.js
 !+ PLATFORM(ios, ext_android_cb)
 @@||mc-premium.org^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/26334
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=highresolutionmusic.com
 !+ PLATFORM(ios, ext_android_cb)
 @@||highresolutionmusic.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26226
@@ -4322,26 +4264,21 @@ freecoursesonline.me#%#AG_abortInlineScript(/\|kcolbdakcolb\|/, 'document.addEve
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24977
 albvid.com#@#.afs_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24940
-hotanime.me#%#Object.defineProperty(window, 'adBlockDetected', { get: function() { return; } });
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=hotanime.me
+! https://github.com/AdguardTeam/AdguardFilters/issues/24887
+! https://github.com/AdguardTeam/AdguardFilters/issues/24857
+hotanime.me,link4gen.com,no1lyrics.com#%#Object.defineProperty(window, 'adBlockDetected', { get: function() { return; } });
 !+ PLATFORM(ios, ext_android_cb)
 @@||hotanime.me^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/24887
-link4gen.com#%#Object.defineProperty(window, 'adBlockDetected', { get: function() { return; } });
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=link4gen.com
 !+ PLATFORM(ios, ext_android_cb)
 @@||link4gen.com^$generichide
+!+ PLATFORM(ios, ext_android_cb)
+@@||no1lyrics.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30644
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24879
 @@||ads.3dtuning.com/ad?placement=*&$~third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24884
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||readonepunchman.net^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/24857
-no1lyrics.com#%#Object.defineProperty(window, 'adBlockDetected', { get: function() { return; } });
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=no1lyrics.com
-!+ PLATFORM(ios, ext_android_cb)
-@@||no1lyrics.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24860
 @@||h5.4j.com/js/ima3.js
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=dressupmix.com
@@ -4356,7 +4293,6 @@ itopmusic.com#%#AG_defineProperty('jQuery.adblock', {value: false});
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org,redirect=nooptext,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24804
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=nekopoi.ga
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||nekopoi.ga^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24683
@@ -4524,7 +4460,6 @@ safelink.miuipedia.com#%#AG_defineProperty('safelink.adblock', { value: false })
 readcomiconline.to##.top_page_alert
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25297
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22921
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=ourl.io
 ourl.io#@#.adsBox
 !+ PLATFORM(ios, ext_android_cb)
 @@||ourl.io^$generichide
@@ -5296,7 +5231,6 @@ intercelestial.com##.swal2-container
 !+ PLATFORM(ios, ext_android_cb)
 @@||kissasian.ch^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17447
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=vcstream.to
 !+ PLATFORM(ios, ext_android_cb)
 @@||vcstream.to^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28391
@@ -5468,13 +5402,11 @@ pacogames.com#@#.afs_ads
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb)
 @@||hdbox.ws^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15623
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=loadvid.online|hdonline.is
 !+ PLATFORM(ios, ext_android_cb)
 @@||loadvid.online^$generichide
 !+ PLATFORM(ios, ext_android_cb)
 @@||hdonline.is^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15533
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=satoshihero.com|satoshimonster.com
 !+ PLATFORM(ios, ext_android_cb)
 @@||satoshihero.com^$generichide
 !+ PLATFORM(ios, ext_android_cb)
@@ -5617,8 +5549,6 @@ forum.blackhatindia.ru$$script[tag-content="onreadystatechange"]
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||blogthetech.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/14970
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=o2tvseries.com
 !+ PLATFORM(ios, ext_android_cb)
 @@||o2tvseries.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/14960
@@ -5747,8 +5677,6 @@ twitch.tv#@#.adsbox
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||weatherx.co.in^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/14297
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=proapkmod.com
 !+ PLATFORM(ios, ext_android_cb)
 @@||proapkmod.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/14020
@@ -6230,8 +6158,6 @@ pluspremieres.us#@##ad-container
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10147
 livesports.pw###adb-enabled
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10221
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=aphim.co
 !+ PLATFORM(ios, ext_android_cb, ext_ublock)
 @@||aphim.co^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10241

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -1712,6 +1712,7 @@ freevocabulary.com#$##adWrap { display: block!important; height: 1px!important; 
 @@||pandora.com/web-version/*/ads.json
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45688
 @@||seeitworks.com/advertisement.js
+! https://github.com/AdguardTeam/AdguardFilters/issues/45588
 televisiongratisenvivo.com###divadblock
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45465
 @@||c.yandexcdn.com/js/adv/ads.js$domain=yandexcdn.com
@@ -2183,6 +2184,7 @@ mobinozer.com#%#AG_setConstant('noAdblock', 'true');
 @@/themes/v*/js/ads.js$domain=123movies.tf
 @@||static.moviescdn.live/themes/v*/js/ads.js
 123movies.tf#%#AG_setConstant('check_adblock', 'true');
+! https://github.com/AdguardTeam/AdguardFilters/issues/40000
 tv-onlinehd.com###divadblock
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39928
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=godmods.com
@@ -2653,6 +2655,7 @@ gametop.com##.adsbygoogle > *
 gametop.com#$#.adsbygoogle { height: 1px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35027
 ||imggram.org/js/ba.js
+! https://github.com/AdguardTeam/AdguardFilters/issues/30536
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||wikiall.org^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35060
@@ -2793,6 +2796,7 @@ yepi.com#%#//scriptlet("set-constant", "evitca_kcolbda", "false")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34176
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||myshorturls.blogspot.com^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/34175
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pitbullofficial.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34026
@@ -3151,6 +3155,7 @@ software-on.com#%#(function(){var b=window.setInterval;window.setInterval=functi
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32479
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||suarankri.me^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/32460
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||memoryhackers.org^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32458
@@ -3662,6 +3667,7 @@ sonycrackle.com#$#.cracklePlayer > div > div { display: block!important; }
 ebonus.gg#$#.grey-area { position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28471
 @@||googletagmanager.com/gtag/js$domain=telerium.tv
+! https://github.com/AdguardTeam/AdguardFilters/issues/28720
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||getpaidtoshare.money^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27408
@@ -3828,6 +3834,7 @@ filegage.com#$##blockblockA { display: none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27506
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||nooyul.co^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/27435
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||giga74.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27398
@@ -4060,6 +4067,7 @@ thoptv.info#%#AG_onLoad(function() { var el=document.querySelector('ins.adsbygoo
 @@||cdnjs.cloudflare.com/ajax/libs/blockadblock/*/blockadblock.js$domain=clk.ink
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||clk.ink^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/26242
 !+ PLATFORM(ios, ext_android_cb)
 @@||upost.info^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26336
@@ -4069,6 +4077,7 @@ thoptv.info#%#AG_onLoad(function() { var el=document.querySelector('ins.adsbygoo
 @@||mc-premium.org/assets/js/fuckadblock.js
 !+ PLATFORM(ios, ext_android_cb)
 @@||mc-premium.org^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/26334
 !+ PLATFORM(ios, ext_android_cb)
 @@||highresolutionmusic.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26226

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -2091,7 +2091,6 @@ pockethow.com#@#.ad-banner
 *.*/*.$third-party,redirect=nooptext,xmlhttprequest,domain=uploadship.com
 @@*.*/*.ico$xmlhttprequest,domain=uploadship.com
 @@||doubleclick.net/*.$xmlhttprequest,domain=uploadship.com
-@@||stats.g.doubleclick.net/*.$xmlhttprequest,domain=uploadship.com
 @@||asadcdn.com/adlib/pages/*.js$domain=uploadship.com
 uploadship.com#%#//scriptlet('abort-current-inline-script', 'document.addEventListener', '/"adblockinfo"/')
 @@||uploadship.com^$generichide
@@ -2131,8 +2130,6 @@ phoneswiki.com#%#AG_defineProperty('jQuery.adblock', {value: false});
 @@||d27so4lebom4m9.cloudfront.net/assets/advertisement/ads-ad7a5d608196d8a3a02d451c604c2ad5.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39493
 @@||adshorted.net/ads.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/40589
-@@||getfree.co.in/*/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40531
 @@||services.brid.tv/player/build/plugins/adunit.js
 gem021.com#%#AG_setConstant('document.bridCanRunAds', 'true');
@@ -2597,6 +2594,7 @@ linksht.com#%#//scriptlet("prevent-setTimeout", "_$_")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35273
 !+ NOT_PLATFORM(windows, mac, android)
 @@||theseotools.net^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/19880
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35235
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||singingdalong.blogspot.com^$generichide
@@ -3052,7 +3050,6 @@ nonsensediamond.website#%#(function(){var b=window.setInterval;window.setInterva
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||itopmusic.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33025
-@@||uploadship.com/themes/pro/frontend_assets/js/advertisement.js
 uploadship.com#%#AG_abortInlineScript(/"adblockinfo"/, 'document.getElementById');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33008
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
@@ -3096,8 +3093,6 @@ teachertube.com#%#AG_abortInlineScript(/\|kcolbdakcolb\|/, 'document.addEventLis
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32784
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||agradarpan.com^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/32896
-@@||mediaite.com/adbait/adsbygoogle.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31731
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||ausbt.com.au^$generichide
@@ -3470,6 +3465,7 @@ heidisql.com#%#window.adsbygoogle = { loaded: !0 };
 @@||uploadrar.com^$generichide
 ! https://forum.adguard.com/index.php?threads/up-4-net.30856
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=www.up-4.net
+! https://github.com/AdguardTeam/AdguardFilters/issues/19256
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30296
 uploadbank.com#%#AG_abortInlineScript(/ad blocking/, 'Math.random');
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
@@ -4117,8 +4113,6 @@ pluspremieres.eu#%#(function(){var b=window.setTimeout;window.setTimeout=functio
 @@||native.propellerclick.com/1?z=^$domain=swatchseries.to
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25923
 receive-sms-online.info$$script[wildcard="*document.getElementsByTagName*AdBlock*"][max-length="1200"]
-!+ NOT_PLATFORM(windows, mac, android)
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=receive-sms-online.info
 !+ NOT_PLATFORM(windows, mac, android)
 @@||google-analytics.com/analytics.js$domain=receive-sms-online.info
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25765
@@ -4883,11 +4877,6 @@ rollercoin.com#%#AG_onLoad(function() { window.addBlockTest = function() {}; });
 @@||zonebourse.com/js/googleads.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19889
 @@||rules.noadblock.org^$domain=hackintoshzone.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/19880
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||singingdalong.blogspot.com^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/19837
-@@||imgadult.com/anex/alt2.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19838
 @@||imgdrive.net/anex/alt2.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19855
@@ -4998,9 +4987,6 @@ xclusivejams.com##.main-container > div[id][class][style*="z-index: 9999"] + div
 asiancorrespondent.com#%#AG_abortInlineScript(/bidWon/, 'Math.floor');
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||asiancorrespondent.com^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/19256
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||uploadbank.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18503
 @@||titsbox.com/js/pop.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18937
@@ -5011,9 +4997,6 @@ asiancorrespondent.com#%#AG_abortInlineScript(/bidWon/, 'Math.floor');
 @@$domain=rapidvideo.com,webrtc,websocket
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19092
 @@||ad.skylinewebcams.com/ad.php
-! https://github.com/AdguardTeam/AdguardFilters/issues/19061
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||winhelp.us^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18731
 countrylife.co.uk#%#AG_abortInlineScript(/bidWon/, 'IPCCoreQueue');
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
@@ -5093,7 +5076,6 @@ goodtoknow.co.uk#%#AG_abortInlineScript(/bidWon/, 'IPCCoreQueue');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35064
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20387
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18523
-@@||kissasian.sh/Scripts/adsense.js
 kissasian.sh$$script[tag-content="Please disable AdBlock"][max-length="2000"]
 kissasian.sh,kissasian.ch#%#Object.defineProperty(window, 'alb', { value: false });
 !+ NOT_PLATFORM(ios, ext_android_cb, ext_ublock)
@@ -5140,8 +5122,6 @@ couponcabin.com#@##bottomAd
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17989
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||repo.xarold.com/ads.php$~third-party
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=repo.xarold.com
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||pagead2.googlesyndication.com/pagead/js/r*/show_ads_impl.js$domain=repo.xarold.com
 !+ PLATFORM(ios, ext_android_cb)
@@ -5227,6 +5207,7 @@ pluspremieres.io#@#.adsbygoogle
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17336
 sofonesia.com###popDiv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17341
+! https://github.com/AdguardTeam/AdguardFilters/issues/19061
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||winhelp.us^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17104
@@ -5244,7 +5225,6 @@ intercelestial.com##.swal2-container
 @@||vcstream.to^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28391
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18113
-@@||facebook.com/adsmanager/manage^
 facebook.com,facebookcorewwwi.onion#@#.AdBox
 facebook.com,facebookcorewwwi.onion#@#.Ad
 facebook.com,facebookcorewwwi.onion#@#.advert
@@ -5694,6 +5674,7 @@ twitch.tv#@#.adsbox
 !+ PLATFORM(ios, ext_android_cb)
 @@||faucetgame.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13806
+! https://github.com/AdguardTeam/AdguardFilters/issues/40589
 @@||getfree.co.in/*/libs/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/14392
 @@||mapquest.com^$generichide
@@ -7005,8 +6986,6 @@ wallpapersite.com#%#window.canRunAds = true;
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6280
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=lolalytics.com
 lolalytics.com#@#.adsbygoogle
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-@@||pagead2.googlesyndication.com/pagead/js/r*/show_ads_impl.js$domain=lolalytics.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/6278
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||sznpaste.net^$generichide
@@ -7782,12 +7761,10 @@ indiatimes.com$$script[wildcard="*blockit*adblocker*var chk*"][max-length="6000"
 indiatimes.com$$script[wildcard="*var _0x*false;if(!_0x*}(document,window));*"][max-length="8000"]
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=indiatimes.com
 @@||static.clmbtech.com/ase/$script,domain=indiatimes.com
-@@||partner.googleadservices.com/gpt/pubads_impl_*.js$script,domain=indiatimes.com
 @@||static.chartbeat.com/js/chartbeat.js$script,domain=indiatimes.com
 @@||www.google-analytics.com/analytics.js$script,domain=indiatimes.com
 @@||b.scorecardresearch.com/beacon.js$script,domain=indiatimes.com
 @@||tags.crwdcntrl.net/c/*/cc.js$script,domain=indiatimes.com
-@@||static.clmbtech.com/ad/commons/js/colombia_v2.js$script,domain=indiatimes.com
 @@||files.adspdbl.com/publishers/timesofindia/code.js$script,domain=indiatimes.com
 @@||ads.pubmatic.com/AdServer/js/pwt/*/pwt.js$script,domain=indiatimes.com
 @@||static.columbia.timesinternet.in/ad/commons/js/colombia.js$script,domain=indiatimes.com

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -11041,9 +11041,6 @@ bestfitnesstips.club##.adsbygoogle
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34497
 !+ NOT_PLATFORM(windows, mac, android)
 filmywap.world##.adsbygoogle
-! https://github.com/AdguardTeam/AdguardFilters/issues/34399
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
-@@||infosehatku.club^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34311
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 kubadownload.com##.adsbygoogle

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -10906,7 +10906,6 @@ turbobit.net##body > a#body-link
 !
 ! /expla*.js^$important,domain=rarbgto.org.
 ! /expla*.js^$important,domain=rarbgway.org|rarbgunblock.com|rarbgcore.org|rarbgp2p.org|rarbgenter.org|rarbg2019.org|rarbgunblocked.org|rarbgproxied.org|rarbgmirrored.org|rarbgprx.org|rarbgtor.org|rarbgget.org|proxyrarbg.org|rarbgto.org|rarbgunblock.org|rarbg2018.org|rarbg.bypassed.org|rarbg.is|rarbg.to|rarbg.unblockall.org|rarbg.unblocked.kim|rarbgaccess.org|rarbgmirror.com|rarbgmirror.org|rarbgmirror.xyz|rarbgproxy.com|rarbgproxy.org|rarbgunblock.co|rarbgaccessed.org
-/:\/\/rarbg.bypassed.org\/cdn\/static\/20\/js\/[a-z0-9]{20,}.js/$domain=rarbg.bypassed.org
 !
 ! twitch.tv - streamer's ads
 twitch.tv##a[href^="https://ggbetpromo.com/"]
@@ -11384,7 +11383,7 @@ thedenverchannel.com##.container--ad
 !+ PLATFORM(ios, ext_android_cb)
 loveawake.com###main_ad
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-||binance.com^$popup,domain=lavamovies.se
+||binance.com^$popup,domain=lavamovies.se/
 !+ NOT_PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 androidrepublic.org##.sectionMain.funbox
 !+ NOT_PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -1824,7 +1824,6 @@ viprow.net##button.btn[data-open="_blank"]
 gfxtra31.com##center > a[target="_blank"] > h4
 thepointsguy.com##.article-body-ad
 thepointsguy.com##.beam-top-banner
-missoulian.com##div.ad-col
 steamplay.me##iframe[src^="//gontent.steamplay.me/"]
 memeburn.com###single-wrapper > .wrapper--grey > .py-md-5:empty
 chromeunboxed.com##.topSpace
@@ -3488,7 +3487,6 @@ katmoviehd.eu###sidebar > #text-3
 ||japscan.to/sw.js
 imgadult.com##a[href^="http://xapi.juicyads.com/"]
 ||youtubeloop.net/img/banner/*-banner.gif
-uploadedpremiumlink.xyz##.col-md-12 > div[style^="margin-top:"][style*="width: 728px;height: 90px;"]:not([class]):not([id])
 uploadedpremiumlink.xyz##.col-md-12 > div > div[style^="margin-bottom:"][style*="width:300px; height:250px;"]:not([class]):not([id])
 myhdporn.net##.afc_popup
 myhdporn.net##a[href="http://myhdporn.net/other.php"][rel="nofollow"] > img
@@ -3768,7 +3766,6 @@ xxxdan.com,jizzbunker.com###content .banner
 anyporn.com##.container .native-footer-desktop-6x1
 fetishshrine.com,xxx-photo.com,youfreeporntube.net,reallifecam.vip##.nav > li > a[target="_blank"]
 vivud.com##.in-gallery-banner
-vivud.com##.adv
 hdzog.com##.main-content > .block-thumbs:not([class*=" "])
 hdzog.com##.player-wrapper > .player-showtime-two.without-title
 ||sexu.com/ifrm/*?ad=awn
@@ -3799,7 +3796,6 @@ usgamer.net##.below-comments > .recommendations
 usgamer.net##.leaderboard-container
 irisbuddies.blogspot.com##a[href^="http://go.oclasrv.com/"]
 irisbuddies.blogspot.com##a[href^="https://publishers.propellerads.com/"]
-pornoxo.com##.video-player .video-extra-overlay
 pornoxo.com##div[class*="advi"]
 pornicom.com##.thumb_spots
 utimetableresult.in,getfreshcloud.xyz,fabsdeals.com,funnyquiz.blog,blogginggyanbox.com,yesmoviesapp.info##.box-main > .banner ~ center
@@ -3949,7 +3945,6 @@ jav.guru###main_header > li.menu-item > a[href="https://theporndude.com/"]
 washingtonpost.com##div[class*="pb-f-ad-leaderboard"]
 politicaloutcast.com##.ad-336x280
 politicaloutcast.com##.ad-336x280-nativeads
-wololo.net##.content > div[style="background-color:#DDEEDD;"]:not([class]):not([id])
 addoncloud.org##.well.vpn
 addoncloud.org##.vertical-left
 courant.com##div[data-pb-name="DFP Ad"]
@@ -4395,7 +4390,6 @@ gotporn.com##.nav > li > a[href="https://www.gotporn.com/casino"]
 ||safemov.site/safelink.js
 ultimate-guitar.com##.js-ab-regular
 limetorrents.info###content > table[style="padding-bottom:10px;width:100%;font-size: 12px;font-family:Verdana"]
-windowscentral.com##.header-top-alert-bar > .content > .surface-2018-order
 tmearn.com##iframe[src*=".tmearn.com/"][style^="overflow:hidden;"]
 ||tmearn.com^$third-party
 collectionofbestporn.com##.main-nav-list > li > a[rel="nofollow"]
@@ -4713,8 +4707,6 @@ vidbull.tv##a[href^="https://go.pub2srv.com/afu.php?"]
 vidbull.tv##a[href^="https://syndication.dynsrvtbg.com/splash.php"]
 ||vidbull.tv/contents/other/player/embed/png-resizeimage.png
 bgr.com##.entry-content > .dont-miss
-vg247.com##.newsad
-vg247.com##.page > .content > .low-leader-container
 ||muskaer.com/mu.js
 blackclovermanga.com,sololeveling.net,readshingekinokyojin.com,readonepunchman.net,readheroacademia.com##.pages__ad
 ||pornzexx.com/fuxxxx.js
@@ -6373,7 +6365,6 @@ gaypornwave.com##.it-sponsor-site
 ||gaypornwave.com/baclo.php
 gaypornwave.com##.thr-ot > .refill[style*="width:100%;"]
 gaypornwave.com##.it-download > .it-download-content
-pornoxo.com##.videoDetail > div[class*="advi"]
 ||ww.x-xn.com/api/spots^$third-party
 youporn.com##.e8-column
 novelasesp.blogspot.de,novelasesp.blogspot.com,novelasesp.blogspot.com.au,novelasesp.blogspot.pe###HTML2
@@ -7838,7 +7829,6 @@ hotclips24.com###vertical-banners
 hotclips24.com###top-banners > div[align="right"][style="color:#333;text-align:center;"]
 hotclips24.com##.adbox-inner
 hotclips24.com###footer > div[style="color:#BBB;text-align:center;"] > font
-vivud.com##.in-gallery-banner
 vivud.com##.player-b-container
 ||vivud.com/js/pns.min.js
 ||naughtyblog.org/wp-content/cache/minify/1e473.js
@@ -8112,9 +8102,7 @@ smallnetbuilder.com###leaderboardspacer
 forums.overclockers.co.uk###Offer
 ||pornxs.com/ajax.php?action=get_link$important
 ||pornxs.com/js/a/*.js
-whatismybrowser.com##.fun.desktop
 whatismybrowser.com##.ads-by-google
-whatismybrowser.com##.content > .fun
 whatismybrowser.com###main > .leaderboard
 watchxxxfree.com##.sidebar-banner
 ||newstarget.com/Javascripts/Abigail.js
@@ -8986,7 +8974,6 @@ xiaomitoday.com###secondary > div.g1-sticky-sidebar
 adultboard.net##td[align="center"] > a > img
 stackexchange.com##div[id^="adzerk"]
 pushsquare.com##div[id^="rcjsload"]
-pushsquare.com##.insert.with-label
 bgr.com##.bgr-outbrain-amp-widget
 ||img.hentai-foundry.com/themes/Hentai/images/*.mp4
 ||yourlink.in/links/popad$popup
@@ -9006,7 +8993,6 @@ neowin.net##.ipsLayout_sidebarright  > div.cWidgetContainer > ul.ipsList_reset >
 androidheadlines.com##.amp-ad-bottom
 techradar.com##.placeholder
 sport.ua,xda-developers.com##amp-iframe
-quora.com##.PromptsList
 vimeo.com##.profile__ad-wrapper
 demonoid.pw##.main_content > table[width="100%"] > tbody > tr > td[onload="fixvbb"]
 mmo-champion.com##div[style="text-align:center;margin-left:auto;margin-right:auto;width:900px;margin-bottom:10px;"]
@@ -9125,7 +9111,6 @@ whattomine.com##.baikal-link
 steamid.eu##.row.text-center[style$="min-height:110px;"]
 independent.co.uk##.taboola-leaderboard
 dato.porn##div[style*="z-index: 999"][onclick]
-tampermonkey.net###ads_are_visible+table div.adventing.house
 ||onclkds.com/apu.php^
 ||xvidstage.com/superplayer.png
 ||powvideo.xyz/bon/
@@ -9898,15 +9883,12 @@ armorgames.com##.promos
 hongkiat.com##.promote
 solidfiles.com##.promoted-dl
 pornjam.com##.publis-bottom
-yts.ag##.rating-row.hidden-sm > a.fd
-yts.ag##.rating-row.hidden-sm > a[class^="button-green-download"][href="javascript:void(0);"]
 familyhandyman.com##.rd_mediakit
 designyourway.net##.reclamaint
 dailydot.com##.recommendation-engine
 svscomics.org##.regi
 wagnardmobile.com##.region-preblocks:first-child
 gamepur.com##.region-sidebar-second-top > .block:not(#block-quicktabs-content_comments)
-redtube.com##.removeAdLink
 sammobile.com##.rev
 allrecipes.com##.review-ad-space
 jizzbunker.com##.right-banners
@@ -9922,7 +9904,6 @@ mensfitness.com##.rr-zergnet-wrapper
 economictimes.indiatimes.com##.rtAdContainer
 ebay.co.uk,ebay.com,ebay.de##.rtmCss
 filepuma.com##.screenshots_ads
-pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 onwatchseries.to##.shd_button
 siliconera.com##.show-ads div.t-footer-curseNetwork
 cubuffs.com##.sidearm-ad-blocker-message-container
@@ -10121,7 +10102,6 @@ dailyuploads.net##a[href^="http://www.total-way.biz/"]
 vodlocker.lol##a[href^="http://www.vodlocker.lol/download"]
 vodlocker.lol##a[href^="http://www.vodlocker.lol/stream"]
 windows10update.com##a[href^="http://www.windows10update.com/windows-10-business-training"]
-watchseries.cr##a[href^="http://www.xl415.com/apu.php"]
 xtremetop100.com##a[href^="http://www.xtremetop100.com/out.php?site="]
 avxhome.in##a[href^="http://www.zevera.com"]
 z-news.link##a[href^="https://accounts.fozzy.com"]
@@ -10359,7 +10339,6 @@ imgwallet.com##iframe[src^="frame.php"]
 clipconverter.cc##iframe[src^="http://a.clipconverter.cc/www/d/"]
 debridnet.com##iframe[style$="width: 300px; height: 250px;"]
 pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[style*="height: 60px;"]
-pcmag.com##iframe[title="3rd party ad content"]
 biggestplayer.me##iframe[width="300"][height="250"]:not([id^="adblock"])
 pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[width="315"]
 pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##iframe[width="950"]
@@ -11347,8 +11326,6 @@ dz4soft.blogspot.com,dz4soft.blogspot.de##.adsbygoogle
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 freenod32key.com,nod32key.xyz##.mobile-ad
 ! https://github.com/AdguardTeam/AdguardFilters/issues/12098
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-porngun.net##.adv
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 porngun.net##.adv-container
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -11383,7 +11383,7 @@ thedenverchannel.com##.container--ad
 !+ PLATFORM(ios, ext_android_cb)
 loveawake.com###main_ad
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-||binance.com^$popup,domain=lavamovies.se/
+||binance.com^$popup,domain=lavamovies.se
 !+ NOT_PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 androidrepublic.org##.sectionMain.funbox
 !+ NOT_PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -580,7 +580,6 @@ youjizz.com##.top_pr
 zoomgirls.net##.side-header2
 grabon.in##.promo-banner
 xlecx.org##iframe[src^="https://promo-bc.com/"]
-||adilk.ilikecomix.com/*.js$domain=xyzcomics.com
 ||erofus.com/loader
 ||erofus.com/*/loader.js
 ||multporn.net/*.php$script
@@ -1192,7 +1191,6 @@ bitconews.net###btn-cerrar
 bleepingcomputer.com##.cz-sponsorposts
 extramovies.*##.ad_btn
 denofgeek.com##.ad-dog
-||d13k7prax1yi04.cloudfront.net/midnight.jquery.min.js
 cointelegraph.com##.posts-listing__bnr
 servedez.com###ad_below_menu_2
 servedez.com##.sp_block > a[href="https://nexusbytes.com"] > img
@@ -4420,7 +4418,6 @@ zetabitco.com###bottom-ads
 zetabitco.com##.top_adspace
 zetabitco.com##div[id*="-adspace"]
 4tube.com##.adv
-||api.camclips.cc/api/proxy?a=
 camclips.cc##.toasted.error
 updatesmarugujarat.in###HTML7
 updatesmarugujarat.in##.adsbygoogle
@@ -9096,7 +9093,6 @@ putlockertv.is##.menu-box > h2:nth-of-type(2)
 ||pornhost.com/*.php?js=*&cache=
 ://*.top^$domain=putlockertv.is
 ://*.party^$domain=putlockertv.is
-||ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js$domain=eurogamer.net
 search.yahoo.com##.searchRightMiddleAds
 search.yahoo.com##.searchCenterTopAds
 search.yahoo.com##.searchRightBottomAds
@@ -10457,7 +10453,6 @@ xxxadd.com/eureka
 ||bcast.pw/ads/promo.html
 ||bcast.site/static/300x25*.html
 ||befuck.com/js/befuck*.js
-||bestadbid.com/apu.php$domain=tusfiles.net
 ||bestandroidappsdownload.com/img/da/$image
 ||bestreams.net/jquery.mn.js
 ||biophobia.tv/tania/banner
@@ -10482,7 +10477,6 @@ xxxadd.com/eureka
 ||cdn.static.fapdu.com/*_popup.
 ||cdn.subs.ro/assets/storm-systems.png
 ||cdn.subs.ro/assets/xservers.png
-||cdn.taboola.com/libtrc/cbsinteractive-downloadcom/loader.js$domain=cnet.com
 ||cdn.taboola.com/libtrc/ndtv-ndtvmobile/loader.js$domain=ndtv.com
 ||cdn.taboola.com/libtrc/needrom/loader.js$domain=needrom.com
 ||cdn.taboola.com/libtrc/skidrowc/loader.js

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -1434,8 +1434,6 @@ kwik.cx#@#.adSense
 @@||api.splice.com/www/advertisement/community-explore$domain=splice.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30979
 @@||securepubads.g.doubleclick.net/gpt/pubads_impl_*.js$domain=irctc.co.in
-! https://github.com/AdguardTeam/AdguardFilters/issues/30981
-@@||reutersmedia.net/resources/r/?$image,domain=reuters.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30968
 actu17.fr#@#.td-ad-background-link
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30706
@@ -1872,7 +1870,6 @@ slogen.ru#@##ad_text:not(textarea)
 @@||optout*.*^$domain=privacy.aol.com
 @@||intentmedia.net/adServer/edaaObaCtl?action_id=3$domain=youronlinechoices.com
 @@||ad.amgdgt.com/ads/js/optout.js
-@@||media.fastclick.net/iab/verify$domain=youronlinechoices.com
 @@||opt.semasio.net/optsvc^$domain=youronlinechoices.com
 @@||et.twyn.com/yocoptstate$domain=youronlinechoices.com
 @@||euoptout.mookie1.com^$domain=optout.mookie1.com
@@ -2052,7 +2049,6 @@ pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#[style] > div > ifr
 ! watchcartoononline.io
 @@||watchcartoononline.io/favicon.ico
 @@||watchcartoononline.io/inc/
-@@||watchcartoononline.io/inc/js/tabcontent.js
 @@||watchcartoononline.io/search|$popup
 @@||watchcartoononline.io/thumbs/
 @@||watchcartoononline.io/back.jpg
@@ -2103,6 +2099,7 @@ readwhere.com#@#.adunit
 @@||jkanime.net/jk.php?
 @@||jkanime.net//buscar/q/?q=
 @@||staticxx.facebook.com/connect/xd_arbiter/*.js?version=$domain=jkanime.net
+! https://github.com/AdguardTeam/AdguardFilters/issues/19417
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20388
 @@||memecenter.com/app/
 @@||memecenter.com/comments/get_comments
@@ -2131,8 +2128,6 @@ readwhere.com#@#.adunit
 @@||play.kisscartoon.ac/player.php?
 @@||kisscartoon.ac/themes/vast/videojs.ads.min.js
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=kisscartoon.ac
-! https://github.com/AdguardTeam/AdguardFilters/issues/19417
-@@||memecenter.com/app/get_morecontent
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19375
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 veporns.com#@#.video_ads
@@ -2737,8 +2732,6 @@ livetracklist.com#@#iframe[width="100%"][height="60"]
 @@||androidcentral.com/sites/androidcentral.com/files/advagg_js/js__*.js
 ! https://forum.adguard.com/index.php?threads/22224/
 @@||messenger.com^$extension
-! https://forum.adguard.com/index.php?threads/22199/
-@@||innovid.com/crossdomain.xml$domain=channel4.com
 ! https://forum.adguard.com/index.php?threads/http-gelbooru-com.14368/
 gelbooru.com#@##paginator
 ! https://forums.lanik.us/viewtopic.php?f=64&t=35469
@@ -3594,7 +3587,6 @@ m.alpha.facebook.com,touch.alpha.facebook.com,mtouch.alpha.facebook.com,x.alpha.
 @@||gogoanime.in/statics/js^
 @@||animeflv.net/redirector.php^
 @@||gogoanime.in/fonts^
-@@||readcomiconline.to$popup
 @@||mangadex.*/images^
 @@||mangapanda.com/sup/js/*.js$~third-party
 @@||i*.mangapanda.com^$image
@@ -3620,7 +3612,7 @@ destructoid.com#@#[style*="background-image:"]
 @@||assets-jpcust.jwpsrv.com^$domain=destructoid.com
 @@||videos-f.jwpsrv.com^$domain=destructoid.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/16349
-@@||readcomiconline.to/cdn-cgi$popup
+@@||readcomiconline.to$popup
 ! https://github.com/easylist/easylist/issues/1141
 @@||9anime.is/captcha/
 !+ NOT_OPTIMIZED

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -239,8 +239,6 @@ copypastecharacter.com#$##contents { visibility: visible!important; }
 ! Remove this rule for reproducing
 !+ PLATFORM(ext_edge)
 @@||docs.google.com^$document
-! Reported: https://forums.lanik.us/viewtopic.php?f=64&t=35443&p=117720#p117720
-pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/2063
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8669
 !+ PLATFORM(windows, mac)
@@ -1961,8 +1959,6 @@ rema.no#@#.top-banners
 @@||sportslens.com/files1/newsnow_f_ab.gif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10718
 newyorker.com#@#iframe[width="100%"][height="60"]
-! https://github.com/AdguardTeam/AdguardFilters/issues/9751
-quora.com#@#.PromptsList
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10947 - higher CPU usage due to constant requests
 @@||voyeurhit.com/related_videos.php
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10950
@@ -1973,8 +1969,6 @@ quora.com#@#.PromptsList
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9527
 @@||em.realtimetv.me/embed.min.js
 @@||cdn.cdnserv.pw/js/general.v2.min.js
-! https://github.com/AdguardTeam/AdguardFilters/issues/9482
-redtube.com#@#.removeAdLink
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9435
 @@||static.xmovies88.stream^$domain=xmovies8.es
 @@||ostr.tv^$domain=xmovies8.es


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

[//]: # (Substitute this line with a description of the problem)

I figured that since "Hacktober" has begun, and it'd probably seem underwhelming for me to just do a "Fix-PR for one or two issue reports" thing, I thought it'd seem more impressive to do redundancy removal PRs like these.

My plan was to go through the 178 most important lines I got in the report when I ran AdGuard Base as a whole through https://abp.surge.sh/redundantRuleChecker/. However, I began to lose track of AdGuard Base's 15 source files after a little more than an hour, and Fanboy seemed to me personally to cast doubt about how desired it was to remove redundant rules in major lists when [I did the same in EasyList](https://github.com/easylist/easylist/pull/6104), so I only went through ~140 of the 178 report lines.

```
/:\/\/rarbg.bypassed.org\/cdn\/static\/20\/js\/[a-z0-9]{20,}.js/$domain=rarbg.bypassed.org has been made redundant by /:\/\/rarbg.bypassed.org\/cdn\/static\/20\/js\/[a-z0-9]{20,}.js/$domain=rarbg.bypassed.org
@@/js/showad_.js$domain=flashx.tv has been made redundant by @@/js/showad*.js$domain=flashx.tv|flashx.to
@@|https:///ovh.webshark.pl/adserver/*/main_script.js?advertise_check=1 has been made redundant by @@||ovh.webshark.pl/adserver/*/main_script.js?advertise_check=1
@@||adm.fwmrm.net/p/msn_live/AdManager.swf$domain=msn.com has been made redundant by @@||adm.fwmrm.net/p/msn_live/AdManager.swf$domain=msn.com|akamaized.net
@@||ajax.googleapis.com/ajax/libs/jquery/$domain=2ddl.unblocked.vc|daporn.com|imagefap.com|linkdrop.net|gelbooru.com|fmovies.is|fmovies.se|imagespicy.site|mycloud.to has been made redundant by @@||ajax.googleapis.com/ajax/libs/jquery/
@@||androgalaxy.in^$generichide has been made redundant by @@||androgalaxy.in^$generichide
@@||aphim.co^$generichide has been made redundant by @@||aphim.co^$generichide
@@||apitvh.net/embed/ads_code_1.js$domain=apitvh.net has been made redundant by @@||apitvh.net/embed/*ads_code_*.js
@@||asianovel.com^$generichide has been made redundant by @@||asianovel.com^$generichide
@@||bitearns.com/*/libs/advertisement.js has been made redundant by @@||bitearns.com/*/advertisement.js
@@||cdn.staticdata.site/js/loadjs.min.js^$domain=strikeout.nu has been made redundant by @@||cdn.staticdata.site/js/loadjs*.min.js$domain=strikeout.nu
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=ac-mo.com|nfmovies.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=asahihen.blogspot.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=mp4mania.xyz has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=she2013.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=sport-tv-guide.live has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=streamcloud.eu has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=televisiongratishd.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=todosobrepsp.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js$domain=ventax.net has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=1004lucifer.blogspot.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=abazero.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=androidaba.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=aphim.co has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=c11.kr has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=comicspace.com.br has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=daemon-hentai.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=donia2link.net|sqrible.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=evilkingmedia.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=ezbit.co.in has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=faucetcrypto.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=filmninja.ws has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=getpaidtoshare.money has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=giga74.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=gmyankee.tistory.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=highresolutionmusic.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=hotanime.me has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=jyra.online has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=link4gen.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=loadvid.online|hdonline.is has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=marimo.me has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=mega-hentai2.blogspot.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=memoryhackers.org has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=naszraciborz.pl has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=nekopoi.ga has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=no1lyrics.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=o2tvseries.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=okcaller.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=onlineinterviewquestions.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=orangespotlight.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=ourl.io has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=papalah.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=pitbullofficial.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=premium4ever.blogspot.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=proapkmod.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=sadistic.pl has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=satoshihero.com|satoshimonster.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=shiroyasha.me has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=tekloggers.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=televisiongratisenvivo.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=tv-onlinehd.com has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=uiz.io|uiz.app has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=upost.info has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=vcstream.to has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=voxc.org has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=wikiall.org has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=wikimotors.net has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=yungeblog.xyz has been made redundant by @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@||facebook.com/adsmanager/manage^ has been made redundant by @@||facebook.com/adsmanager^
@@||getfree.co.in/*/libs/advertisement.js has been made redundant by @@||getfree.co.in/*/libs/advertisement.js
@@||imgadult.com/anex/alt2.js has been made redundant by @@||imgadult.com/anex/alt2.js
@@||kissasian.sh/Scripts/adsense.js has been made redundant by @@||kissasian.sh/Scripts/*.js
@@||mediaite.com/adbait/adsbygoogle.js has been made redundant by @@||mediaite.com/*/adsbygoogle.js
@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=receive-sms-online.info has been made redundant by @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=receive-sms-online.info
@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=repo.xarold.com has been made redundant by @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=repo.xarold.com
@@||pagead2.googlesyndication.com/pagead/js/r*/show_ads_impl.js$domain=lolalytics.com has been made redundant by @@||pagead2.googlesyndication.com/pagead/js/*/show_ads_impl.js$domain=lolalytics.com
@@||partner.googleadservices.com/gpt/pubads_impl_*.js$script,domain=indiatimes.com has been made redundant by @@||partner.googleadservices.com/gpt/pubads_impl_$domain=indiatimes.com
@@||singingdalong.blogspot.com^$generichide has been made redundant by @@||singingdalong.blogspot.com^$generichide
@@||static.clmbtech.com/ad/commons/js/colombia_v2.js$script,domain=indiatimes.com has been made redundant by @@||static.clmbtech.com/ad/commons/js/colombia_v2.js$domain=indiatimes.com
@@||stats.g.doubleclick.net/*.$xmlhttprequest,domain=uploadship.com has been made redundant by @@||doubleclick.net/*.$xmlhttprequest,domain=uploadship.com
@@||uploadbank.com^$generichide has been made redundant by @@||uploadbank.com^$generichide
@@||uploadship.com/themes/pro/frontend_assets/js/advertisement.js has been made redundant by @@||uploadship.com/*/*adv*.js
@@||winhelp.us^$generichide has been made redundant by @@||winhelp.us^$generichide
@@||infosehatku.club^$generichide has been made redundant by @@||infosehatku.club^$generichide
@@||memecenter.com/app/get_morecontent has been made redundant by @@||memecenter.com/app/
@@||readcomiconline.to/cdn-cgi$popup has been made redundant by @@||readcomiconline.to$popup
@@||reutersmedia.net/resources/r/?$image,domain=reuters.com has been made redundant by @@||reutersmedia.net/resources^
@@||watchcartoononline.io/inc/js/tabcontent.js has been made redundant by @@||watchcartoononline.io/inc/
@@||youmaker.com/js/prebid.js$domain=epochtimes.com has been made redundant by @@||youmaker.com/js/prebid.js
@@||innovid.com/crossdomain.xml$domain=channel4.com has been made redundant by @@/crossdomain.xml$domain=channel4.com
@@||media.fastclick.net/iab/verify$domain=youronlinechoices.com has been made redundant by @@||media.fastclick.net/iab^$domain=youronlinechoices.com
missoulian.com##div.ad-col has been made redundant by gazettetimes.com,missoulian.com,kenoshanews.com,cumberlink.com,trib.com,dailyprogress.com,stltoday.com,journalstar.com##.ad-col
porngun.net##.adv has been made redundant by porngun.net,eteenporn.com,bobs-tube.com,camwhores.tv,sexboomcams.com,pornformance.com,vivud.com##.adv
pornoxo.com##.video-player .video-extra-overlay has been made redundant by ashemaletube.com,pornoxo.com,boyfriendtv.com,fetishpapa.com##.video-extra-overlay
pornoxo.com##.videoDetail > div[class*="advi"] has been made redundant by pornoxo.com##div[class*="advi"]
pushsquare.com##.insert.with-label has been made redundant by pushsquare.com##.insert
tampermonkey.net###ads_are_visible+table div.adventing.house has been made redundant by tampermonkey.net##.adventing
uploadedpremiumlink.xyz##.col-md-12 > div[style^="margin-top:"][style*="width: 728px;height: 90px;"]:not([class]):not([id]) has been made redundant by uploadedpremiumlink.xyz##div[style*="width: 728px;height: 90px;"]
vg247.com##.page > .content > .low-leader-container has been made redundant by vg247.com##.content > .low-leader-container
vivud.com##.adv has been made redundant by porngun.net,eteenporn.com,bobs-tube.com,camwhores.tv,sexboomcams.com,pornformance.com,vivud.com##.adv
vivud.com##.in-gallery-banner has been made redundant by vivud.com##.in-gallery-banner
watchseries.cr##a[href^="http://www.xl415.com/apu.php"] has been made redundant by watchseries.cr##a[href*="/apu.php"]
whatismybrowser.com##.content > .fun has been made redundant by whatismybrowser.com##.fun
whatismybrowser.com##.fun.desktop has been made redundant by whatismybrowser.com##.fun
windowscentral.com##.header-top-alert-bar > .content > .surface-2018-order has been made redundant by androidcentral.com,windowscentral.com,imore.com##.header-top-alert-bar
wololo.net##.content > div[style="background-color:#DDEEDD;"]:not([class]):not([id]) has been made redundant by wololo.net##.content > div[style*="background-color"]:not([class]):not([id])
yts.ag##.rating-row.hidden-sm > a.fd has been made redundant by yts.ag##.hidden-sm.rating-row > a
yts.ag##.rating-row.hidden-sm > a[class^="button-green-download"][href="javascript:void(0);"] has been made redundant by yts.ag##.hidden-sm.rating-row > a
||adilk.ilikecomix.com/*.js$domain=xyzcomics.com has been made redundant by ||adilk.ilikecomix.com^
||ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js$domain=eurogamer.net has been made redundant by @@||ajax.googleapis.com/ajax/libs/jquery/
||api.camclips.cc/api/proxy?a= has been made redundant by ||api.camclips.cc/api/*?a=
||bestadbid.com/apu.php$domain=tusfiles.net has been made redundant by ||bestadbid.com^
||cdn.taboola.com/libtrc/cbsinteractive-downloadcom/loader.js$domain=cnet.com has been made redundant by @@||cdn.taboola.com/libtrc/*/loader.js$domain=cnet.com
||d13k7prax1yi04.cloudfront.net/midnight.jquery.min.js has been made redundant by ||d13k7prax1yi04.cloudfront.net^
Whitelisting for an identical blocklisting: quora.com#@#.PromptsList
Whitelisting for an identical blocklisting: pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#@#.sectionWrapper > div[class*=" "]:not([class="sectionTitle"]):not([class="reset"])
Whitelisting for an identical blocklisting: redtube.com#@#.removeAdLink
139.99.120.222##.navbar-brand#fbawah has been made redundant by 139.99.120.222##.navbar-brand
mp3.big.az##body > a[href="http://unvan.az"][target="_blank"] has been made redundant by big.az##a[href="http://unvan.az"]
mp3.xodver.az#?#.main_content_info > .main_tittle:contains(Reklam) + .main_in_content has been made redundant by mp3.xodver.az#?#.main_content_info > .main_tittle:contains(Reklam)
mp3.xodver.az#?#.main_right_side > .main_tittle:first-child:contains(Reklam) + .main_in_content has been made redundant by mp3.xodver.az#?#.main_right_side > .main_tittle:first-child:contains(Reklam)
novelasesp.blogspot.de,novelasesp.blogspot.com,novelasesp.blogspot.com.au,novelasesp.blogspot.pe###HTML2 has been made redundant by novelasesp.blogspot.de,novelasesp.blogspot.com,novelasesp.blogspot.com.au,novelasesp.blogspot.pe###HTML2
nudeteenwhore.com#?#.title:has(> h2:contains(Recommend)) + div.thumbs has been made redundant by nudeteenwhore.com#?#.title:has(> h2:contains(Recommend))
pilot.wp.pl#@#.ads has been made redundant by autokult.pl,fotoblogia.pl,komorkomania.pl,gadzetomania.pl,money.pl,so-magazyn.pl,o2.pl,pudelek.pl,wp.pl#@#.ads
pluspremieres.us#@##ad-container has been made redundant by pluspremieres.us#@##ad-container
pluspremieres.us#@#.adsbygoogle has been made redundant by pluspremieres.us#@#.adsbygoogle
pogoda.wp.pl#?#.grid-container > div[class^="grid-"] > .list > ul > li > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty) has been made redundant by pogoda.wp.pl#?#.grid-container > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty)
pogoda.wp.pl#?#.grid-container > div[class^="grid-"] > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty) has been made redundant by pogoda.wp.pl#?#.grid-container > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty)
pogoda.wp.pl#?#.grid-container > div[class^="grid-"] > div[class] > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty) has been made redundant by pogoda.wp.pl#?#.grid-container > div[class*=" "]:matches-css(background-image: /^url\(data:image/png;base64,iVBOR/):has(> div:only-child:empty)
qan.az#?#div[style="text-align: center"] > b > b[-ext-contains="Reklam:"]+a[href^="http://qan.az/chat/simaz/go.php?id="]+br has been made redundant by qan.az#?#div[style="text-align: center"] > b > b[-ext-contains="Reklam:"]
Whitelisting for an identical blocklisting: pcmag.com#@#iframe[title="3rd party ad content"]
Whitelisting for an identical blocklisting: vg247.com#@#.newsad
so-magazyn.pl,o2.pl,pudelek.pl,wp.pl#@#.ads has been made redundant by autokult.pl,fotoblogia.pl,komorkomania.pl,gadzetomania.pl,money.pl,so-magazyn.pl,o2.pl,pudelek.pl,wp.pl#@#.ads
so-magazyn.pl,o2.pl,pudelek.pl,wp.pl#@#[class^="advertisement"] has been made redundant by autokult.pl,fotoblogia.pl,komorkomania.pl,gadzetomania.pl,money.pl,so-magazyn.pl,o2.pl,pudelek.pl,wp.pl#@#[class^="advertisement"]
soulreaperzone.com##body > div[id^="ai-adb-"][style^="position: fixed; top:"][style*="z-index: 9999"] has been made redundant by jpopsingles.eu,nulledfree.pw,chuksguide.com,tencentgamingbuddy.co,gplcanyon.com,civildigital.com,paksociety.com,iptv4sat.com,apkmb.com,loveroms.online,loveroms.online,soulreaperzone.com,freecoursesonline.me##body > div[id^="ai-adb-"][style^="position: fixed; top:"][style*="z-index: 9999"]
thewatchcartoononline.tv#@#.adBanner has been made redundant by thewatchcartoononline.tv,wco.tv,wcostream.com,wcoanimesub.tv,wcoanimedub.tv#@#.adBanner
tinhte.vn##.root > header + div[class^="jsx-"].main > .root > div[class^="jsx-"].main > div[class^="jsx-"].main > div[style="width:320px;height:50px"]:empty has been made redundant by tinhte.vn##div[style="width:320px;height:50px"]
turizm.fins.az##.banner has been made redundant by fins.az##.banner
vg.no##.appnexus.ad has been made redundant by vg.no##.ad
www.filmweb.pl#@#.ws__wrapper has been made redundant by filmweb.pl#@#.ws__wrapper
xz2.xyz##+js(window.open-defuser) has been made redundant by xz2.xyz##+js(window.open-defuser)
||21moviemaniaasli.club/asset/default/player/plugins/vast-*.js has been made redundant by /asset/default/player/plugins/vast-*.js
||ads2.contentabc.com^$third-party has been made redundant by ||ads2.contentabc.com^$third-party
||alio.lt/info*.html$domain=delfi.lt has been made redundant by ||alio.lt^$domain=delfi.lt
||beglorena.com^$third-party has been made redundant by ||beglorena.com^
||bestadbid.com^$third-party has been made redundant by ||bestadbid.com^
||bfe4e6d364be199.com^$third-party has been made redundant by ||bfe4e6d364be199.com^
||bms.adjarabet.com^$third-party has been made redundant by ||adjarabet.com^$third-party
||bodelen.com^$third-party has been made redundant by ||bodelen.com^$third-party
||bp.blogspot.com^$image,domain=nontonmovie33.net has been made redundant by ||bp.blogspot.com^$image,domain=movie303.com|nontonmovie33.net
||bubblesmedia.ru^$third-party,popup has been made redundant by ||bubblesmedia.ru^$popup
||d1r90st78epsag.cloudfront.net^ has been made redundant by ||d1r90st78epsag.cloudfront.net^
||d2ho1n52p59mwv.cloudfront.net^ has been made redundant by ||d2ho1n52p59mwv.cloudfront.net^
||dd.70yst.com^$third-party has been made redundant by ||70yst.com^$third-party
||delfi.lv/news_export/widget_creator.php$domain=reklama.vesti.lv has been made redundant by ||delfi.lv/news_export$domain=~delfi.ee|~delfi.lv
||exe.io/files/p10.js has been made redundant by ||exe.io/files/p*.js
||flyordie.com/games/online/iframeafg*.html has been made redundant by @@||flyordie.com/games/online/iframeafg*.html
||givirsou.net^$third-party has been made redundant by ||givirsou.net^
||javporn.best/asset/default/player/plugins/vast-*.js has been made redundant by /asset/default/player/plugins/vast-*.js
||js.hdzog.com/saber/hdzog/dutti/ has been made redundant by ||js.hdzog.com/saber/
||kickassanime.io/codea/720x90*.html has been made redundant by ||kickassanime.io/codea/
||kurkizraka.com^$third-party has been made redundant by ||kurkizraka.com^
||niltutch.com^$third-party has been made redundant by ||niltutch.com^$third-party
||pegloang.com^ has been made redundant by ||pegloang.com^
||rotumal.com^$popup,domain=dailymotiontomp3.com has been made redundant by ||rotumal.com^$document,popup
||sexu.com/ifrm/*?ad=awn has been made redundant by ||sexu.com/ifrm/
||show.g.mediav.com^$third-party has been made redundant by ||mediav.com^$third-party
||superfastcdn.com^$third-party has been made redundant by ||superfastcdn.com^
||util.simply-hentai.com/prod/$script,image,domain=simply-hentai.com has been made redundant by ||util.simply-hentai.com/prod/
||velocecdn.com^$third-party has been made redundant by ||velocecdn.com^
||voastauz.net^$third-party has been made redundant by ||voastauz.net^
||waubasou.com^$third-party has been made redundant by ||waubasou.com^
||xcouj.com^$third-party has been made redundant by ||xcouj.com^$third-party
||xozilla.com/player/html.php?aid=pause_html&video_id=*&*referer= has been made redundant by ||xozilla.com/player/html.php
||zbporn.com/xdman/ has been made redundant by ||zbporn.*/xdman/
||zbporn.com/xdman/license.*.js has been made redundant by ||zbporn.*/xdman/
||zbporn.com/zpi/zp.js has been made redundant by ||zbporn.*/zpi/zp.js
```

* **Expected behaviour**: 

N/A

***Steps to reproduce the problem***:

N/A

***System configuration***

**Filters:**

![image](https://user-images.githubusercontent.com/22780683/94770484-fedfab80-03b4-11eb-9d07-8a25f679b118.png)

Additionally, for temporary Twitch purposes, I have "AdGuard Base filter (Optimized)" and no other lists turned on in AdGuard for Windows.

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Operating system version (Android/iOS) | May 2020 Update
Browser:                               | Chrome 85.0.4183.121 x64
AdGuard version:                       | Nano Adblocker 1.0.0.153 + Nano Defender 15.0.0.205 + AdGuard for Windows 7.5.1 + IDCAC 3.2.2
Filters enabled:                       | See screenshot and notice above.
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | N/A
HTTPS filtering (Android only):        | On
Simplified filters (iOS only)          | Off (Nano Adblocker) + On (AdGuard for Windows)
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | N/A
Helpdesk ID (if exists):               | N/A

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)