### PR TITLE
fix #79990 duden.de

### DIFF
--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -79,6 +79,7 @@ wiesbadenaktuell.de,rauchmeldungen.de,simfans.de,wn.de,cosmopolitan.de,wallstree
 ! ##.id-Container--proBEEP
 hallo-muenchen.de,az-online.de,lokalo24.de,rosenheim24.de,kreiszeitung.de,nordbuzz.de,mannheim24.de,merkur.de,oktoberfest-live.de,tz.de##.id-Container--proBEEP
 !
+duden.de##.medrec
 goettinger-tageblatt.de##.pdb-adplacement-container
 goettinger-tageblatt.de,waz-online.de,maz-online.de,ostsee-zeitung.de,dnn.de###gpt_superbanner
 freundin.de##article[role="article"][data-internal-url][about]:not([about*="freundin.de"])


### PR DESCRIPTION
#79990
This rule fixes ad-leftover. Cookie nag is fixed by a rule in Annoyances Filter.

