### PR TITLE
fix #64912 my.bookmark.rakuten.co.jp

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -875,6 +875,7 @@ yahoo.co.jp##ul[class^="sponsor"]
 ||pranking*.ziyu.net/img.php?
 ||pranking*.ziyu.net/rranking.gif
 ||rakuten.co.jp/b/
+||rakuten.co.jp/com/img/thumb/logout/bnr/
 ||response.jp/ad/
 ||response.jp/pv.php?
 ||ric.hi-ho.ne.jp/webmaster-p/shanbara/

--- a/JapaneseFilter/sections/whitelist.txt
+++ b/JapaneseFilter/sections/whitelist.txt
@@ -1,6 +1,8 @@
 !
 ! White list. Fixing filtration errors(false-positive)
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/64912
+@@||ranking.rakuten.co.jp^$domain=bookmark.rakuten.co.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62583
 @@||proto2ad.durasite.net/A-affiliate2/mobile$script,domain=ok.goo-net.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58153


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/64912
Account and bookmarking a store required to reproduce, probably hard for you. I'm not sure why `ranking.rakuten.co.jp` is blocked though.