### PR TITLE
Add new ad blockers

### DIFF
--- a/SpanishFilter/sections/specific.txt
+++ b/SpanishFilter/sections/specific.txt
@@ -2030,3 +2030,5 @@ urlcero.com##.banner
 urlcloud.us##.adsbygoogle
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 urlcloud.us##.banner
+||static.draft5.gg/partners/dell/dell-bg-large.jpg$image
+||comparaplano.com.br/app/uploads/2021/01/910x200-16gb.jpg$image

--- a/SpanishFilter/sections/specific.txt
+++ b/SpanishFilter/sections/specific.txt
@@ -8,6 +8,7 @@
 !
 repelis.io###ads
 ouvirmusica.com.br##.an-full
+draft5.gg##div[class^="AdmUnit_"]
 tuasaude.com###footerWidgets
 tuasaude.com##.taboola-container
 correiobraziliense.com.br##div[id^="cb-publicidade-"]
@@ -2030,5 +2031,3 @@ urlcero.com##.banner
 urlcloud.us##.adsbygoogle
 !+ NOT_OPTIMIZED PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 urlcloud.us##.banner
-||static.draft5.gg/partners/dell/dell-bg-large.jpg$image
-||comparaplano.com.br/app/uploads/2021/01/910x200-16gb.jpg$image


### PR DESCRIPTION
Simple changes. Updated filter for language Portuguese (PT_BR) based in my daily usage.

Added new filters to prevent showing two ads in two websites, that the current filters are letting through.

For these websites:
 1) https://draft5.gg/
 2) https://comparaplano.com.br/
 
 
 Block this side banner inside website (1):
<details><summary>Screenshot 1:</summary>

![Screenshot from 2021-01-26 14-26-23](https://user-images.githubusercontent.com/6011385/105881151-ec802200-5fe2-11eb-973e-565b6d92ddb7.png)
</details><br/>


And block this ad of a  mobile carrier inside website (2):
<details><summary>Screenshot 2:</summary>

![Screenshot from 2021-01-26 14-30-10](https://user-images.githubusercontent.com/6011385/105881259-0883c380-5fe3-11eb-8ddc-d6c064f4e80b.png)

</details><br/>