### PR TITLE
jav.direct - leftover [NSFW]

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -493,7 +493,7 @@ blog.esuteru.com##.article-main .rss.clearfix
 shopping.yahoo.co.jp##.mdNorthBuyee
 ||macotakara.jp/banaer/
 macotakara.jp##iframe[src^="http://ad.jp.ap.valuecommerce.com"]
-javmix.tv##.__isboostOverContent
+jav.direct,javmix.tv##.__isboostOverContent
 top.togeko.net##a[href^="https://book.dmm.co.jp"]
 ||top.togeko.net/*/randomad*.js
 ||cowboy.blog.jp/main/rss*.html


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

URL: `https://jav.direct/censored/stars-310/`
Ad leftover

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![javdirect](https://user-images.githubusercontent.com/58900598/103165340-bb80c600-4859-11eb-9df2-c8fe11bb0745.png)

</details><br/>

***Steps to reproduce the problem***:

Visit the site

***System configuration***

**Filters:**

Base, TPL, & Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Win 10
Browser:                               | Brave 1.18.75
AdGuard version:                       | 3.5.31
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
