### PR TITLE
fix #77718 kiyi-derinligi.nedir.org

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -42,7 +42,8 @@ yemektarifleri.org,lifebursa.com,mshowto.org,macizlee1.com,macizlee.ne,dunyaatla
 fullhdfilmcibaba.com,720pizlemek.com,1080pfilmizle.net,fullhdfilmcidayi.com,hdfilmizledayi.com,720-pizleme.com,fullhdfilmizlebaba.com,evrenselfilmlerim.net###adStarter
 !
 basarisiralamalari.com##.arkaresimmasas
-nedir.org##.icreklam
+nedir.org##.icreklam > .googleic
+nedir.org##iframe[data-id="nedir.org_300x600_sidebar_responsive_2_DFP"]
 aspor.com.tr,yeniasir.com.tr,samdan.com.tr,esquire.com.tr,harpersbazaar.com.tr##.ad-control-left
 aspor.com.tr##.ad-control-full
 forum.mevsim.org##div[class^="xgt-Banner"] > ul[class]

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -42,6 +42,7 @@ yemektarifleri.org,lifebursa.com,mshowto.org,macizlee1.com,macizlee.ne,dunyaatla
 fullhdfilmcibaba.com,720pizlemek.com,1080pfilmizle.net,fullhdfilmcidayi.com,hdfilmizledayi.com,720-pizleme.com,fullhdfilmizlebaba.com,evrenselfilmlerim.net###adStarter
 !
 basarisiralamalari.com##.arkaresimmasas
+nedir.org##.icreklam
 aspor.com.tr,yeniasir.com.tr,samdan.com.tr,esquire.com.tr,harpersbazaar.com.tr##.ad-control-left
 aspor.com.tr##.ad-control-full
 forum.mevsim.org##div[class^="xgt-Banner"] > ul[class]


### PR DESCRIPTION
#77718
`nedir.org` is added because there are a lot of domains. For example, `https://divan-i-mezalim.nedir.org/`
