### PR TITLE
fix #74335 linkedin.com

### DIFF
--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -9,8 +9,7 @@ lovehug.net#?#center > h5 > font[color="white"]:contains(Advertisement)
 mad4wheels.com#?#.prodotti-grid > .mb-5 > .card > .card-body > a > img[src^="/ads/"]:upward(.mb-5)
 mad4wheels.com#?#.prodotti-grid > .mb-5 > .card  > .card-footer > .pull-right:contains(/^Ads$/):upward(.mb-5)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/74335
-linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[target="_blank"][rel="noopener nofollow"])
-linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[href^="https://www.linkedin.com/leadGenForm/"])
+linkedin.com#?##main > .ember-view > div > div[data-id^="urn:li:activity:"] > .occludable-update > div[class^="feed-shared-update-"][data-urn] > div > .feed-shared-actor > .app-aware-link > .feed-shared-actor__meta > span.feed-shared-actor__sub-description:last-child:not(:has(>*)):upward(div[data-id^="urn:li:activity:"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73781
 escapegames24.com#?#.sidebar > div.widget:has(> h2:contains(Advertisement))
 escapegames24.com#?#.widget-content > div[align="center"]:has(> font > b:contains(Advertisement))

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -8,6 +8,9 @@ lovehug.net#?#center > h5 > font[color="white"]:contains(Advertisement)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73691
 mad4wheels.com#?#.prodotti-grid > .mb-5 > .card > .card-body > a > img[src^="/ads/"]:upward(.mb-5)
 mad4wheels.com#?#.prodotti-grid > .mb-5 > .card  > .card-footer > .pull-right:contains(/^Ads$/):upward(.mb-5)
+! https://github.com/AdguardTeam/AdguardFilters/issues/74335
+linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[target="_blank"][rel="noopener nofollow"])
+linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[href^="https://www.linkedin.com/leadGenForm/])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73781
 escapegames24.com#?#.sidebar > div.widget:has(> h2:contains(Advertisement))
 escapegames24.com#?#.widget-content > div[align="center"]:has(> font > b:contains(Advertisement))

--- a/EnglishFilter/sections/css_extended.txt
+++ b/EnglishFilter/sections/css_extended.txt
@@ -10,7 +10,7 @@ mad4wheels.com#?#.prodotti-grid > .mb-5 > .card > .card-body > a > img[src^="/ad
 mad4wheels.com#?#.prodotti-grid > .mb-5 > .card  > .card-footer > .pull-right:contains(/^Ads$/):upward(.mb-5)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/74335
 linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[target="_blank"][rel="noopener nofollow"])
-linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[href^="https://www.linkedin.com/leadGenForm/])
+linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > a[href^="https://www.linkedin.com/leadGenForm/"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73781
 escapegames24.com#?#.sidebar > div.widget:has(> h2:contains(Advertisement))
 escapegames24.com#?#.widget-content > div[align="center"]:has(> font > b:contains(Advertisement))


### PR DESCRIPTION
#74335

There are few types of promoted cards.
There also was
`linkedin.com#?##main > div[id^="ember"] > div > div[data-id][class="relative ember-view"]:has( li.artdeco-carousel__item > div.artdeco-carousel__item-container > div.ember-view > `**`a[target="_blank"] img[src^="https://media-exp1.licdn.com/dms/image/sync/"]`**`)`
but i cant reproduce it anymore.