### PR TITLE
fix #78739 newrelic.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -5366,6 +5366,7 @@ heute.at#%#AG_onLoad(function(){if(!document.cookie.includes("eupubconsent-v2"))
 thehouseofportable.com#%#(function() { try { if ("undefined" != typeof localStorage) { localStorage.setItem('accepted', '1') } } catch (ex) {} })();
 coolmath.com#%#//scriptlet('set-cookie', 'GDPR_Reject', 'true')
 johnlewis.com#%#//scriptlet('set-cookie', 'JOHNLEWIS_ENSIGHTEN_PRIVACY_Functional', '1')
+newrelic.com#%#//scriptlet("set-cookie", "newrelic-gdpr-consent", "false")
 reebok.*#%#//scriptlet('set-cookie', 'notice_preferences', '1')
 corriere.it,video.gazzetta.it#%#AG_onLoad(function() {if (!document.cookie.includes("euconsent-v2")) {var b=new MutationObserver(function() {var c=document.querySelector('#_cpmt-accept'); c&&(b.disconnect(),c.click()) });b.observe(document, {childList: !0,subtree: !0});setTimeout(function() {b.disconnect()}, 1E4)}})
 allocine.fr#%#AG_onLoad(function(){var a=new MutationObserver(function(){if(document.querySelector(".didomi-popup-open")){document.querySelector('button#didomi-notice-learn-more-button').click(); setTimeout(function(){document.querySelector('button[aria-label^="Refuse"]').click();},500); a.disconnect();}});a.observe(document,{childList: !0, subtree: !0});setTimeout(function(){a.disconnect()},5000)});


### PR DESCRIPTION
#78739
`newrelic.com` has many subdomains like `developer.newrelic.com`.
