### PR TITLE
fix #76222 domashnee.24video.net

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -76,6 +76,7 @@ rsload.net###dtxsy
 ||hcdn.online/engine/video/videojs-vast-vpaid-waterfall.
 glav.su##div[style="min-height: 90px;"]
 shopinfo.com.ua###ads_header_right
+24video.net##.result > a[rel="nofollow"][target="_blank"]
 7days.ru###GPM_7days_D_Top
 biqle.org###ics
 youhack.xyz##.mobyaza > div[style="padding: 0;height: 40px;"]
@@ -7135,7 +7136,6 @@ www.ex.ua/*/index.css
 ||24stoma.ru/rkm/
 ||24v.tv/assets/videojs/vast-*.js
 ||24v.tv/video/xmi?*&vast=
-||24video.*/*?*=10
 ||24video.*/assets/bundle/player-*.js?pl=*&wh=*&rnd=*&r=
 ||29ru.net/plugins/s29_nodes/skins/sportsweek/banner.css
 ||2baksa.*/js/vivo.js


### PR DESCRIPTION
#76222

`||24video.*/*?*=10` now blocks video stream.