### PR TITLE
fix placeholder and annoyances on blog.goo.ne.jp (mobile)

### DIFF
--- a/AnnoyancesFilter/sections/mobile-app.txt
+++ b/AnnoyancesFilter/sections/mobile-app.txt
@@ -18,6 +18,8 @@ amp-reddit-com.cdn.ampproject.org##.AppSelectorModal__body
 reddit.com#$#.XPromoPopup { display: none!important; }
 reddit.com#$#body.scroll-disabled { overflow: visible!important; position: static!important; }
 !
+||xgoo.jp/img/portal/misc/footer_app_recommend/
+blog.goo.ne.jp##.app_induction
 m.hurriyet.com.tr##a[href="https://link-to.app/egazete-banner"] > img
 zona.plus##div[id="zona-android"]
 mobi.yahoo.com###header-2-GoldenGate-Proxy

--- a/AnnoyancesFilter/sections/self-promo.txt
+++ b/AnnoyancesFilter/sections/self-promo.txt
@@ -45,6 +45,8 @@ realty.yandex.ru##.Offer__taxiBannerContainer
 !-----------------------------------------------
 !
 !
+! Mobile-only e.g. https://blog.goo.ne.jp/monplacard
+blog.goo.ne.jp##.navbar__link--bottom
 ! When logged out from rakuten
 member.id.rakuten.co.jp###recommendService
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66724

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -56,6 +56,7 @@ amp.n-tv.de,dni.ru,independent.co.uk,komputerswiat.pl,dobreprogramy.pl,amp.pcwel
 ! ##.inline-ad-container
 avclub.com,clickhole.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotaku.com,lifehacker.com,splinternews.com,theinventory.com,theonion.com,theroot.com,thetakeout.com##.inline-ad-container
 !
+blog.goo.ne.jp##.article__hideads
 m.hurriyet.com.tr##a[href^="http://www.mobilbilgiservisleri.com/lp"] > img
 withinnigeria.com##div[data-adid]
 metruyenchu.com##main > section.nh-section > div.text-center.bg-light


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 
`https://blog.goo.ne.jp/monplacard`

1. ad placeholder
2. mobile app banner
3. self-promo banner

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![goo2](https://user-images.githubusercontent.com/58900598/100087278-d98d8c00-2e91-11eb-94f1-2162cee3d810.png)

![goo3](https://user-images.githubusercontent.com/58900598/100087287-dc887c80-2e91-11eb-9f9b-233fc1bda0d1.png)

![goo1](https://user-images.githubusercontent.com/58900598/100087290-de524000-2e91-11eb-8fa9-ef25e7d5b8e2.png)

</details><br/>

***Steps to reproduce the problem***:

Visit the site

***System configuration***

**Filters:**

Base, Mobile, Tracking, Japanese, and Annoyances

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Firefox 83.0 disguised as mobile UA (reproducible with real Firefox Android too)
AdGuard version:                       | 3.5.23
AdGuard DNS:                           | None

