### PR TITLE
fix #76242 unsplash.com

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -1729,6 +1729,7 @@ burmistr.ru##.section-subscribe
 burmistr.ru##.balloon-subscribe
 frame.work##.container > div[data-test-id^="email-signup-"][data-controller="spree--containers--email-signup-component--email-signup"]
 texterra.ru##.blog-subscribe-form
+unsplash.com##div[data-test="say-thanks-card"]
 independent.co.uk##.newsletter-component
 onliner.by##a[href="https://t.me/catalogonliner"]
 99designs.com##section#subscribe

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -289,6 +289,7 @@ tubeoffline.com##div[style^="min-height: 2"][align="center"]
 ||mrdeepfakes.com/static/js/pu.js
 /^(?!.*(doodcdn.com|cloudflare.com)).*$/$third-party,script,domain=dood.so
 ||manga18fx.com/bmo/*.php
+unsplash.com##div[data-test="say-thanks-card-tablet-up-ad-placement-request"]
 manga18fx.com##.kadx
 /random.js$script,domain=lookmovie.*|uppit.ml
 ||sak.userreport.com/blueseed/launcher.js

--- a/MobileFilter/sections/general_extensions.txt
+++ b/MobileFilter/sections/general_extensions.txt
@@ -103,6 +103,9 @@ scmp.com#$##main-content > .home-page--slide-up { transform: none !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68853
 filmakinesi.com#$#.nav-mobile { top: 0 !important; }
 filmakinesi.com#$#.wrapper { padding-top: 64px !important; }
+! https://github.com/AdguardTeam/AdguardFilters/issues/76242
+unsplash.com#$#.ReactModalPortal { display: none !important; }
+unsplash.com#$#body { overflow: visible !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68850
 m.investing.com#$#footer { margin-bottom: -50px !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68045


### PR DESCRIPTION
#76242

There is modal opening after clicking download on mobile, that can be closed by clicking on it. Should we remove it with
```
unsplash.com#$#.ReactModalPortal { display: none !important; }
unsplash.com#$#body { overflow: visible !important; }
```
?