### PR TITLE
fix #76279 tozlu.com

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -129,6 +129,7 @@ the-ans.jp##.side-reccomend
 ||zenback.jp^*/tracking.html
 ||cdn.retailrocket.ru/*/tracking.js
 ||ru-mi.com/*/ee_tracking.js
+||tozlu.com/Scripts/ticimax/analytics.js
 ||matchid.adfox.yandex.ru/getcookie$domain=vseinstrumenti.ru
 ||player.vzaar.com/libs/googleAnalytics/vzaarGoogleAnalytics.js
 ||r.yna.co.kr/global/lib/*/js/nlogger.js


### PR DESCRIPTION
#76279

`||artfut.com^` of DNS filter breaks critical website functionality but is also 100% tracking domain, should we exclude it?