### PR TITLE
fix myhdjav.net popup

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -9,6 +9,7 @@
 !
 ||feed.mikle.com^$domain=blog.livedoor.jp|crx7601.com|fate-rpg.jp|gadgetlife2ch.blomaga.jp|gtoys.blog.fc2.com|h1g.jp|hdouga.com|ibarakinews.jp|obutu.com|totalwar.doorblog.jp|xn--bckadddb2a0d4dnc8dwhngdtb58aya0l4a2om843g5npczp7dwh5g.com|xn--cckea5a6cidcbh6ce7ghug17a2ge3aht3nwigef51658aw7kd.com
 !
+||myhdjav.net/pop.js
 media.moneyforward.com##div[data-ads]
 ||news.2chblog.jp/headline1.htm
 ||news.2chblog.jp/headline2.htm


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL: `https://www1.myhdjav.net/`
Issue: popup on clicking thumbnails

***System configuration***

**Filters:**

Base, TPL, and Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Win 10
Browser:                               | Brave 1.18.70
AdGuard version:                       | 3.5.25
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
