### PR TITLE
fix #74628 userload.co

### DIFF
--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -729,8 +729,8 @@ davidbaptistechirot.blogspot.com#%#//scriptlet("abort-current-inline-script", "d
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=davidbaptistechirot.blogspot.com
 ! userload.co - antiadblock
 userload.co###map
-@@||userload.co/ad-blocker.js
-@@||userload.co/ads/ads-banner.png
+userload.co#%#//scriptlet("prevent-setTimeout", "xza", "500")
+userload.co###xza
 @@||userload.co/popads.js
 userload.co#%#//scriptlet("abort-current-inline-script", "document.getElementById", "popads")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72464


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/74628#issuecomment-777893144
Removed useless rules. 
`userload.co###xza` for platforms without JS rules support.