### PR TITLE
fix #76274 filmora.wondershare.de

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -2940,7 +2940,7 @@ ginagerson.xxx,kitanalure.xxx###gdpr-cookie-accept
 sosfanta.calciomercato.com###gdpr-law
 rtl.hr###gdpr-modal
 allsoppandallsopp.com###gdpr-modal-container
-wondershare.com###gdprAgree
+wondershare.*###gdprAgree
 bollywoodlife.com,netadmin.com.tw,bgr.in,india.com###gdprBox
 cancan.ro###gdpr_consent
 kidstaff.com.ua###gdpr_panel


### PR DESCRIPTION
#76274

There are more sites like this. For example, `https://www.wondershare.tw/`