### PR TITLE
Fix Microsoft Family Safety parental control app on Android.

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -293,7 +293,6 @@
 ||a.bitmango.com^
 ||bitmango.com/log
 ||tracking.directservices.it^
-||vortex.data.microsoft.com^
 ||onedrive-collection.device.mobileengagement.windows.net^
 ||metrics.timewarnercable.com^
 ||flurry.agentportal-*.yahoodns.net^


### PR DESCRIPTION
The MFS app needs access to web.vortex.data.microsoft.com or will display an error preventing the changing of any settings.
