### PR TITLE
fix #74697 ria.ru

### DIFF
--- a/RussianFilter/sections/adservers.txt
+++ b/RussianFilter/sections/adservers.txt
@@ -5,6 +5,7 @@
 ! `window.adswellBaseDomain`
 ! https://damskiy.xyz/vendor/lib/oY.js
 !
+||relap.io^$third-party
 ||aqjlgsv7cvkzocg.ru^$third-party
 ||twtmle.com^$third-party
 ||kcycpp.com^$third-party

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -2374,7 +2374,6 @@
 ||reitingas.lt^$third-party
 ||reitingi.lv^$third-party
 ||rejestr.org^$third-party
-||relap.io^$third-party
 ||relead.com^$third-party
 ||reliablecounter.com^$third-party
 ||relmaxtop.com^$third-party


### PR DESCRIPTION
#74697

Moved `relap.io` to adservers, as it is clearly adserver and not (only) tracker as seen in the issue and the domain itself.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/68852737/108059268-4ade7480-7066-11eb-88eb-f5f50d6cd991.png)
</details><br/>