### PR TITLE
fix #74498 disk.yandex.ru

### DIFF
--- a/RussianFilter/sections/whitelist.txt
+++ b/RussianFilter/sections/whitelist.txt
@@ -36,6 +36,8 @@ price.ua#@#iframe[name^="google_ads_iframe"]
 @@||tpc.googlesyndication.com/simgad/*$image,domain=price.ua
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73307
 mult.tv#@#.rekl
+! https://github.com/AdguardTeam/AdguardFilters/issues/74498
+@@||yastatic.net/q/promo-disk-download-2015/*/static/desktop.bundles/index/_index.ru.js$replace=/var n=\{\};return/var n={};return;/,domain=disk.yandex.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72264
 rupors.com#@#.advertSlider
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72024


### PR DESCRIPTION
#74498

Incorrent blocking caused by 
`||yastatic.net/*.bundles/*.js$replace=/var n=\{\};return/var n={};return;/` from Russian filter,
only reproducable with desktop AG.