### PR TITLE
Update #67965 famitsu.com

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -5,6 +5,7 @@
 !
 ||feed.mikle.com^$domain=blog.livedoor.jp|crx7601.com|fate-rpg.jp|gadgetlife2ch.blomaga.jp|gtoys.blog.fc2.com|h1g.jp|hdouga.com|ibarakinews.jp|obutu.com|totalwar.doorblog.jp|xn--bckadddb2a0d4dnc8dwhngdtb58aya0l4a2om843g5npczp7dwh5g.com|xn--cckea5a6cidcbh6ce7ghug17a2ge3aht3nwigef51658aw7kd.com
 !
+famitsu.com##.article-body__contents-pr-primary
 famitsu.com##.banner-lg-rect-haf-page
 famitsu.com##.banner-footer-rect-container
 ||popin.cc/popin_video6_ads-min.js


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/67965

Missed fix for a reported placeholder:

<details>

![famitsu](https://user-images.githubusercontent.com/58900598/99784567-58678980-2b5f-11eb-8b64-7193bf06e3e9.png)

</details>