### PR TITLE
redtube.net

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -565,7 +565,7 @@ evades.io#%#//scriptlet("set-constant", "adBlockerDetected", "false")
 @@||talkceltic.net/forums/js/Siropu/AM/ads.min.js
 ||yourdictionary.com/scripts/googleFundingChoices.js
 @@||hometheaterforum.com/community/js/siropu/am/ads.min.js
-redtube.com###ab_banner
+redtube.com,redtube.net###ab_banner
 sokakyemekleri.com##.blocker-notice
 creatur.io#%#//scriptlet("set-constant", "canRunAds", "true")
 soft98.ir##body > div.toast
@@ -1655,7 +1655,7 @@ gamekings.tv##.addblocker-detected
 nowloading.co##.supplication
 @@||assets.nowloading.co/js/vendor/advertising.js^
 gismeteo.ru##div[class^="stopblock"]
-nowvid.online,adsurl.co,imtranslator.net,up-4ever.org,jigsawplanet.com,nissan.webstarterz.com,redtube.com,apkmaza.net,vox.com,adsme.cc,dailybreeze.com,theoaklandpress.com,reviewjournal.com,trentonian.com,twincities.com,macombdaily.com,delcotimes.com,eastbaytimes.com,mercurynews.com,ocregister.com,denverpost.com,hdzog.com,wowturkey.com,autoblog.com,technews.tw,newsnow.co.uk#@#.adsbox
+nowvid.online,adsurl.co,imtranslator.net,up-4ever.org,jigsawplanet.com,nissan.webstarterz.com,redtube.com,redtube.net,apkmaza.net,vox.com,adsme.cc,dailybreeze.com,theoaklandpress.com,reviewjournal.com,trentonian.com,twincities.com,macombdaily.com,delcotimes.com,eastbaytimes.com,mercurynews.com,ocregister.com,denverpost.com,hdzog.com,wowturkey.com,autoblog.com,technews.tw,newsnow.co.uk#@#.adsbox
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=emucr.com
 @@||telepolis.pl/js/ads_adv_telepolis_skrypt.js
 @@||weheartit.com/ads.js^

--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -2146,7 +2146,7 @@ msnbc.com,nbcnews.com###cx_bottom_banner
 europepmc.org###data-protection-banner
 2whois.ru###disclaimer
 youporn.com###euCookieModal
-redtube.com###eu_cookie_disclaimer
+redtube.com,redtube.net###eu_cookie_disclaimer
 abetterrouteplanner.com###eula-div
 majorsoft.eu,malnapc.hu,netenpiac.hu,profikisgep.hu###firstLogNanobar
 mql5.com###floatVerticalPanel

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -4065,7 +4065,7 @@ kissanime.si#%#AG_setConstant('check_adblock', 'true');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31232
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11379
 @@||media.trafficjunky.net/__js/test.js
-@@||media.trafficjunky.net/js/holiday-promo.js$domain=redtube.com|tube8.com|youporn.com
+@@||media.trafficjunky.net/js/holiday-promo.js$domain=redtube.com|redtube.net|tube8.com|youporn.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30592
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||yesmoviesapp.info^$generichide

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -1049,7 +1049,7 @@ seriouseats.com#?#.sidebar > div[id^="sidebar-bng-"][-ext-has='.ad-wrapper']
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13834
 cryptomininggame.com#?#.col-lg-3 > .panel:has(>.panel-heading > h2:contains(Advertisements))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43649#issuecomment-551265457
-redtube.com#?##content_container div[class]:has(> div > a.ad-link)
+redtube.com,redtube.net#?##content_container div[class]:has(> div > a.ad-link)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13223
 wuxiaworld.com#?#.row > .col-md-4 > #widget_0:has(>.panel-heading:contains(Advertisement))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/12653

--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -3532,8 +3532,8 @@ dvbtmap.eu#$##content-container { margin-top: 0!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10712
 bitfun.co#$#div[class^="flex"][class*="Ad"] { position: absolute!important; left: -2000px!important; } 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11379
-redtube.com#$#.video_left_section > .hd .subtxt {position: absolute!important; left: -3000px!important; }
-redtube.com#$#.remove_ads {position: absolute!important; left: -3000px!important; }
+redtube.com,redtube.net#$#.video_left_section > .hd .subtxt {position: absolute!important; left: -3000px!important; }
+redtube.com,redtube.net#$#.remove_ads {position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11187
 pictame.com#$#.grid > .panel.clearfix.social-entry.text-center[style*="padding: 0px; min-height:"] { visibility: hidden!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10914
@@ -3838,9 +3838,9 @@ techpowerup.com#$#body { background-image: none !important; background-color: #f
 ! https://forum.adguard.com/index.php?threads/www-c8-fr.15884/
 c8.fr#$#body { cursor:default!important; }
 ! https://forum.adguard.com/index.php?threads/16347/
-redtube.com#$#.video-listing.two-in-row { width: 100% !important; }
-redtube.com#$#.video-listing.two-in-row > li.first-in-row:nth-child(4n-1) { clear: none !important; margin-left: 25px !important; }
-redtube.com#$#.tja { position: absolute!important; left: -3000px!important; }
+redtube.com,redtube.net#$#.video-listing.two-in-row { width: 100% !important; }
+redtube.com,redtube.net#$#.video-listing.two-in-row > li.first-in-row:nth-child(4n-1) { clear: none !important; margin-left: 25px !important; }
+redtube.com,redtube.net#$#.tja { position: absolute!important; left: -3000px!important; }
 ! https://forum.adguard.com/index.php?threads/16312/
 intoday.in#$#.ad-withborder { position: absolute!important; left: -3000px!important; }
 intoday.in#$#.ad_bn { position: absolute!important; left: -3000px!important; }

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -1493,8 +1493,8 @@ moomoo.io###adCard
 moomoo.io##div[style^="width:728px;"][style*="margin-top:10px;"]
 ||hclips.com/qeeen/
 ||txxx.com/erbrightni/
-youporn.com,pornhub.com,redtube.com##.adsbytrafficjunky
-redtube.com##.videos_grid > li:not([class*="js_thumbContainer"]):not([class*="_"])
+youporn.com,pornhub.com,redtube.com,redtube.net##.adsbytrafficjunky
+redtube.com,redtube.net##.videos_grid > li:not([class*="js_thumbContainer"]):not([class*="_"])
 pornhd.com##.video-list-corner-ad
 cbc.ca##.ad-risingstar-container
 bonusbitcoin.co##div[style="text-align:center;margin-bottom:10px;height:300px"]
@@ -3290,7 +3290,7 @@ inoreader.com##.ad_size_leaderboard
 inoreader.com##.leaderboard_ad
 imgbaron.com,picbaron.com##iframe[src^="//a.exosrv.com/"]
 ||toots-a.akamaihd.net/priority/*.mp4$redirect=noopmp4-1s,media,xmlhttprequest,domain=itv.com
-redtube.com##.search_upper_right_ad
+redtube.com,redtube.net##.search_upper_right_ad
 spankwire.com###js-react-player-ad-under
 hentaiworld.tv,hentaiworld.info##.support-ad
 watchanime.video,animeporn.tube,hentaiporn.tube,hentaivideo.tv,naughtyhentai.com,hentaianime.tv,pornxxx.tv,cartoonporn.tv,hentaimovie.tv###myContent
@@ -5106,7 +5106,7 @@ digit.in##.inside-container > .gift > a[href^="https://www.digit.in/tracker/"][t
 uploadocean.com##a[href^="https://uploadocean.com/downloadfile/search.php"]
 sexwebvideo.me##.uk-navbar-nav > li > a[href^="https://p.hecams.com/"]
 sexwebvideo.me##.page-header > a[href^="https://bongacams.com/track?"]
-redtube.com###top_main_menu > li > a[id^="paid_tab_"]
+redtube.com,redtube.net###top_main_menu > li > a[id^="paid_tab_"]
 ||torrentgalaxy.org/common/exs/exs.php
 eztv1.unblocked.wtf###removeThisSection
 porntube.com##.navbar-nav > div > a[rel="nofollow"]:not([href^="http://www.hdporntube.com"])
@@ -5584,7 +5584,7 @@ yespornplease.com##div[class^="col-"] > .well:not([class*=" "])
 ||imgsmarts.info/bast^
 ||mangoporn.net/125_125.php
 ||mangoporn.net/125_125.js
-redtube.com,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###main-container > .abovePlayer
+redtube.com,redtube.net,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion###main-container > .abovePlayer
 indiatoday.in##div[id^="block-itg-ads-ads"]
 scroll.in##.in-article-adx
 bgr.in##.essel_logo_div
@@ -10798,7 +10798,7 @@ mirrorcreator.com##a[href*="offer?prod="][target$="_blank"]
 windowscentral.com##a[href*="shareasale.com/r.cfm?"]
 windowscentral.com##a[href*="windowscentral.com/hidden-gems?"]
 yourbittorrent.com##a[href*="xxcdn.pw/torrent"]
-redtube.com##a[href="/advertising"]
+redtube.com,redtube.net##a[href="/advertising"]
 xtremetop100.com##a[href="/contact.php"] > img
 mediafree.co##a[href="http://cinmaland.com/"]
 getdebrid.com##a[href="http://maxnulled.com/"]
@@ -11170,7 +11170,7 @@ enworld.org##ul > li[class="postbitlegacy postbitim postcontainer"]
 pornhd.com##ul.thumbs + div.listing-zone.mobile-zone
 xxxadd.com/eureka
 |http*://*.xyz^$script,domain=doyki.com
-|http://$image,third-party,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+|http://$image,third-party,domain=pornhub.com|pornhubthbh7ap3u.onion|redtube.com|redtube.net|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 |http://$script,third-party,xmlhttprequest,domain=oogh8ot0el.com
 |https://$script,third-party,xmlhttprequest,domain=oogh8ot0el.com
 ||0torrent.com^
@@ -11459,7 +11459,7 @@ lxax.com###parrot
 ||site2unblock.com/images/vpn*.gif
 ||slatedroid.com/espebanner.js
 ||sleazyneasy.com/_*.php
-||slopeaota.com^$popup,domain=redtube.com
+||slopeaota.com^$popup,domain=redtube.com|redtube.net
 ||smsdate.com/promotion/$third-party
 ||softpedia-static.com/images/afh/
 ||sportstream.tv/img/big.gif

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -226,7 +226,7 @@ swatchseries.to##.download_link_sponsored
 @@||ssgdfm.com^$extension
 ! https://github.com/easylist/easylist/issues/1912
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22746
-|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.net|redtube.com|redtube.net.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.net|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
 @@||pornhub.*/comment^
 @@||pornhub.*/front^
 @@||pornhub.*/user^

--- a/EnglishFilter/sections/whitelist.txt
+++ b/EnglishFilter/sections/whitelist.txt
@@ -62,7 +62,7 @@ inc42.com#@#.tag-social
 @@||registrierung.gmx.net^$extension
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71441
 !+ PLATFORM(ios, ext_android_cb)
-@@||rdtcdn.com^$image,domain=redtube.com
+@@||rdtcdn.com^$image,domain=redtube.com|redtube.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54475
 ! https://github.com/AdguardTeam/CoreLibs/issues/1222
 @@||arkenzoo.se/reload.ajax.php$elemhide,jsinject,extension
@@ -226,7 +226,7 @@ swatchseries.to##.download_link_sponsored
 @@||ssgdfm.com^$extension
 ! https://github.com/easylist/easylist/issues/1912
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22746
-|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$image,xmlhttprequest,domain=pornhub.com|redtube.com|redtube.net|redtube.com|redtube.net.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
 @@||pornhub.*/comment^
 @@||pornhub.*/front^
 @@||pornhub.*/user^
@@ -510,7 +510,7 @@ lmgtfy.app#@##bottom_ads
 ! meilleurpronostic.fr - broken player
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=meilleurpronostic.fr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64588
-redtube.com#@#[src*="blob:"]
+redtube.com,redtube.net#@#[src*="blob:"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64899
 @@||ads.agiliro.gq/style.css$domain=ads.agiliro.gq
 @@||ads.agiliro.gq/script.js$domain=ads.agiliro.gq
@@ -1233,8 +1233,8 @@ sony.com#@#.ad-index
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43696
 @@||c.amazon-adsystem.com/aax2/apstag.js$domain=foxnews.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43388
-redtube.com#@#[src*="base64"]
-redtube.com#@#[src*="data:"]
+redtube.com,redtube.net#@#[src*="base64"]
+redtube.com,redtube.net#@#[src*="data:"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43292
 @@||coolmathgames.com/*/img/ads/Spinner.png$domain=coolmathgames.com
 ! pornhub.com - player is broken
@@ -3143,7 +3143,7 @@ domodedovo.ru#@##adLink1
 ! https://forum.adguard.com/index.php?threads/hltv-org.15531/
 @@||static.hltv.org//images/flag/ad.gif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/3350
-@@||cdne-st.redtubefiles.com/css/*$domain=redtube.com
+@@||cdne-st.redtubefiles.com/css/*$domain=redtube.com|redtube.net
 ! https://forum.adguard.com/index.php?threads/11829/
 @@||linkbucks.com/scripts/intermissionLink*.js
 ! https://forum.adguard.com/index.php?threads/15743/
@@ -3623,7 +3623,7 @@ multiup.org#@#.adbar
 ! http://forum.adguard.com/showthread.php?6257
 @@||invodo.com^$domain=crutchfield.com
 ! pornhub etc - broken player
-@@||pornhub.phncdn.com^$image,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+@@||pornhub.phncdn.com^$image,domain=pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|redtube.net|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 ! web.mention.com - broken cabinet
 @@||web.mention.com^$document
 ! http://forum.adguard.com/showthread.php?6219
@@ -3735,7 +3735,7 @@ onvasortir.com#@##my-smartadserver
 ! http://www.gogoanime.com/ - removed search
 gogoanime.com#@#.topad
 ! http://forum.adguard.com/showthread.php?1748
-@@||ss.phncdn.com^$script,domain=redtube.com
+@@||ss.phncdn.com^$script,domain=redtube.com|redtube.net
 ! http://forum.adguard.com/showthread.php?3601
 ionomusic.com#@#object[width="300"][height="300"]
 ! http://forum.adguard.com/showthread.php?3656-SearchFTPs-org

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1172,7 +1172,7 @@ wasabisyrup.com###main > .content-group:not(.gallery-section)
 wasabisyrup.com##.top-group
 /wasabisyrup.com\/storage\/[-_a-zA-Z0-9]{8,}.gif/$domain=wasabisyrup.com
 wasabisyrup.com##.article-gallery > .article-gallery-group > .content-group
-redtube.com###content_container > div[class]:not(.show_page_modals):not([id]):not([style]):not([class^="content"])
+redtube.com,redtube.net###content_container > div[class]:not(.show_page_modals):not([id]):not([style]):not([class^="content"])
 youtube.com##ytm-promoted-video-renderer
 m.alpha.facebook.com,touch.alpha.facebook.com,mtouch.alpha.facebook.com,x.alpha.facebook.com,iphone.alpha.facebook.com,touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion###m_newsfeed_stream article[data-ft*='"ei\":']
 m.voyeurhit.com##.container > .section--normal[style*="margin-top: -15px"]
@@ -1627,13 +1627,13 @@ reshil.org###trr
 rg.ru###yandex_ads_hor_pda
 apkmirror.com##.OUTBRAIN
 4g.co.uk##.ad4
-m.economictimes.com,m.haberler.com,redtube.com,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.adContainer
+m.economictimes.com,m.haberler.com,redtube.com,redtube.net,pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion##.adContainer
 bhaskar.com,divyabhaskar.co.in,fashion101.in##.ad_320
 m.delfi.lt##.ad_atop
 seclub.org##.ad_block
 about.com##.adhesive
 forums.androidcentral.com##.adunit
-redtube.com##.after-header
+redtube.com,redtube.net##.after-header
 m.sondakika.com##.an-container
 avito.ru##.b-ads
 m.sports.ru##.b-adv-carousel-wrap
@@ -1643,7 +1643,7 @@ timesofisrael.com##.b320x50
 ukr.net##.baner-block
 m.aydin24haber.com,m.xcum.com,m.alphaporno.com,m.yourlust.com,m.3movs.com,m.sexu.com,m.yingshidaquan.cc##.banner
 vnexpress.net##.banner_mobile
-redtube.com##.between-videos
+redtube.com,redtube.net##.between-videos
 thesun.co.uk##.billboard
 m.avtovokzaly.ru##.block.bbc.pointer
 m.avtovokzaly.ru##.block.pt.pb
@@ -1680,7 +1680,7 @@ zvistka.net##.pum-container
 pcmag.com##.row.pcm-content
 healthboards.com##.sticky_ad
 forums.androidcentral.com##.threadbit + li.ui-body-null
-redtube.com##.top-tabs
+redtube.com,redtube.net##.top-tabs
 m.yingshidaquan.cc##.topmessage
 xhamster.com##.ts
 m.vk.com##.wall_item[data-ad-view]

--- a/MobileFilter/sections/whitelist.txt
+++ b/MobileFilter/sections/whitelist.txt
@@ -110,7 +110,7 @@ niji-gazo.com#@#.ad-block
 @@||gannettdigital.com/universal-web-client/$domain=usatoday.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26089
 !+ PLATFORM(ios, ext_android_cb)
-extremetube.com,redtube.com,tube8.com,tube8.es,tube8.fr,xtube.com,youjizz.com,youporn.com,youporngay.com#@#[src*="data:"]
+extremetube.com,redtube.com,redtube.net,tube8.com,tube8.es,tube8.fr,xtube.com,youjizz.com,youporn.com,youporngay.com#@#[src*="data:"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/27605
 m.veporns.com#@#.advertisment
 m.veporns.com#@##topAds
@@ -287,7 +287,7 @@ idownloadblog.com#@#.header-ad
 @@||doubleclick.net^$app=com.google.android.music
 @@||googleadservices.com^$app=com.google.android.music
 ! redtube.com - fixing icons
-@@||static.redtube.com/mobi/images/$domain=redtube.com
+@@||static.redtube.com/mobi/images/$domain=redtube.com|redtube.net
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/2153
 @@||ads.adfox.ru/*/getCode$app=ru.infoshell.android
 ! https://forum.adguard.com/index.php?threads/12453/


### PR DESCRIPTION
* Fix #73193

`redtube.net` is an official clone of `redtube.com`, hence I see no reason why the entries for the former shouldn't work on the latter.