### PR TITLE
The fourth large cleanup of JP filter

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -376,6 +376,7 @@ kadinlarkulubu.com,pinknews.co.uk,newsru.com,livejournal.com,tecmundo.com.br,rap
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=web2.0calc.com
 !
 !
+websearch.rakuten.co.jp###adblocker-warning-popup
 shinden.pl#%#AG_onLoad(function(){var a=document.querySelectorAll('div[id^="spolecznosci"]');0<a.length&&a.forEach(function(b){b.appendChild(document.createElement("div"))})}); 
 mysnip.xyz##.form-group > b > h3
 ||eurogamer.net/scripts/Eurogamer/meurogamer-fsm.js

--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -38,6 +38,7 @@ macwelt.de,pcwelt.de#%#AG_setConstant('firebase.messaging', 'noopFunc');
 .site/?pus=$script,third-party
 !
 ! /pnsw_init.js
+||push.asahiinteractive.com^$third-party
 ||cdn.onepush.app^$third-party
 ||dryum.ru^$third-party
 ||spattepush.com^$third-party

--- a/AnnoyancesFilter/sections/self-promo.txt
+++ b/AnnoyancesFilter/sections/self-promo.txt
@@ -44,6 +44,9 @@ realty.yandex.ru##.Offer__taxiBannerContainer
 !-----------------------------------------------
 !
 !
+! yomiuri.co.jp footer promotion banner
+||yomiuri.co.jp/assets/images/footer-subscribe/
+yomiuri.co.jp##.js-footer-2020-subscribe
 ! Hdrezka - promo in the player
 hdrezkaonline.com,drhdrezka.com,mrhdrezka.com,hdrezka.sh,nukinopoisk.com,livekinopoisk.com,betahdrezka.com,cokinopoisk.com,hdrezka-ag.com,hdrezka-online.me,hdrezka.club,hdrezka.cm,hdrezka.co,hdrezka.com.ua,hdrezka.host,hdrezka.lol,hdrezka.name,hdrezka.site,hdrezka.today,hdrezka.tv,hdrezka.website,hdrezkaag.net,hdrezkaweb.com,hdrezkayou.com,instahdrezka.com,myhdrezka.com,rezka.ag,tryhdrezka.com###tg-info-block-exclusive
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65892

--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -64,6 +64,7 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||adsrvr.org^$third-party
 ||digitiminimi.com^$third-party
 ||ladsp.jp^
 ||af.fukuishimbun.co.jp^$third-party
@@ -240,7 +241,6 @@
 ||affili.dmm.com^$third-party
 ||affiliate-b.com^$third-party
 ||an.mainichi.jp^
-||analytics.qlook.net^$third-party
 ||animate.tv/ad/
 ||api.unthem.com^$third-party
 ||arms.livedoor.net^

--- a/JapaneseFilter/sections/css_extended.txt
+++ b/JapaneseFilter/sections/css_extended.txt
@@ -6,6 +6,12 @@ animeanime.jp,cinemacafe.net,gamespark.jp,getnavi.jp,gow.asia,iionna.tokyo,insid
 animeanime.jp,getnavi.jp,the-uranai.jp#?#._popIn_infinite_page > li:has(._popIn_recommend_article_ad_reserved)
 chosunonline.com,taishu.jp#?##_popIn_recommend li:has(._popIn_recommend_article_ad)
 cinemacafe.net#?#._popIn_infinite_page:has(._popIn_recommend_article_ad_reserved)
+finance.yahoo.co.jp#?#div:has(> #mainAdTop)
+finance.yahoo.co.jp#?#div:has(> [id^="subAd"]):matches-css(min-height: 250px)
+blog.shinobi.jp#?#article.EntryTextBox:has(#ninja-blog-inactive)
+blog.shinobi.jp#?#div.EntryInner:has(#ninja-blog-inactive)
+blog.shinobi.jp#?#div.EntryBlock:has(#ninja-blog-inactive)
+blog.shinobi.jp#?#div.EntryTitle:has(a[href=""]:contains([PR]))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58879
 moeimg.net#?##main-2 > .post:has(> .pc_ad:only-child)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -3,7 +3,28 @@
 !
 ! /banner/banner_ - if it is necessary, make this rule domain specific
 !
+bikebros.co.jp,virginbmw.com,virginducati.com,virgintriumph.com##.adsw
+blog.shinobi.jp##.NinjaEntryCommercial
+cnn.co.jp###_popIn_recommend
+||dlsite.com/js/blogparts.js
+||himasoku.com^$subdocument,~third-party
+himasoku.com##.article-body-more > .akares
+himasoku.com##.himajin-headline
+himasoku.com##.netabare
+||labaq.com/user/json/lq_amarray.js
+labaq.com###ArticleBottom > span[style="font-size:0.8em;color:#666;clear:both"]
+labaq.com###logoad
+labaq.com###rightbody > .plugin-memo > .side > div[style^="width: 100%; height: 250px;"]
+labaq.com###rightbody > .sideparts_200c + .plugin-memo > .sidetitlebody
+labaq.com##div[class^="sideparts_"]
 jable.tv##a[href^="https://l.tyrantdb.com/"]
+mainichi.jp##.yads
+namakeru.com##.customized-header > .entry-header-html
+namakeru.com##.entry-footer-html > font[size="1"]
+namakeru.com##.hatena-module-html:first-child
+page2.jp###meerkat-wrap
+page2.jp,sitemix.jp###sitemix_pr_footer_js
+websearch.rakuten.co.jp###ad-ichiba
 ||excite.co.jp/jp/ox/
 excite.co.jp##div[id^="gpt_pc_news_"]
 ||chaos2ch.com/rss.html
@@ -16,6 +37,7 @@ hamusoku.com##.topbox
 nanjhistory.2chblog.jp##.kiji-ue-rss
 373news.com##.mns_bn
 ||sponichi.co.jp/adds/*/shopping/sannex_
+||nifty.com/pubc0m/$script
 koneta.nifty.com###custom_html-2
 ||joins.com/HomeAds/$subdocument
 ||p.net-public.com/js/b.js
@@ -117,6 +139,8 @@ dousyoko.net##.plugin2_outline
 dousyoko.net##.plugin3_outline
 ||nikkei.jp^*/f1h_text1.js|
 ||partsa.nikkei.com/static/nkis/js/foneH.js
+business.nikkei.com##.cbCxense
+business.nikkei.com##section[class^="recommendAd"]
 www.nikkei.com##.PRb
 www.nikkei.com##.k-ad__text
 www.nikkei.com##.k-hub-pr
@@ -273,7 +297,11 @@ dhbr.net##div[id^="FreesSpark_"]
 dhbr.net##.bn_trial a[href]:not([href^="http://www.dhbr.net/"]) > img
 solomon-review.net###right_folder > div.textwidget > a[rel^="nofollow"] > img
 news4vip.livedoor.biz##a[href^="https://www.amazon.co.jp/gp/"]
+||moviead.cdnext.stream.ne.jp/player/latest/MovieADPlayer.js$domain=yomiuri.co.jp
+yomiuri.co.jp##.home-2020-prime-headline__ad
 yomiuri.co.jp##.p-ad-org-news-txt
+yomiuri.co.jp##[class^="home-2020-ad"]
+yomiuri.co.jp##[id^="ad_dfp_news-txt"]
 nikkansports.com###MiddleAD
 nikkansports.com##.adgiftextlist
 mainichi.jp##.ad-list
@@ -655,9 +683,6 @@ javegg.com##.sidebar > .widget_text.sidebar-wrapper
 ||javhub.net/img/r18_
 ||javhub.net/highporn.html
 ||jav.guru/wp-content/uploads/*/TokyoHentaiClub.jpg
-jadult.net##a[href^="https://goo.gl"]
-jadult.net##a[href^="http://www.adxpansion"]
-jadult.net##.icon_fb
 twi55.com,mindhack2ch.com,vippers.jp,repeat-drama.info##.ad
 mukulog.com##.theContentWrap-ccc > .head-cons2-pc
 mukulog.com##div[id^="side_ad"]
@@ -677,78 +702,10 @@ websearch.rakuten.co.jp###ads-billboard
 websearch.rakuten.co.jp###teamsite-mid-pickup
 websearch.rakuten.co.jp##.section-title1[style="margin-bottom: 10px;"]
 livedoor.jp##.google-user-ad
-nikkeibp.co.jp##.header-banner
-sponichi.co.jp##.heading-pr-relation
 4gamer.net##.hot_game_now
-livedoor.com##.large-showcase
-mainichi.jp##.leftFPR
-mainichi.jp##.leftPR
-mainichi.jp##.leftSPR
-yahoo.co.jp##.lrec
-yomiuri.co.jp##.m-tab
-yomiuri.co.jp##.m-txtad-weekly
-yomiuri.co.jp##.m-txtad2
-impressrd.jp##.microsites_links
-goo.ne.jp##.oshiete-ad
-jp.techcrunch.com##.overture_vertical
-jp.msn.com##.parent.chromeCustom4G
-finance.yahoo.co.jp##.pos-tn.ymuiContainer
-shinobi.jp##.posi1
-shinobi.jp##.posi11
-shinobi.jp##.posi3
-nifty.com##.pr
-yahoo.co.jp##.prTitle
-livedoor.com##.prtextBox
-infoseek.co.jp##.prtxt
-cyzo.com##.r-pr
-nikkeibp.co.jp##.rectangle
-joins.com##.rightBanner
-mtvjapan.com##.rightBannerBlock
-howfile.com##.row1_right
-dmm.co.jp,dmm.com##.sb.rect-banner
-yahoo.co.jp##.seeAllResult
-jp.luxist.com##.shopping
-asylum.jp,japanese.engadget.com##.shopping2
-4gamer.net##.sidetop_extra_H320
-cnn.co.jp##.spBnr08
-infoseek.co.jp##.sponsordisplay
-infoseek.co.jp##.ssnavi
-nikkeibp.co.jp##.sub-banner
-yomiuri.co.jp##.t-shopping
-nifty.com##.textPR
-vippers.jp##.top_space2
-cnn.co.jp##.txtPR
-bikebros.co.jp##.w240
-namakeru.com##[href^="http://linkage-m.net/system/link.php"]
-google.co.jp##[id^="tpa"].tas
-yomiuri.co.jp##[style="margin: 8px 0pt;"]
-yomiuri.co.jp##[style="margin:8px 0 8px;"]
-page2.jp##[style="text-align:left; background-color:#FFFBFF; width:450px; height:50px; font-size:12px; color:#9aa9ac; margin:3px 0 auto 20px; float: right; padding-top:2px;"]
-infoseek.co.jp##[width="300"][height="260"]
-livedoor.jp##a[href="http://blog.livedoor.com/smartphone/dqnplus/"]
-livedoor.jp##a[href="http://cambridge-correction.com"]
-livedoor.jp##a[href^="http://9lick.net"]
-infoseek.co.jp##a[href^="http://c.p-advg.com/"]
 ameblo.jp##a[href^="http://ck.jp.ap.valuecommerce.com/"]
-livedoor.jp##a[href^="http://on.jpn.org/s/"]
-livedoor.jp##a[href^="http://sell4.info/"]
 nifty.com##a[href^="http://track.nifty.com/"]
 livedoor.jp##a[href^="http://track.xmax.jp/"]
-12freeweb.com##a[href^="http://www.adultshoping.com/"]
-12freeweb.com##a[href^="http://www.benri21.com/"]
-himasoku.com##a[href^="http://www.mgstage.jp/"]
-yahoo.co.jp##div[class^="fsst adTyumoku"]
-zdnet.com##div[class^="style_kwad_"]
-search.rakuten.co.jp##div[style="background-color:#1aaeca;text-align:center;"]
-bikebros.co.jp##div[style="float:left; margin-bottom:5px"]
-livedoor.biz##div[style="margin:5px;height:250px;width:300px;"]
-labaq.com##div[style="width: 300px; height: 250px; position: absolute; top: 0px; left: 690px; background-color: #FFFFFF;"]
-rakuten.co.jp##div[style="width:100%;text-align:center;background: #1aaeca url(http://a.ichiba.jp.rakuten-static.com/com/img/thumb/festival/bgimg.gif) repeat-x left top;"]
-livedoor.jp##span[style="line-height:100%;font-size:10px;"]
-google.co.jp##table[style="border: 1px solid #369"]
-rakuten.co.jp##table[width="163"]
-websearch.rakuten.co.jp##table[width="950"]
-yahoo.co.jp##ul[class^="sponsor"]
 ||18ban.jp/ad/
 ||2chan.net/dec/ad/
 ||accesstrade.net/at/

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -36,6 +36,12 @@
 !||i.snssdk.com/log/*
 !||i.snssdk.com/slardar/sdk.js
 !
+||analytics.qlook.net^$third-party
+||analysis.shinobi.jp^
+||asumi.shinobi.jp^
+||ipcheck.blogsys.jp^
+||track.nifty.com^
+||xlisting.jp^$third-party
 ||userreport.com^$third-party
 ||beusable.net^$third-party
 ||ccgateway.net^$third-party

--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -148,6 +148,8 @@ ebay.de#@?#.srp-list > .s-item:has(> div > .s-item__info > a > div[style="displa
 ebay.com,ebay.co.uk,ebay.com.au#@?#div[itemtype="https://schema.org/Product"] div[id^="merch_html_"]:has(> div[id] .mfe-header > h2.mfe-pull-left:contains(Sponsored))
 ebay.com,ebay.co.uk,ebay.com.au#@?#div[itemtype="https://schema.org/Product"] div[id^="merch_html_"]:has(> div[id] h2.mfe-card-group-title:contains(sponsored))
 !
+! Rakuten web search
+websearch.rakuten.co.jp#@##ad-ichiba
 ! epochtimes.de
 epochtimes.de#@##spendPopupBG
 epochtimes.de#@##news-content .buchempfehlung ~ p


### PR DESCRIPTION
I guess I should have separated to two reports. Anyway.
```
! ---------- Obsolete elements
jadult.net##a[href^="https://goo.gl"]
jadult.net##a[href^="http://www.adxpansion"]
jadult.net##.icon_fb
nikkeibp.co.jp##.header-banner
sponichi.co.jp##.heading-pr-relation
livedoor.com##.large-showcase
mainichi.jp##.leftFPR
mainichi.jp##.leftPR
mainichi.jp##.leftSPR
yahoo.co.jp##.lrec
yomiuri.co.jp##.m-tab
yomiuri.co.jp##.m-txtad-weekly
yomiuri.co.jp##.m-txtad2
impressrd.jp##.microsites_links
goo.ne.jp##.oshiete-ad
jp.techcrunch.com##.overture_vertical
jp.msn.com##.parent.chromeCustom4G
finance.yahoo.co.jp##.pos-tn.ymuiContainer
shinobi.jp##.posi1
shinobi.jp##.posi11
shinobi.jp##.posi3
nifty.com##.pr
yahoo.co.jp##.prTitle
livedoor.com##.prtextBox
infoseek.co.jp##.prtxt
cyzo.com##.r-pr
nikkeibp.co.jp##.rectangle
joins.com##.rightBanner
mtvjapan.com##.rightBannerBlock
howfile.com##.row1_right
dmm.co.jp,dmm.com##.sb.rect-banner
yahoo.co.jp##.seeAllResult
jp.luxist.com##.shopping
asylum.jp,japanese.engadget.com##.shopping2
4gamer.net##.sidetop_extra_H320
cnn.co.jp##.spBnr08
infoseek.co.jp##.sponsordisplay
infoseek.co.jp##.ssnavi
nikkeibp.co.jp##.sub-banner
yomiuri.co.jp##.t-shopping
nifty.com##.textPR
vippers.jp##.top_space2
cnn.co.jp##.txtPR
bikebros.co.jp##.w240
namakeru.com##[href^="http://linkage-m.net/system/link.php"]
google.co.jp##[id^="tpa"].tas
yomiuri.co.jp##[style="margin: 8px 0pt;"]
yomiuri.co.jp##[style="margin:8px 0 8px;"]
page2.jp##[style="text-align:left; background-color:#FFFBFF; width:450px; height:50px; font-size:12px; color:#9aa9ac; margin:3px 0 auto 20px; float: right; padding-top:2px;"]
infoseek.co.jp##[width="300"][height="260"]
! Checking href on shared domain like livedoor.jp is not trivial, but these can probably be removed
! The only living link is cambridge-correction and sell4 (but Hindi site?!) but couldn't find href with publicwww & Google.
! Even if there is, outright removing it has potential for FP.
livedoor.jp##a[href="http://blog.livedoor.com/smartphone/dqnplus/"]
livedoor.jp##a[href="http://cambridge-correction.com"]
livedoor.jp##a[href^="http://9lick.net"]
livedoor.jp##a[href^="http://sell4.info/"]
livedoor.jp##a[href^="http://on.jpn.org/s/"]
infoseek.co.jp##a[href^="http://c.p-advg.com/"]
12freeweb.com##a[href^="http://www.adultshoping.com/"]
12freeweb.com##a[href^="http://www.benri21.com/"]
himasoku.com##a[href^="http://www.mgstage.jp/"]
yahoo.co.jp##div[class^="fsst adTyumoku"]
zdnet.com##div[class^="style_kwad_"]
search.rakuten.co.jp##div[style="background-color:#1aaeca;text-align:center;"]
bikebros.co.jp##div[style="float:left; margin-bottom:5px"]
labaq.com##div[style="width: 300px; height: 250px; position: absolute; top: 0px; left: 690px; background-color: #FFFFFF;"]
rakuten.co.jp##div[style="width:100%;text-align:center;background: #1aaeca url(http://a.ichiba.jp.rakuten-static.com/com/img/thumb/festival/bgimg.gif) repeat-x left top;"]
! Even if it's still in use, may cause FP
livedoor.jp##span[style="line-height:100%;font-size:10px;"]
google.co.jp##table[style="border: 1px solid #369"]
rakuten.co.jp##table[width="163"]
websearch.rakuten.co.jp##table[width="950"]
yahoo.co.jp##ul[class^="sponsor"]



! ---------- New cosmetic rules
! Currently this is exactly ads, but it may also be used for other notification so I leave you (extended syntax can be used)
!oshiete.goo.ne.jp##.emergencyArea

bikebros.co.jp,virginbmw.com,virginducati.com,virgintriumph.com##.adsw

! http://bowie0.blog.shinobi.jp/
blog.shinobi.jp##.NinjaEntryCommercial

business.nikkei.com##.cbCxense
business.nikkei.com##section[class^="recommendAd"]

! Ads-only case of popIn
cnn.co.jp###_popIn_recommend

himasoku.com##.article-body-more > .akares
himasoku.com##.himajin-headline
himasoku.com##.netabare

labaq.com###ArticleBottom > span[style="font-size:0.8em;color:#666;clear:both"]
labaq.com###logoad
labaq.com###rightbody > .plugin-memo > .side > div[style^="width: 100%; height: 250px;"]
labaq.com###rightbody > .sideparts_200c + .plugin-memo > .sidetitlebody
labaq.com##div[class^="sideparts_"]

mainichi.jp##.yads

namakeru.com##.customized-header > .entry-header-html
namakeru.com##.entry-footer-html > font[size="1"]
namakeru.com##.hatena-module-html:first-child

! http://aaj2sv4ovn.page2.jp
page2.jp###meerkat-wrap
! e.g. http://tecyo2013.page2.jp
page2.jp,sitemix.jp###sitemix_pr_footer_js

websearch.rakuten.co.jp###ad-ichiba

yomiuri.co.jp##.home-2020-prime-headline__ad
yomiuri.co.jp##[class^="home-2020-ad"]
yomiuri.co.jp##[id^="ad_dfp_news-txt"]



! ---------- New extended rules
! Here I violated standard-rule-only principle, as the placeholders are so large and I had FP in past;
! #?#div:has(> [id^="subAd"]) will look okay at first glance, but causes FP on some subpages, hence matches-css.
finance.yahoo.co.jp#?#div:has(> #mainAdTop)
finance.yahoo.co.jp#?#div:has(> [id^="subAd"]):matches-css(min-height: 250px)
! http://dragate.blog.shinobi.jp/
blog.shinobi.jp#?#article.EntryTextBox:has(#ninja-blog-inactive)
! http://zare.blog.shinobi.jp
blog.shinobi.jp#?#div.EntryInner:has(#ninja-blog-inactive)
! http://happyxmas.blog.shinobi.jp/
blog.shinobi.jp#?#div.EntryBlock:has(#ninja-blog-inactive)
blog.shinobi.jp#?#div.EntryTitle:has(a[href=""]:contains([PR]))


! ---------- New basic rules
! https://search.rakuten.co.jp/search/mall/%E3%83%90%E3%83%83%E3%82%B0/?v=2
||adsrvr.org^$third-party

! himasoku.com
||dlsite.com/js/blogparts.js
||himasoku.com^$subdocument,~third-party

! http://labaq.com/archives/51925533.html
||labaq.com/user/json/lq_amarray.js

! https://www.yomiuri.co.jp/national/20201022-OYT1T50252/
||moviead.cdnext.stream.ne.jp/player/latest/MovieADPlayer.js$domain=yomiuri.co.jp

! https://www.nifty.com/navi/cs/category/level3/147/1.htm
||nifty.com/pubc0m/$script


! ---------- New rules for Spyware
! I don't know if you want to block bug report
! the below is called from popIn and seen in e.g. http://labaq.com/
!||assets-momentum.akamaized.net^

! http://tecyo2013.page2.jp/
! Shouldn't we move the rule below from JP to spyware?
||analytics.qlook.net^$third-party

! http://bowie0.blog.shinobi.jp/
||analysis.shinobi.jp^
||asumi.shinobi.jp^

! http://labaq.com/
||ipcheck.blogsys.jp^

! search.nifty.com
||track.nifty.com^
||xlisting.jp^$third-party


! ---------- New rules for Annoyances
! www.cnn.co.jp
||push.asahiinteractive.com^$third-party

! Only at the first time
websearch.rakuten.co.jp###adblocker-warning-popup

! self-promo banner
||yomiuri.co.jp/assets/images/footer-subscribe/
yomiuri.co.jp##.js-footer-2020-subscribe


! ---------- New rule for Search ads
websearch.rakuten.co.jp#@##ad-ichiba
```