### PR TITLE
removal of a problematic rule

### DIFF
--- a/AnnoyancesFilter/sections/tweaks.txt
+++ b/AnnoyancesFilter/sections/tweaks.txt
@@ -208,8 +208,6 @@ newsweek.com##iframe[src="http://sns.europe.newsweek.com/newsletter?popup=1"]
 !######### JS tweaks ##########
 !##############################
 !
-! to boost timer in mega4up.com
-mega4up.com#%#//scriptlet('adjust-setTimeout', 'tick', '1000', '0.02')
 ! festyy.com countdown
 festyy.com#%#//scriptlet('adjust-setInterval', 'o--', '1000', '0.02')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/75436


### PR DESCRIPTION
`https://mega4up.com/lr0mwpg7q0va`
Says skipped countdown.
