### PR TITLE
tumblr.com removed few outdated(?) rules

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -938,7 +938,6 @@ corrierecomunicazioni.it##.cookie-body-background
 hopkinssports.com##.sidearm-gdpr-modal
 kap-3.de,p4web.de###fhw_cookiehinweis
 bbc.com##header[role="banner"] > div[dir="rtl"]
-||tumblr.com/dashboard/iframe/consent
 airfrance.am,airfrance.be,airfrance.bf,airfrance.bg,airfrance.bj,airfrance.ca,airfrance.cd,airfrance.cg,airfrance.ch,airfrance.cl,airfrance.co.ao,airfrance.co.il,airfrance.co.jp,airfrance.co.kr,airfrance.co.th,airfrance.co.uk,airfrance.com,airfrance.com.br,airfrance.com.cn,airfrance.com.co,airfrance.com.eg,airfrance.com.hk,airfrance.com.kh,airfrance.com.lb,airfrance.com.mx,airfrance.com.tw,airfrance.com.uy,airfrance.cz,airfrance.de,airfrance.es,airfrance.fr,airfrance.gf,airfrance.gp,airfrance.ht,airfrance.hu,airfrance.id,airfrance.it,airfrance.mq,airfrance.mu,airfrance.my,airfrance.nc,airfrance.ne,airfrance.pa,airfrance.pe,airfrance.pf,airfrance.pl,airfrance.pt,airfrance.re,airfrance.ro,airfrance.ru,airfrance.sa,airfrance.sg,airfrance.si,airfrance.tg,airfrance.ua,airfrance.us,airfrance.vn#$##gdpr_popin { display: none!important; }
 airfrance.am,airfrance.be,airfrance.bf,airfrance.bg,airfrance.bj,airfrance.ca,airfrance.cd,airfrance.cg,airfrance.ch,airfrance.cl,airfrance.co.ao,airfrance.co.il,airfrance.co.jp,airfrance.co.kr,airfrance.co.th,airfrance.co.uk,airfrance.com,airfrance.com.br,airfrance.com.cn,airfrance.com.co,airfrance.com.eg,airfrance.com.hk,airfrance.com.kh,airfrance.com.lb,airfrance.com.mx,airfrance.com.tw,airfrance.com.uy,airfrance.cz,airfrance.de,airfrance.es,airfrance.fr,airfrance.gf,airfrance.gp,airfrance.ht,airfrance.hu,airfrance.id,airfrance.it,airfrance.mq,airfrance.mu,airfrance.my,airfrance.nc,airfrance.ne,airfrance.pa,airfrance.pe,airfrance.pf,airfrance.pl,airfrance.pt,airfrance.re,airfrance.ro,airfrance.ru,airfrance.sa,airfrance.sg,airfrance.si,airfrance.tg,airfrance.ua,airfrance.us,airfrance.vn#$#body[style] { overflow: visible!important; position: static!important; }
 softlist.com.ua##.cookie-notify-block
@@ -1081,7 +1080,6 @@ radio-internetowe.com##body > #cc
 freeyou.ag#$#.cookies { display: none !important; }
 motionarray.com##.site-accept-tos-warning
 inc.com##div[class*="privacyPolicyPopup"]
-tumblr.com##.tmblr-iframe--gdpr-banner
 definition-of.com##body > div[style="z-index:9900;position:relative"]:not([class]):not([id])
 thekitchn.com##.GdprBanner
 bynogame.com##.cookie_agreements

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -362,6 +362,9 @@ reclaimthenet.org#?#.ezoic-ad
 temp-mail.org#?#.inbox-dataList > ul > li[class]:has(> div[class="col-box"] > a > span.inboxSenderEmail:contains(/^ad\s*\|.*|^AD\s*\|.*/))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52861
 android-x86.org#?#section > h6:contains(Advertisement)
+! https://github.com/AdguardTeam/AdguardFilters/issues/59259
+! https://github.com/AdguardTeam/AdguardFilters/issues/52326
+tumblr.com#?##base-container main div:not([class]):not([id]) > div[class^="_"]:not([data-id]):has(.iab_sf)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52376
 djmag.com#?#._section--row > ._teaser--container--MPU:has(> ._teaser--MPU > .pane-djmag-advert-responsive-pane)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52221

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -1177,7 +1177,7 @@ tube8.com#?##flvplayer > div[id]:has(> div[id] > div[id] > ins.adsbytrafficjunky
 teslarati.com#?#body div[class^="ntv-"]:not([class="ntv-title"]):has(a.ntv-headline-anchor)
 mangaworld.cc#?#.container > div.row > div.col-sm-12 > div.row:has(> div.col-md-12 > div.ads)
 indy100.com#?#header ~ div:matches-css(height: 250px)
-tumblr.com#?#div:has(> h1:contains(Спонсируется))
+tumblr.com#?##base-container aside > div[class^="_"] > div[class^="_"] > div[class^="_"] > div[class^="_"] > h1 + div[class] > div[class^="_"] div.iab_sf:upward(4)
 fapality.com##.nativeaside > div.page_second_title:contains(Advertisement)
 submityourflicks.com#?#.twocolumns > div.aside:has(> div[align="center"] > b:contains(Advertisements))
 hotscope.tv#?#div[class]:has(> a[target="_blank"] > div[class] > button[tabindex="0"] > div[class] > p:contains(Advertisement))

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -189,8 +189,6 @@ washingtontimes.com#?#.block-content > .article-position-render:has(> .page-head
 washingtontimes.com#?#body > div[align="center"][style^="height: 90px"]:has(> .ad-slot)
 washingtontimes.com#?#.aside-inner > .block:has(> .block-content > .sponsored-container)
 washingtontimes.com#?#.aside-inner > .block:has(> .block-content > script[data-paid-clicks])
-! https://github.com/AdguardTeam/AdguardFilters/issues/60847
-tumblr.com#?#div[class^="_"][tabindex] > div[tabindex] > div:has(> a[href="http://primevideo.tumblr.com"] ~ div > a[href$="/relevantads"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60995
 unity3diy.blogspot.com#?##sidebar > div.widget:has(> div.widget-content > ins.adsbygoogle)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60795
@@ -364,10 +362,6 @@ reclaimthenet.org#?#.ezoic-ad
 temp-mail.org#?#.inbox-dataList > ul > li[class]:has(> div[class="col-box"] > a > span.inboxSenderEmail:contains(/^ad\s*\|.*|^AD\s*\|.*/))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52861
 android-x86.org#?#section > h6:contains(Advertisement)
-! https://github.com/AdguardTeam/AdguardFilters/issues/59259
-! https://github.com/AdguardTeam/AdguardFilters/issues/52326
-tumblr.com#?##base-container aside > div[class^="_"]:has(> div[class^="_"] > h1 + div[class] > div[class^="_"] > div.iab_sf)
-tumblr.com#?##base-container main div:not([class]):not([id]) > div[class^="_"]:not([data-id]):has(.iab_sf)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52376
 djmag.com#?#._section--row > ._teaser--container--MPU:has(> ._teaser--MPU > .pane-djmag-advert-responsive-pane)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52221
@@ -1180,6 +1174,7 @@ tube8.com#?##flvplayer > div[id]:has(> div[id] > div[id] > ins.adsbytrafficjunky
 teslarati.com#?#body div[class^="ntv-"]:not([class="ntv-title"]):has(a.ntv-headline-anchor)
 mangaworld.cc#?#.container > div.row > div.col-sm-12 > div.row:has(> div.col-md-12 > div.ads)
 indy100.com#?#header ~ div:matches-css(height: 250px)
+tumblr.com#?#div:has(> h1:contains(Спонсируется))
 fapality.com##.nativeaside > div.page_second_title:contains(Advertisement)
 submityourflicks.com#?#.twocolumns > div.aside:has(> div[align="center"] > b:contains(Advertisements))
 hotscope.tv#?#div[class]:has(> a[target="_blank"] > div[class] > button[tabindex="0"] > div[class] > p:contains(Advertisement))

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -1286,7 +1286,6 @@ pinkvilla.com##li[id^="sideBarAd"]
 pinkvilla.com##div[id^="gptTag"]
 stackshare.io##div[data-testid="Squib"] > a[rel="nofollow"] > img
 pkmods.com###leader-wrapper
-tumblr.com##div[class^="_"][tabindex] > div[tabindex] > div > div ~ a[href="http://primevideo.tumblr.com"][target="_blank"]
 autofaucet.dutchycorp.space##.hide-on-med-and-down > div[style="text-align:center"] > a[onmousedown^="$(this).attr('href',"]
 canyoublockit.com##a[href="ad.com"]
 canyoublockit.com##iframe[src^="//ds88pc0kw6cvc.cloudfront.net/"]


### PR DESCRIPTION
It seems to me these rules do nothing at the moment for tumblr.com: 
```
tumblr.com##.tmblr-iframe--gdpr-banner
||tumblr.com/dashboard/iframe/consent
tumblr.com#?#div[class^="_"][tabindex] > div[tabindex] > div:has(> a[href="http://primevideo.tumblr.com"] ~ div > a[href$="/relevantads"])
tumblr.com#?##base-container aside > div[class^="_"]:has(> div[class^="_"] > h1 + div[class] > div[class^="_"] > div.iab_sf)
tumblr.com##div[class^="_"][tabindex] > div[tabindex] > div > div ~ a[href="http://primevideo.tumblr.com"][target="_blank"]
```

Also removing "Sponsored" block to the right
`tumblr.com#?#div:has(> h1:contains(Спонсируется))`