### PR TITLE
fix www.allcinema.net ads

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -63,6 +63,7 @@
 ! Eimg.jp
 ||adingo.jp.eimg.jp^
 !
+||gyro-n.com^$third-party
 ||amoad.com^$third-party
 ||caprofitx.com^
 ||x-value.net^$third-party

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -9,6 +9,7 @@
 !
 ||feed.mikle.com^$domain=blog.livedoor.jp|crx7601.com|fate-rpg.jp|gadgetlife2ch.blomaga.jp|gtoys.blog.fc2.com|h1g.jp|hdouga.com|ibarakinews.jp|obutu.com|totalwar.doorblog.jp|xn--bckadddb2a0d4dnc8dwhngdtb58aya0l4a2om843g5npczp7dwh5g.com|xn--cckea5a6cidcbh6ce7ghug17a2ge3aht3nwigef51658aw7kd.com
 !
+||allcinema.net/js/min.ad.js
 jprealtime.com##.video-plugin-for-adv > div.video-plugin-div.flex-video.widescreen
 ||cdn.r18hub.com/assets/videos/$domain=yavtube.com
 yavtube.com##.fluid_initial_play.transform-active


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

`https://www.allcinema.net/`

Ads

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![allcinema net](https://user-images.githubusercontent.com/58900598/100338807-6c5a3200-301c-11eb-9540-b6e72a067f67.png)

</details><br/>

***Steps to reproduce the problem***:

Reload MANY times (I did more than dozen times to reproduce)

***System configuration***

**Filters:**

Base, Tracking, and Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Brave 1.17.73
AdGuard version:                       | 3.5.20
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
