### PR TITLE
The second large cleanup of JP filters

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -64,6 +64,8 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||ad.pr.ameba.jp^
+||d2-apps.net^$third-party
 ||a-affiliate.net^$third-party
 ||ad999.biz^
 ||nend.net^$third-party

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -3,6 +3,8 @@
 !
 ! /banner/banner_ - if it is necessary, make this rule domain specific
 !
+||sponichi.co.jp/adds/*/shopping/sannex_
+koneta.nifty.com###custom_html-2
 ||joins.com/HomeAds/$subdocument
 ||p.net-public.com/js/b.js
 ||seesaa.net/image/loopad*$subdocument,third-party
@@ -12,9 +14,12 @@
 amaebi.co##.advertisement-position
 amaebi.co##.blogroll-wrapper
 amaebi.co##.side--right > div:last-child
+asahi.com###NativePr
+asahi.com###Outbrain_Osusume
 asahi.com##.p-ad--topNews
 asahi.com##.p-chumoku
 asahi.com##.p-rectangleAd
+dot.asahi.com##.atclTitleAreaRecommendarticle
 ascii.jp###artAds
 ascii.jp##.lnkBanner
 ascii.jp##.pickwrap
@@ -24,6 +29,9 @@ japan.cnet.com###ad_textbottom
 japan.cnet.com###content-bottom-block
 japanese.joins.com##.YahooAds
 jiji.com##.ArticleInnerAD
+dic.nicovideo.jp###right-column > div[style*="height:250px; width:300px;"]
+dic.nicovideo.jp##.ad-bannar-maincolumn-top
+dic.nicovideo.jp##.adsense-728
 live.nicovideo.jp,live2.nicovideo.jp##[class^="___billboard-ad"]
 www.nicovideo.jp##.NicoadContainer
 mainichi.jp##.cx
@@ -646,35 +654,12 @@ youflix.is##.over_videoAd
 youflix.is##.content_vlist .content_vlist[style^="height:305px; overflow:hidden;"]
 ||image.getchu.com/afbanner/
 yahoo.co.jp###pos-sqb
-sponichi.co.jp###relation-block
-ameblo.jp###resPointAreaWrapper
-nifty.com###sexy
-jiji.com###shopping_2nd
-muzie.ne.jp###sideb
-warnermycal.com###skyBnr
-imageporter.com###slashpage
-rakuten.co.jp###sponcerMain
-newsonjapan.com###squarebanner_text300x250
-rakuten.co.jp###srEsper
-rakuten.co.jp###srEsperHead
-rakuten.co.jp###srNaviSponcer
 rakuten.co.jp##a[href^="https://ad2.trafficgate.net/"]
 rakuten.co.jp##a[href^="https://www.jpcert.or.jp"]
-infoseek.co.jp###srchls
-jiji.com###sumai_banner
-google.co.jp###tadsb
-mocovideo.jp###toprightad_m_r
-nicovideo.jp###web_pc_premium
-nicovideo.jp###web_pc_prime
-sponichi.co.jp###yaad4
-mainichi.jp##.AdAA
-mainichi.jp##.ArticleAd
-asahi.com##.BnrLnkLct
-asahi.com##.BnrLnkSbs
-asahi.com##.BoxFeatPlan
-mainichi.jp##.Campaign
-lifehacker.jp##.EntryMoreBanner
-nikkei.com##.JSID_tagFooter
+plaza.rakuten.co.jp###commonAdsParts
+websearch.rakuten.co.jp###ads-billboard
+websearch.rakuten.co.jp###teamsite-mid-pickup
+websearch.rakuten.co.jp##.section-title1[style="margin-bottom: 10px;"]
 livedoor.com##.LDservice-link
 chunichi.co.jp,tokyo-np.co.jp##.PR
 asahi.com##.PrInfo


### PR DESCRIPTION
```
! Obsolete elements
sponichi.co.jp###relation-block
ameblo.jp###resPointAreaWrapper
nifty.com###sexy
jiji.com###shopping_2nd
muzie.ne.jp###sideb
warnermycal.com###skyBnr
imageporter.com###slashpage
rakuten.co.jp###sponcerMain
newsonjapan.com###squarebanner_text300x250
rakuten.co.jp###srEsper
rakuten.co.jp###srEsperHead
rakuten.co.jp###srNaviSponcer
infoseek.co.jp###srchls
jiji.com###sumai_banner
! should be covered by ###tadsb[aria-label] in EL
google.co.jp###tadsb
mocovideo.jp###toprightad_m_r
nicovideo.jp###web_pc_premium
nicovideo.jp###web_pc_prime
sponichi.co.jp###yaad4
mainichi.jp##.AdAA
mainichi.jp##.ArticleAd
asahi.com##.BnrLnkLct
asahi.com##.BnrLnkSbs
asahi.com##.BoxFeatPlan
mainichi.jp##.Campaign
lifehacker.jp##.EntryMoreBanner
! The rule below is more of FP. Test on https://www.nikkei.com/article/DGXMZO65071870W0A011C2MM0000/
nikkei.com##.JSID_tagFooter

! New cosmetic rules
asahi.com###NativePr
asahi.com###Outbrain_Osusume
dic.nicovideo.jp###right-column > div[style*="height:250px; width:300px;"]
dic.nicovideo.jp##.ad-bannar-maincolumn-top
dic.nicovideo.jp##.adsense-728
dot.asahi.com##.atclTitleAreaRecommendarticle
koneta.nifty.com###custom_html-2
plaza.rakuten.co.jp###commonAdsParts
websearch.rakuten.co.jp###ads-billboard
websearch.rakuten.co.jp###teamsite-mid-pickup
websearch.rakuten.co.jp##.section-title1[style="margin-bottom: 10px;"]


! New basic rules
! https://www.sponichi.co.jp/entertainment/news/2020/10/16/kiji/20201016s00041000171000c.html
||d2-apps.net^$third-party
||sponichi.co.jp/adds/*/shopping/sannex_

! https://ameblo.jp/mathisii/
||ad.pr.ameba.jp^
```