### PR TITLE
Update #62403 itest.5ch.net

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -63,6 +63,7 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||amoad.com^$third-party
 ||caprofitx.com^
 ||x-value.net^$third-party
 ||mhub.work^

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -400,16 +400,8 @@ m.comic.sportsseoul.com##div[style*="width:100%"][style*="height:100px"]
 winfuture.mobi##iframe[src^="//j.wfcdn.de/j/iframes/outbrain_"]
 setfilmizle.vip##.menu_alti_reklam_mobil
 m.imdb.com##.cornerstone_slot
-itest.5ch.net###instant_ad
-itest.5ch.net###js-bottom-ad-300x250
-itest.5ch.net###js-bottom-ad-320x250
-itest.5ch.net###js-cardview_ad
 itest.5ch.net##.js-cardview_ad-320x180 > iframe
-itest.5ch.net##.js-cardview_ad-320x50
-itest.5ch.net##.js-overlay_ad
-itest.5ch.net##.ad_320x50
 itest.5ch.net##div[class^="sproutad_"]
-itest.5ch.net##.res_ad
 thenewsminute.com##.view-ads
 thenewsminute.com##amp-iframe#prebid-user-sync
 purepc.pl##a[databx][href*="/red1r.php"]


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/pull/62403
Removed cosmetic filters added to EL as generic ones and added an unblocked adserver.

URL: `http://itest.5ch.net/test/read.cgi/android/1604314941/`

<details>
<summary>Screenshot</summary>

![itest](https://user-images.githubusercontent.com/58900598/99553250-48399800-2a01-11eb-9105-88d24523c8a2.png)

</details>