### PR TITLE
fix #79481 hocvientruyentranh.net

### DIFF
--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -235,6 +235,8 @@ kat.*,kickass.*,kickass2.*,kickasstorrents.*,kat2.*,kattracker.*,thekat.*,thekic
 !
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/79481
+hocvientruyentranh.net#%#//scriptlet("abort-on-property-read", "popup_link")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/78643
 themaclife.com#%#AG_onLoad(function(){setTimeout(function(){document.querySelector("#sidebar").childNodes.forEach(function(a){3===a.TEXT_NODE&&a.textContent.match("Advertisement")&&20>a.length&&a.remove()})},300)});
 ! https://github.com/AdguardTeam/AdguardFilters/issues/79047


### PR DESCRIPTION
#79481
Ads, popup overlay fixed in ABPVN List.
