### PR TITLE
Remove stockmann.com cookie dialog and allow scrolling

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -5056,8 +5056,8 @@ vi.nl#%#AG_onLoad(function() { if(window.location.href.indexOf("cookies") != -1)
 volkskrant.nl#%#AG_onLoad(function() { setTimeout(function() {if(document.getElementsByClassName("modal-overlay")[0].isvisible = true){document.getElementsByClassName("button button--accept")[0].click();}}, 300); });
 ziekenhuis.nl#%#AG_onLoad(function() { setTimeout(function() {var check = document.getElementsByClassName('cookiewall')[0]; if (check){document.cookie = "acceptcookies=true"; location.reload();}; }, 300); });
 !
-stockmann.com#$#body { position: static; }
-stockmann.com##div.cookie-dialog-screen.open
+stockmann.com#$#body { position: static!important; }
+stockmann.com#$#.cookie-dialog-screen { display: none!important; }
 !
 ! HTML rules
 !

--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -5056,6 +5056,9 @@ vi.nl#%#AG_onLoad(function() { if(window.location.href.indexOf("cookies") != -1)
 volkskrant.nl#%#AG_onLoad(function() { setTimeout(function() {if(document.getElementsByClassName("modal-overlay")[0].isvisible = true){document.getElementsByClassName("button button--accept")[0].click();}}, 300); });
 ziekenhuis.nl#%#AG_onLoad(function() { setTimeout(function() {var check = document.getElementsByClassName('cookiewall')[0]; if (check){document.cookie = "acceptcookies=true"; location.reload();}; }, 300); });
 !
+stockmann.com#$#body { position: static; }
+stockmann.com##div.cookie-dialog-screen.open
+!
 ! HTML rules
 !
 m.timesofindia.com,m-timesofindia-com.cdn.ampproject.org$$amp-consent


### PR DESCRIPTION
***Description***:
Remove stockmann.com cookie dialog and allow scrolling

* **Current behaviour**: 

Cookie dialog shows and not able to scroll.

* **Expected behaviour**: 

No dialog.

* **Fix**:

Filter out the cookie div and allow scrolling on body. They use "position": fixed; to disable scrolling and take it away when dialog is accepted.

***System configuration***

**Filters:**

AdGuard Annoyances filter
Fanboy's Annoyances


Information                            | Value
---                                    | ---
Operating system:                      | iOS, Mac
Browser:                               | Safari
AdGuard version:                       | 1.8.6
Filters enabled:                       | yes
Simplified filters (iOS only)          | Off
AdGuard DNS:                           | None 

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
