### PR TITLE
Block Canvas LMS tracking

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1937,3 +1937,14 @@ link.gmapp*.net$image
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69722
 ||digikey.com^$removeparam=/^mkt_tok/
 ||digikey.com^$removeparam=/^utm_cid/
+
+! Canvas LMS tracking
+canvas.*.edu/page_views
+canvas.*.edu.*/page_views
+canvas.*.ac.*/page_views
+*.instructure.com/page_views
+
+canvas.*.edu/api/v1/courses/*/ping
+canvas.*.edu.*/api/v1/courses/*/ping
+canvas.*.ac.*/api/v1/courses/*/ping
+*.instructure.com/api/v1/courses/*/ping


### PR DESCRIPTION
There seem to be two "problematic" `POST` requests—to `/page_views` and to `/api/v1/courses/*/ping`. I've added four entries for each, guessing some common canvas domains.