### PR TITLE
fix #73751 m.tutudao.net

### DIFF
--- a/AnnoyancesFilter/sections/mobile-app.txt
+++ b/AnnoyancesFilter/sections/mobile-app.txt
@@ -40,6 +40,7 @@ coincodex.com##.download-coincodex-app
 mirtesen.ru#$#html { overflow: auto !important; }
 mirtesen.ru#$#.app-promotion-fullscreen { display: none !important; }
 hindustantimes.com##.appDownload
+tutudao.net##a[href="/app/download/"]
 muzofond.fm###sveta__muzika-banner
 m.kenh14.vn##a[href="https://kenh14.vn/download-app.htm"] > img
 himovies.to,tinyzonetv.to###gift-top

--- a/AnnoyancesFilter/sections/mobile-app.txt
+++ b/AnnoyancesFilter/sections/mobile-app.txt
@@ -40,7 +40,6 @@ coincodex.com##.download-coincodex-app
 mirtesen.ru#$#html { overflow: auto !important; }
 mirtesen.ru#$#.app-promotion-fullscreen { display: none !important; }
 hindustantimes.com##.appDownload
-tutudao.net##a[href="/app/download/"]
 muzofond.fm###sveta__muzika-banner
 m.kenh14.vn##a[href="https://kenh14.vn/download-app.htm"] > img
 himovies.to,tinyzonetv.to###gift-top
@@ -1092,6 +1091,7 @@ edeka.de#@##smartbanner.android
 !#endif
 !
 !#if (adguard_app_android || adguard_app_ios || adguard_ext_android_cb)
+tutudao.net##a[href="/app/download/"]
 mega.nz##.download-app
 justwatch.com,flvto.biz##.mobile-banner
 adguard.com###overlay-download + div.sticky-bar

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -4,6 +4,7 @@
 icbc.com.cn##.action_Y_more
 /dngz.net\/g\d+.js/$domain=dngz.net
 ||dngz.net/x/
+||tutudao.net/js/gg*.js
 dngz.net##.listright > a[target="_blank"] > img
 ||v.icbc.com.cn/userfiles/ADResources/$domain=icbc.com.cn
 icbc.com.cn###kv-admain > div[id$="_1900_380"]

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -78,6 +78,8 @@ onet.pl##.slot-placeholder--active
 sexkvartal.net##div[style^="text-align: center;"][style*="background-color: #FFFFFF;"][style*="overflow: hidden;"]
 dict.cc##div[style="text-align:center;width:728px"]
 sefon.pro##.rklm
+tutudao.net##a[href="https://hhyy33.com/"][target="_blank"]
+tutudao.net##.m_adv > a[href="https://m.13xp.com/"]
 namobilu.com##.b_adsen_wrap
 collectionofbestporn.com##.banner-mobile-header
 javsubtitle.co###mimpanel


### PR DESCRIPTION
#73751

easyList China has
```
/gg4.
/gg5.
/gg6.
```
This website has gg1.js — gg4.js, should we add `/gg*.js` as a common rule?

