### PR TITLE
fix javtheater.com placeholders [NSFW]

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -64,6 +64,7 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||boost-next.co.jp^
 ||ala.durasite.net^
 ||scottdwebgraphics.com^$third-party
 ||p.permalink-system.com^$third-party

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -3,6 +3,7 @@
 !
 ! /banner/banner_ - if it is necessary, make this rule domain specific
 !
+javtheater.com##.__isboostOverContent
 9tsu.net,miomio.us##.ads-system
 9tsu.net,miomio.us##.cactus-sidebar-content > .widget_text
 ||rakuten.co.jp/com/img/thumb/logout/bnr/

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -5,7 +5,7 @@
 ! Popular on Japanese sites
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587#issuecomment-656098019
 ! Sample URL: ||js.passaro-de-fogo.biz/t/113/750/a1113750.js
-/^https?:\/\/js\.[-.0-9a-z]+\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{7}\.js$/$script,third-party
+/^https?:\/\/js\.[-.0-9a-z]+\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{7,9}\.js$/$script,third-party
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60875
 /facebookproductad/views/js/pixel.js


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL (nsfw): 
`https://javtheater.com/`
`https://javtheater.com/archives/242581/ebod-674%e5%8c%97%e9%99%b8%e7%99%ba%ef%bc%81%ef%bc%81%e5%a4%a7%e4%ba%ba%e6%b0%97%ef%bc%81%ef%bc%81%e3%81%94%e5%bd%93%e5%9c%b0icup%e3%82%a2%e3%82%a4%e3%83%89%e3%83%ab%e7%99%bd%e7%9f%b3%e3%82%81/`

Annoying icon left-over and placeholders

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![javtheater1](https://user-images.githubusercontent.com/58900598/95081619-c47b6300-0754-11eb-89a0-4a1aed35f660.png)

![javtheater2](https://user-images.githubusercontent.com/58900598/95081620-c5ac9000-0754-11eb-9efc-aefbc957bdf6.png)

![javtheater3](https://user-images.githubusercontent.com/58900598/95081625-c6ddbd00-0754-11eb-84c1-9fdfae17a939.png)

</details><br/>

***System configuration***

**Filters:**

Base, Tracking, and Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Brave 1.14.84/Firefox 81.0.1
AdGuard version:                       | 3.5.12
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled

