### PR TITLE
Fix #70107 mv12.site

### DIFF
--- a/SpanishFilter/sections/general_extensions.txt
+++ b/SpanishFilter/sections/general_extensions.txt
@@ -21,7 +21,7 @@ drivelinks.me,pclinks.site,pelislinks.me#%#(function(){if(-1<window.location.hre
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66187
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70107
 ! https://gist.github.com/AdamWr/baad2e6e9cf8ea4eabcf9a4cf9a2fa37
-mv12.site#%#AG_onLoad(function(){setTimeout(function(){if("undefinded"!==typeof e&&"string"===typeof e&&e.startsWith("http")){a:{try{new URL(e)}catch(b){var a=!1;break a}a=!0}a&&(window.location=e)}},500)});
+mv12.site#%#AG_onLoad(function(){setTimeout(function(){if("undefined"!==typeof e&&"string"===typeof e&&e.startsWith("http")){a:{try{new URL(e)}catch(b){var a=!1;break a}a=!0}a&&(window.location=e)}},500)});
 temparchive.com#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66106
 megadescarga.net#%#//scriptlet("set-constant", "clicked", "true")

--- a/SpanishFilter/sections/general_extensions.txt
+++ b/SpanishFilter/sections/general_extensions.txt
@@ -19,6 +19,9 @@ hentaiporno.xxx#%#//scriptlet("set-constant", "vidorev_jav_plugin_video_ads_obje
 ! https://github.com/AdguardTeam/AdguardFilters/issues/67054
 drivelinks.me,pclinks.site,pelislinks.me#%#(function(){if(-1<window.location.href.indexOf("s.php?i=")){var a=location.href.split("s.php?i=");if(a&&a[1]){a=a[1];for(var c=0;10>c;c++)try{a=atob(a)}catch(f){var d=a.replace(/[a-zA-Z]/g,function(b){return String.fromCharCode(("Z">=b?90:122)>=(b=b.charCodeAt(0)+13)?b:b-26)});try{new URL(d);var e=!0}catch(b){e=!1}if(e){window.location=d;break}}}}})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66187
+! https://github.com/AdguardTeam/AdguardFilters/issues/70107
+! https://gist.github.com/AdamWr/baad2e6e9cf8ea4eabcf9a4cf9a2fa37
+mv12.site#%#AG_onLoad(function(){setTimeout(function(){if("undefinded"!==typeof e&&"string"===typeof e&&e.startsWith("http")){a:{try{new URL(e)}catch(b){var a=!1;break a}a=!0}a&&(window.location=e)}},500)});
 temparchive.com#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66106
 megadescarga.net#%#//scriptlet("set-constant", "clicked", "true")


### PR DESCRIPTION
Issue - https://github.com/AdguardTeam/AdguardFilters/issues/70107
Code - https://gist.github.com/AdamWr/baad2e6e9cf8ea4eabcf9a4cf9a2fa37

Steps to reproduce:
1. Go here -  [https://www.pcprogramasymas.net/windows-7-sp1-ultimate-6in1-aio-x32-x64espanoldiciembre-2020gen2/](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https%3A%2F%2Fwww.pcprogramasymas.net%2Fwindows-7-sp1-ultimate-6in1-aio-x32-x64espanoldiciembre-2020gen2%2F)
2. Click on any link to download file
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/102487622-274d7c80-406b-11eb-89d7-25da7a09b102.png)

</details>

3. New tab will be opened and it requires to click on an ad to be redirected to destination page.

It seems that destination page is defined in `e` variable.
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/29142494/102487936-9925c600-406b-11eb-8c92-e2d5603ccb15.png)

</details>