### PR TITLE
fix #75986 n12.co.il  - Cookie popup

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -3031,7 +3031,7 @@ hirezstudios.com##.CookieOverlay
 coinbase.com##.CookieWarning__Container-s1eysx2e-0
 tv2.dk##.CookieWarning_container__Pjx-P
 pri.org##.CtaMessage__loadUnder___3S4ya
-mako.co.il##.GDPR-Msg
+n12.co.il,mako.co.il##.GDPR-Msg
 meduza.io##.GDPRPanel-root
 relic.com##.GdprCookieConsent-ConsentContainerOverlay
 forums.techguy.org##.Notice


### PR DESCRIPTION
#75986
Anti-Adblock is already fixed in EasyList Hebrew.