### PR TITLE
fix #78577 javadecompilers.com

### DIFF
--- a/EnglishFilter/sections/content_blocker.txt
+++ b/EnglishFilter/sections/content_blocker.txt
@@ -240,6 +240,7 @@ cdn.braun634.com^$third-party
 @@||kpopstan.com^$generichide
 @@||zuketcreation.com^$generichide
 @@||akwam.co^$generichide
+@@||javadecompilers.com^$generichide
 @@||ohmygirl.ml^$generichide
 @@||thepoorcoder.com^$generichide
 @@||streamingcommunity.to^$generichide

--- a/MobileFilter/sections/antiadblock.txt
+++ b/MobileFilter/sections/antiadblock.txt
@@ -65,8 +65,6 @@ m.postimees.ee#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.tex
 ! https://forum.adguard.com/index.php?threads/15378/
 @@||ads.dainikbhaskar.com/AdTech/ads/ads.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/3067
-@@||javadecompilers.com^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/3067
 delfi.ee#@#.adbanner
 delfi.ee#%#Object.defineProperty(window, 'adblock_detect_run', { get: function() { return true; } });
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23128


### PR DESCRIPTION
#78577
Anti-adblock is already fixed. Removed `generichide` from mobile filter, it unblocks leftovers.
