### PR TITLE
revert

### DIFF
--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -3985,7 +3985,7 @@ neowin.net#$#div[class^="banner-"] { height: 0!important; min-height: 0!importan
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72892
 ! The rule needs for apps and, according to the user's response, since there are many such sites it became a generic one.
 !+ NOT_PLATFORM(ext_ff)
-$$script[tag-content="parseInt(zoneSett"][min-length="3000"]
+$$script[tag-content="zoneSett"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69383
 youporngay.com$$script[tag-content="{""zone_id"":"""]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/63153


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/commit/57487de40b76f4e31570a43435237787fc0cc35b
I am getting pop-ups again with link shorteners. This wasn't happening before with this rule `$$script[tag-content="zoneSett"]`. 