### PR TITLE
Some fixes for JP filter cleanups

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -54,7 +54,6 @@ asahi.com##.p-chumoku
 asahi.com##.p-rectangleAd
 dot.asahi.com##.atclTitleAreaRecommendarticle
 ascii.jp###artAds
-ascii.jp##.lnkBanner
 ascii.jp##.pickwrap
 chunichi.co.jp,tokyo-np.co.jp##.pr
 tokyo-np.co.jp##.header > .cmp-bnr001

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -38,7 +38,6 @@ nanjhistory.2chblog.jp##.kiji-ue-rss
 373news.com##.mns_bn
 ||sponichi.co.jp/adds/*/shopping/sannex_
 ||nifty.com/pubc0m/$script
-koneta.nifty.com###custom_html-2
 ||joins.com/HomeAds/$subdocument
 ||p.net-public.com/js/b.js
 ||seesaa.net/image/loopad*$subdocument,third-party
@@ -139,7 +138,6 @@ dousyoko.net##.plugin2_outline
 dousyoko.net##.plugin3_outline
 ||nikkei.jp^*/f1h_text1.js|
 ||partsa.nikkei.com/static/nkis/js/foneH.js
-business.nikkei.com##.cbCxense
 business.nikkei.com##section[class^="recommendAd"]
 www.nikkei.com##.PRb
 www.nikkei.com##.k-ad__text

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -22,6 +22,8 @@
 ||nd.demdex.net/event?d_mid=$redirect=nooptext,important,domain=9now.com.au
 ||adc.nine.com.au/?token=$redirect=nooptext,important,domain=9now.com.au
 !
+business.nikkei.com##.cbCxense
+koneta.nifty.com###custom_html-2
 ||api.aws.mapquest.com/logger
 ||yuzde100yerli.com/wp-json/pum/v*/analytics/?event=
 ||mysexgames.com/statstracker.php


### PR DESCRIPTION
When I done them, I had Base, Spyware, and Japanese enabled but now noticed `business.nikkei.com##.cbCxense` is placeholder only if Spyware is enabled or `cxense.com` is blocked.

<details>

![bnikkei](https://user-images.githubusercontent.com/58900598/97102535-a7013f80-16e9-11eb-93b6-80bfbd256407.png)

</details>

So I quickly checked the former cleanups too and found this is also the case to `koneta.nifty.com###custom_html-2` (placeholder only if `rtoaster.jp` is blocked). So moved them to Spyware. Also in the check process I happened to come across potential FP by `ascii.jp##.lnkBanner` (link banners to websites of the same corporate group)

<details>

![ascii](https://user-images.githubusercontent.com/58900598/97102546-bd0f0000-16e9-11eb-8935-45267c12a071.png)

</details>

So removed this too.