### PR TITLE
fix #73338 shi.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_general.txt
+++ b/AnnoyancesFilter/sections/cookies_general.txt
@@ -9,6 +9,7 @@
 ###cookieseal-banner
 ##.taunton-user-consent-visible
 ###onetrust-consent-sdk
+###gdrpNotification
 ###gdpr-cookie-message
 ###notice-cookie-block
 ###moove_gdpr_cookie_info_bar


### PR DESCRIPTION
#73338
This is a common cookie notice that hasn't been added to AdGuard Annoyances. Consider adding this.