### PR TITLE
Update #67960 bbc.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -427,7 +427,7 @@ mobilenet.cz##.sys-alert
 ||privacy.selbst.de^
 ||baseendpoint.stern.de^
 leaflets.kaufland.com##.c-cookieconsent
-bbc.com##header[role="banner"] > div[dir="ltr"][class*="-Wrapper "]:not([class*="-Banner"])
+bbc.com##header[role="banner"] div[dir="ltr"][class*="-Wrapper "]:not([class*="-Banner"])
 nudiejeans.com##div[aria-label="Cookie bar"]
 peek-cloppenburg.at#$#.cw-modal-overlay { display: none !important; }
 peek-cloppenburg.at#$#.cookie-wall { display: none !important; }


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/67960
`https://www.bbc.com/japanese`
Now there's another div under `header[role="banner"]`:

<details>
<summary>Screenshot</summary>

![bbc](https://user-images.githubusercontent.com/58900598/105685417-622fb380-5f39-11eb-9a9b-c109e97612f9.png)

</details>