### PR TITLE
fix #67854 news.biglobe.ne.jp

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -63,6 +63,8 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||caprofitx.com^
+||x-value.net^$third-party
 ||mhub.work^
 ||adpicker.net^
 ||anymind360.com^

--- a/JapaneseFilter/sections/general_elemhide.txt
+++ b/JapaneseFilter/sections/general_elemhide.txt
@@ -1,6 +1,7 @@
 !
 ! Section contains list general hiding rules
 !
+##._popIn_infinite_ad
 ##._popIn_recommend_article_ad
 ##._popIn_recommend_article_ad_reserved
 ##.google-afc-image


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/67854

I see placeholder instead of the PR ads. I think it's okay to make the cosmetic rule generic even for one example, given how widely PopIn is used over Japanese sites.