### PR TITLE
fix #74241 fullindirsene.net

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -71,7 +71,8 @@ korezin.com##.type-ads
 gundemsaros.com.tr##body > #panel
 aydinda.com###adni_widgets-2
 aydinda.com##._ning_zone_inner
-indirvip.club,fullindirsene.net##a[href^="https://kingads.link/"]
+indirvip.club##a[href^="https://kingads.link/"]
+fullindirsene.net##.entry-content > div.code-block > center > div
 nefisyemektarifleri.com##.arsiv-native
 patisahiplen.com##.advertizing
 filmindir.be##a[href*="https://kingads.mobi/"]

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -72,7 +72,7 @@ gundemsaros.com.tr##body > #panel
 aydinda.com###adni_widgets-2
 aydinda.com##._ning_zone_inner
 indirvip.club##a[href^="https://kingads.link/"]
-fullindirsene.net##.entry-content > div.code-block > center > div
+fullindirsene.net##.entry-content > div[style^="margin: 8px auto;"][style*="text-align: center"] > center
 nefisyemektarifleri.com##.arsiv-native
 patisahiplen.com##.advertizing
 filmindir.be##a[href*="https://kingads.mobi/"]


### PR DESCRIPTION
#74241

Existing rule `fullindirsene.net##a[href^="https://kingads.link/"]` doesn't work for AG desktop.
It seems that targeting `a[href^="https://kingads.link/"]` doesn't work for desktop and mobile layout.