### PR TITLE
Fix #69089 ithome.com

### DIFF
--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -1000,8 +1000,9 @@ inmywordz.com##.acca-block
 manhuaren.com###lb-win
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69089
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62199
-ithome.com#?#.t-b.sel > ul.nl > li:has(> a[href*="/lapin."])
-ithome.com#$?##nnews > .t-b > ul.nl:nth-child(even):has(> li[style="display: none !important;"] ~ li[style="display: none !important;"]) { margin-bottom: 35px !important; }
+! https://gist.github.com/AdamWr/f9e43774da32b1e6389c122fd8a73aa5#file-ithome_fix_empty_spaces-js
+ithome.com#$?#.t-b.sel > ul.nl > li:has(> a[href*="/lapin."]) { remove: true; }
+ithome.com#%#AG_onLoad(function(){var elements=document.querySelectorAll("#nnews > .t-b > ul.nl:nth-child(even):not([style])");if(elements.length>0){var a=new MutationObserver(function(){elements.forEach(function(el){if(el.previousElementSibling)if(el.previousElementSibling.childElementCount>el.childElementCount){var marginBottomValue=35*(el.previousElementSibling.childElementCount-el.childElementCount);el.style.marginBottom=marginBottomValue+"px"}})});a.observe(document,{childList:!0,subtree:!0})}});
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62452
 @@||potalapalace.cn/upload/images/advertise/picture/131030000583.jpg
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61686


### PR DESCRIPTION
Issue - https://github.com/AdguardTeam/AdguardFilters/issues/69089
Code - https://gist.github.com/AdamWr/f9e43774da32b1e6389c122fd8a73aa5#file-ithome_fix_empty_spaces-js

This problem occurs only if right column (one of the `#nnews > .t-b > ul.nl` elements) has less rows/children than the left column.
It seems that it depends on layout and it doesn't happen every time, sometimes is necessary to change a page (buttons with number at the bottom of the screenhot), sometimes it doesn't occur at all.
I tried to fix it with CSS rule, but it didn't work in all cases, maybe you will have a better idea.

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/101100292-8bc9ff80-35c6-11eb-966c-32312a68dc5b.png)

</details>