### PR TITLE
fix #70440 nytimes.com

### DIFF
--- a/AnnoyancesFilter/sections/popups.txt
+++ b/AnnoyancesFilter/sections/popups.txt
@@ -107,8 +107,6 @@ blograffo.net#$#.pum-overlay[data-popmake*="blograffo-telegram"] { display: none
 siberkalem.com#$##popup-box { display: none !important; }
 siberkalem.com#$#body { overflow: visible !important; }
 tweaktown.com##.newsletter-overlay
-nytimes.com#$#.ReactModalPortal { display: none!important; }
-nytimes.com#$#body { overflow: visible!important; position: static!important; }
 stanleyblackanddecker.com###popup-salesforce-signup
 twitter.com#?##layers > div[class] > div[class] > div[class] > div[class]:has(> div[class] > div[class] > div[class] > div[class] > div[class] > a[href="/login"])
 devcourseweb.com##body .brave_popup


### PR DESCRIPTION
#70440

Короткий промо-попап лежит на общих модальных окнах с меню логина и мобильным меню.