### PR TITLE
Update #64962 9tsu.net (fixes auto-redirect)

### DIFF
--- a/EnglishFilter/sections/adservers.txt
+++ b/EnglishFilter/sections/adservers.txt
@@ -5,6 +5,7 @@
 !
 !! https://a.bestcontentitem.top/warp/*?r=
 !
+||developingstripes.com^
 ||africaewgrhdtb.com^$third-party
 ||traffic-go.com^$document,popup
 ||pulpsbarndomed.com^

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -4729,7 +4729,7 @@ addictivetips.com##a[href^="https://www.addictivetips.com/go"] > img
 citethisforme.com##.sbm-ad
 x1337x.se##a[href^="/vpn"][href*=".php"]
 x1337x.se##.aabfdbb[id][href*=".php"]:not([onclick])
-/^https?:\/\/[a-z0-9]{5,14}\.(com|bid|online|top|club)\/[0-9a-f]{32}\/invoke.js$/$script,third-party
+/^https?:\/\/[a-z0-9]{5,17}\.(com|bid|online|top|club)\/[0-9a-f]{32}\/invoke.js$/$script,third-party
 premium4ever.blogspot.com,hxload.io,haxhits.com###fixedban
 ||haxhits.com/gdata/ad-vast.xml
 healthline.com##.article-body > div[class^="css-"][class*=" e"]


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL: `https://9tsu.net/`

Auto redirected to scam sites.

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![winnertoday](https://user-images.githubusercontent.com/58900598/95660426-cbdeaa00-0b62-11eb-9b5b-2646179c4ca4.png)
</details><br/>

***Steps to reproduce the problem***:

Visit the site.

***System configuration***

**Filters:**

Base, TPL, & JPN

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Brave 1.15.72
AdGuard version:                       | 3.5.12
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled
