### PR TITLE
The 1st large cleanup of Mobile filters

### DIFF
--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -67,8 +67,6 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20567
 ||bu1.duba.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11291
-||behacdn.ksmobile.net^
-||cmdts.ksmobile.com^
 ||p-behacdn.ksmobile.net^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8642
 ||crosspromotion.weplayer.cc^
@@ -76,9 +74,7 @@
 ! https://forum.adguard.com/index.php?threads/24268/
 ||mobile-campaigns.avast.com^
 ! https://forum.adguard.com/index.php?threads/s-photo-editor-missed-ads-android.21096/
-||advs2sonline.goforandroid.com^
 ||adpush.goforandroid.com^
-||advonline.goforandroid.com^
 ! https://forum.adguard.com/index.php?threads/dodonpachi-unlimited-missed-ads-android.21000/
 ||dzpu6za66svjl.cloudfront.net^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/4757
@@ -90,8 +86,6 @@
 ||api.ads.watchabc.go.com^
 ! https://play.google.com/store/apps/details?id=fr.playsoft.teleloisirs
 ||ad.prismamediadigital.com^
-! https://play.google.com/store/apps/details?id=fr.francetv.pluzz&hl=fr
-||ad2play.ftv-publicite.fr^
 ! Supership.jp (also mobile ads)
 ||socdm.com^
 !
@@ -101,8 +95,6 @@
 !
 ||appodeal.com^
 ||a.76674bdad304297eda3d325f449f6f49.com^
-||a.4ee395e5b8a076c7bd8592851ff8cad.com^
-||a.6d47c1118927cf53ba9654931df80e8d.com^
 !
 ||banner.hpmdnetwork.ru^
 ||hybrid.ai^
@@ -123,12 +115,8 @@
 ||common.duapps.com^
 ||pasta.esfile.duapps.com^
 ||api.mobula.sdk.duapps.com^
-||mobula.ssl2.duapps.com^
 ||ad.duapps.com^
 ! Ads on some Chinese smartphones
-||sync.mobojoy.baidu.com^
-||api.mobojoy.baidu.com^
-||js.mobojoy.baidu.com^
 ||ufz.doesxyz.com^
 ||id1.cn^
 ||xdrig.com^
@@ -188,8 +176,6 @@
 ||api.adnet.mob.com^
 ||sf3-ttcdn-tos.pstatp.com^
 ||iam.datasavannah.com^
-||a.f590906c3e6c07bb5f80801f2dfc4295.com^
-||a.eed1729eebe45b8cd49e10f2dd80e297.com^
 ||ad.doublemax.net^
 ||yovoads.com^
 ||restartad.com^
@@ -215,7 +201,6 @@
 ||adsmobila.com^$third-party
 ||tw-api.vpon.com^
 ||haorun.pw^$third-party
-||pochengweiyuan.com^$third-party
 ||ts166.net^$third-party
 ||imrworldwide.com^
 ||tccbanner.com^
@@ -238,36 +223,26 @@
 ||thind-gke-euw.prd.data.corp.unity3d.com^
 ||unityads.unity3d.com^
 ||gop1.co^
-||m.wangliqin.top^$third-party
-||m.yangzhenpeng.top^$third-party
 ||adpriv.nikkei.com^
 ||nkis.nikkei.com^
 ||gameanalysis.appcpi.net^
 ||ads.bulldogcpi.com^
 ||other.appcpi.net^
-||92kyxiz5xg.execute-api.us-west-2.amazonaws.com^
-||0jkro0unul.execute-api.us-west-2.amazonaws.com^
 ||d19xf4taj229i8.cloudfront.net^
-||nsjpu.com^$third-party
-||nbvcb.xyz^$third-party
 ||ad999.biz^$third-party
-||cafe-latte.myshoplus.com^
 ||luckyforworlds.com^
 ||cdn-adn.rayjump.com^
 ||cdn-adn-*.rayjump.com^
 ||buysellads.com^
 ||casino-ad-mediation.me2zengame.com^
 ||postut.cn^$third-party
-||eysmaa.pw^$third-party
 ||vennala.pw^$redirect=nooptext
 ||promoted.soundcloud.com^
 ||activity.browser.intl.miui.com^
 ||api.brs.intl.miui.com^
 ||api.newsfeed.intl.miui.com^
 ||huangye.miui.com^
-||eihjefbbbbddeiacedb.ru^
 ||adv.sec.intl.miui.com^
-||zhfosenghtr.com^$third-party
 ||adsrvr.io^
 ||t7z.cupid.iqiyi.com^
 ||data2.doodlemobile.com^
@@ -275,7 +250,6 @@
 ||newfeatureview.perfectionholic.com^
 ||featured.perfectionholic.com^
 ||crosspromo.voodoo.io^
-||abtest.mistat.intl.xiaomi.com^
 ||abtest.mistat.xiaomi.com^
 ||adsnative.com^
 ||liftoff.io^
@@ -289,14 +263,12 @@
 ||studcat.infra.systems^
 ||adplex.co.kr^$third-party
 ||tveta.naver.net^
-||opr.formulas.jp^$third-party
 ||deliveryengine.adswizz.com
 ||sitemaji.com^
 ||h5.wannaplay.cn^
 ||adsapi.manhuaren.com^
 ||euadsapi.manhuaren.com^
 ||msg.ettoday.net^
-||d1zkodo2u3p4pe.cloudfront.net^
 ||ad-ettoday.cdn.hinet.net^
 ||adv-ettoday.cdn.hinet.net^
 ||adv.ettoday.net^
@@ -332,11 +304,9 @@
 ||adsmogo.net^
 ||adsmogo.org^
 ||adsmogo.mobi^
-||adbetnet.advertserve.com^
 ||chartboosts.com^
 ||mobpowertech.com^
 ||ap.smardroid.com^
-||aclickoooo.host^$third-party
 ||api.ampiri.com^
 ||httpkafka.unityads.unity3d.com^
 ||amazonaws.com/cp4pox^
@@ -355,9 +325,6 @@
 ||sumatoad.com^
 ||upsight-api.com^
 ||gdn.bigfishgames.com^
-||883.engine.mobileapptracking.com^
-||ads.cricbuzz.com^
-||adops.cricbuzz.com^
 ||ad.daum.net^
 ||etcodes.com^
 ||onedrive.su^
@@ -369,26 +336,17 @@
 ||cdn7.rocks^
 ||bgrndi.com^
 ||et-code.ru^
-||gocdn.ru^
 ||gynax.com^
-||nasdfg.com^
-||fastmap33.com^$redirect=nooptext
 ||avazunativeads.com^
 ||mobilebanner.ru^$third-party
 ||api.ad-locus.com^
-||m.nbhaosheng168.com^$third-party
-||m.jakc0.com^$third-party
-||s.nvrentao8.com^$third-party
-||xz15801.com^
 ||023hysj.com^
 ||lxqcgj.com^
 ||inclk.com^$popup
 ||betsonsport.ru^
-||m.mrsasharingspace.com^$third-party
 ||holder.com.ua^
 ||crosspromotion-us.avosapps.us^
 ||ad.period-calendar.com^
-||dc.altamob.com^
 ||cpactions.com^
 ||native.cli.bz^
 ||adplatform.vrtcal.com^
@@ -398,51 +356,22 @@
 ||cls.vrvm.com^
 ||nycp-hlb.dvgtm.akadns.net^
 ||abbott.vo.llnwd.net^
-||advantech.vo.llnwd.net^
 ||atkins.vo.llnwd.net^
-||bandai.hs.llnwd.net^
 ||behance.vo.llnwd.net^
 ||edwlifes.vo.llnwd.net^
-||embanet.vo.llnwd.net^
-||eyewond.hs.llnwd.net^
-||finedesign.vo.llnwd.net^
-||gulfstream.vo.llnwd.net^
-||gymboree.hs.llnwd.net^
-||harvardbp.vo.llnwd.net^
-||hbpub.vo.llnwd.net^
-||icvdm.vo.llnwd.net^
-||inskin.vo.llnwd.net^
 ||kjos.vo.llnwd.net^
-||msbmopod.vo.llnwd.net^
-||msbrandent.vo.llnwd.net^
-||navigon.vo.llnwd.net^
-||nytelecom.vo.llnwd.net^
-||rbb.ic.llnwd.net^
-||responsys.hs.llnwd.net^
-||surveyor.vo.llnwd.net^
 ||synthes.vo.llnwd.net^
 ||teachscape.vo.llnwd.net^
-||textron.vo.llnwd.net^
 ||tmz.vo.llnwd.net^
-||toyota.vo.llnwd.net^
-||usarmy.vo.llnwd.net^
 ||videoplus.vo.llnwd.net^
 ||wdig.vo.llnwd.net^
-||xmpie.vo.llnwd.net^
 ||appnext.hs.llnwd.net^
-||sdk.adincube.com^
-||ads.avocarrot.com^
 ||adsdk.vrvm.com^
-||moatads.com.edgekey.net^
-||nexage.akadns.net^
 ||a.applvn.com^
-||listat.biz^
 ||buzzad.io^
 ||adslot.uc.cn^
 ||disqusads.com^
-||mobsrv.in^
 ||jssdk.rayjump.com^$third-party
-||dc.altmob.com^
 ||rtb.adentifi.com^$third-party
 ||adtheorent.com^$third-party
 ||qgss8.com^
@@ -453,20 +382,15 @@
 ||i2ad.jp^
 ||mxvp-ad-config-prod-1.zenmxapps.com^
 ||mxvp-feature-toggle-prod-1.zenmxapps.com^
-||js4386.fujianryt.com^
-||m.12306media.com^
 ||zzhengre.com^
 ||wmhlch.com^
 ||fjrkn.com^
 ||tongqing2015.com^$third-party
-||m.jsqinvest.com^$third-party
-||sube.puwangkj.com^$third-party
 ||pw.lpsxssm.com^$third-party
 ||go.admost.com^
 ||med-api.admost.com^
 ||cdn-api.admost.com^
 ||webview.unityads.unity3d.com^
-||clickkydsp.com^
 ||bidsopt.com^
 ||tpbid.com^
 ||exe.bid^
@@ -476,7 +400,6 @@
 ||mopub-win-us-east.bksn.se^
 ||nativead.s3.amazonaws.com^
 ||adserver.*.yahoodns.net^
-||eu-ma.sam4m.com^
 ||eu-ad.sam4m.com^
 ||c2i.startappnetwork.com^
 ||c2s.startappnetwork.com^
@@ -511,7 +434,6 @@
 ||ad.apsalar.com^
 ||ad.doubleclick.net^
 ||ad.jorte.com^
-||ad.kixer.com^
 ||ad.leadbolt.net^
 ||ad.leadboltapps.net^
 ||ad.madvertise.de^
@@ -556,7 +478,6 @@
 ||admitad.com^
 ||admixer.co.kr^
 ||admixer.net^
-||admob.com^
 ||admulti.com^
 ||adnxs.com^
 ||adocean.pl^
@@ -1002,7 +923,6 @@
 ||singular.net^
 ||sitescout.com^
 ||slb.gedawang.com^$third-party
-||smaato.net^
 ||smaclick.com^
 ||smartadserver.com^
 ||smarttds.ru^

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -320,9 +320,7 @@ news18.com##div[class*="Footer_closestickybtn_"]
 9gag.com##.salt-container
 ||m.pufei8.com/skin/view/ft2.js
 ||m.pufei8.com/skin/middle.js
-m.hindustantimes.com###stickydivAD
 ctwant.com##.m-adpopup
-lifestyle.24tv.ua##div[class="within-ads"]
 m.lenta.ru##.topic-page > div.board
 m.ruliweb.com##div[id^="nbp_container_"]
 yahoo.com##li[data-test-locator="ntk-ad"]
@@ -360,7 +358,6 @@ charivari.de##.block_area_sidebar > .hidden-md.hidden-lg + .divider
 baidu.com##.navs-bottom-bar[style="margin-top: 10px; height: 0px;"]
 m.techfocus.cz##.foot.scrolled
 m.baidu.com##.c-touchable-feedback[rl-node][rl-highlight-self][style^="padding-bottom:"]:not([data-module]) > a[href^="https://m.baidu.com/from"][target="_self"][data-log]
-amp.strana.ua##amp-iframe[src^="https://mg.lentainform.com/"]
 odnaminyta.com##amp-iframe[src^="https://html.redtram.com/"]
 depor.com##.ad-amp-movil
 finance.rambler.ru##div[data-blocks^="cluster_"] > script[type] + div[class]
@@ -468,7 +465,6 @@ trashbox.ru##.div_aj_top4_2020
 fiorentina.it##.advdesksi
 mensxp.com##.list-card > li:not(.track_ga) > div[class*=" "] > div > div > a[onclick]
 m.thisisgame.com##div[id^="ad_layer"]
-gordonua.com##amp-iframe[src^="https://recreativ.ru/"]
 m.imgur.com##div[class^="Ad-adhesive"]
 zona.media##.mz-advert-item__root_news
 zaycev.fm##.not_for_premium
@@ -513,7 +509,6 @@ gram.pl##.external-entity-container.adrino
 ||bd2.guancha.cn^$domain=m.guancha.cn
 krayot.com###front_trandiv
 game4v.com##div[id^="banner-"]
-m.lenta.ru##amp-embed.b-banner-smi2
 hosyusokuhou.jp##.rankbox
 spielen.de##.s4u
 eiga.com###rankingArea
@@ -721,7 +716,6 @@ m.3movs.com##span[id="3Mm-Nat"]
 porntrex.com,daftsex.com##iframe[src^="https://a.adtng.com/"]
 youjizz.com##.underPlayerPr
 ||cdn.nsimg.net/cache/landing/pr/*/yjmobile-*.xml$domain=youjizz.com
-dailywire.com##article[class^="css-"] > div[style="width: 320px; height: 50px; margin: 0px auto 32px;"]
 gadgetsnow.com,www-firstpost-com.cdn.ampproject.org,firstpost.com,m.economictimes.com,m-economictimes-com.cdn.ampproject.org,hurriyet.com.tr,m.news.de##amp-fx-flying-carpet[height="300px"]
 prothomalo.com##.anchor_ad_wrapper
 tgd.kr##body > div[style="background: #efefef;padding:0;"]
@@ -889,7 +883,6 @@ m.merdeka.com,ampproject.org,m.otosia.com##.ads-flying_carpet
 m.veporns.com##iframe[name^="spot_id_"]
 ||m.yeniakit.com.tr/anlasma
 tribunnewswiki.com,tribunnews.com###anchorads
-m.detik.com##.footer_banner
 m.detik.com##.parallax
 m.detik.com##center > p[style^="margin:0px;font-size:10px;padding:"][style$="background-color:#204099;color:white;"]
 arabam.com##.min-md-width > .homepage-jellybean-wrapper
@@ -1030,13 +1023,11 @@ opencritic.com,www-news18-com.cdn.ampproject.org,eurogamer.net,mumsnet.com,news1
 jianshu.com##.dt-open-bg[data-scene="leftBtn"]
 jianshu.com##.note-comment-above-ad-wrap
 theinventory.com,thetakeout.com,theonion.com,splinternews.com,clickhole.com,avclub.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotaku.com,lifehacker.com,theroot.com##main > div > script[type="application/ld+json"] ~ div[class*="-1 "][class*="-0 "]
-theinventory.com,thetakeout.com,theonion.com,splinternews.com,clickhole.com,avclub.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotaku.com,lifehacker.com,theroot.com##.inline-ad-container
 rbc.ru##.banners__mobile-freeze
 lifo.gr##.ad_inside > .sticky-wrap
 eporner.com###ad-top-2
 ||eporner.com/dotm/pop2.php
 outlook.live.com###topLevelItemsExceptFolderPane > main > div[class*=" "] > div[class^="_"]:not([role="group"])
-ficbook.net##.rkl-stick-to-bottom
 ck101.com###mobile_backgroundAD
 atlasobscura.com##.ad-background-intra-body
 insideevs.com##.top-banner-placeholder
@@ -1628,7 +1619,6 @@ focus.de,ampproject.org,newsweekjapan.jp,chip.de##.amp-outbrain
 trustedreviews.com##.ipc-advert
 |http$third-party,script,domain=kinotut.tv
 mobil.nwzonline.de,mobil-nwzonline-de.cdn.ampproject.org##.advert
-m.sweclockers.com##.header > .container > #topBanner
 lenfilm.tv##.rek
 mp4mania.rocks##center > a[rel="nofollow"] > img
 ||mobj.space/api/openOffer?asid=
@@ -1867,7 +1857,6 @@ m.watchcartoononline.io##div[id^="epmads-"]
 piluli.ru##div[id^="medads_banner"]
 bash.im##div[style*="width: 300px; height: 250px;"]
 sports.ru##iframe[src^="http://www.sports.ru/desktop/special"]
-m.9gag.com##section.salt-container
 livestrong.com##section[class*="js-mobile_adsense"]
 pornhd.com##ul.thumbs.inside-row > li:not([data-thumbindexes])
 ||48dreams.com/player/adstype/advmaker.php


### PR DESCRIPTION
```
! Dead
behacdn.ksmobile.net
cmdts.ksmobile.com
advs2sonline.goforandroid.com
advonline.goforandroid.com
a.6d47c1118927cf53ba9654931df80e8d.com
a.4ee395e5b8a076c7bd8592851ff8cad.com
mobula.ssl2.duapps.com
sync.mobojoy.baidu.com
api.mobojoy.baidu.com
js.mobojoy.baidu.com
a.f590906c3e6c07bb5f80801f2dfc4295.com
a.eed1729eebe45b8cd49e10f2dd80e297.com
pochengweiyuan.com
m.wangliqin.top
m.yangzhenpeng.top
92kyxiz5xg.execute-api.us-west-2.amazonaws.com
0jkro0unul.execute-api.us-west-2.amazonaws.com
nsjpu.com
nbvcb.xyz
cafe-latte.myshoplus.com
eysmaa.pw
eihjefbbbbddeiacedb.ru
zhfosenghtr.com
abtest.mistat.intl.xiaomi.com
opr.formulas.jp
d1zkodo2u3p4pe.cloudfront.net
adbetnet.advertserve.com
aclickoooo.host
883.engine.mobileapptracking.com
ads.cricbuzz.com
adops.cricbuzz.com
nasdfg.com
gocdn.ru
fastmap33.com
m.nbhaosheng168.com
m.jakc0.com
s.nvrentao8.com
xz15801.com
m.mrsasharingspace.com
dc.altamob.com
advantech.vo.llnwd.net
bandai.hs.llnwd.net
embanet.vo.llnwd.net
eyewond.hs.llnwd.net
finedesign.vo.llnwd.net
gulfstream.vo.llnwd.net
gymboree.hs.llnwd.net
harvardbp.vo.llnwd.net
hbpub.vo.llnwd.net
icvdm.vo.llnwd.net
inskin.vo.llnwd.net
msbmopod.vo.llnwd.net
msbrandent.vo.llnwd.net
navigon.vo.llnwd.net
nytelecom.vo.llnwd.net
rbb.ic.llnwd.net
responsys.hs.llnwd.net
surveyor.vo.llnwd.net
toyota.vo.llnwd.net
usarmy.vo.llnwd.net
textron.vo.llnwd.net
xmpie.vo.llnwd.net
sdk.adincube.com
ads.avocarrot.com
moatads.com.edgekey.net
nexage.akadns.net
listat.biz
mobsrv.in
dc.altmob.com
js4386.fujianryt.com
m.12306media.com
sube.puwangkj.com
m.jsqinvest.com
clickkydsp.com
eu-ma.sam4m.com
ad.kixer.com


! in EL
||ad2play.ftv-publicite.fr^
||admob.com^
||smaato.net^

! Redundant
ficbook.net##.rkl-stick-to-bottom
m.hindustantimes.com###stickydivAD

! avclub.com,clickhole.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotaku.com,lifehacker.com,splinternews.com,theinventory.com,theonion.com,theroot.com,thetakeout.com##.inline-ad-container
theinventory.com,thetakeout.com,theonion.com,splinternews.com,clickhole.com,avclub.com,deadspin.com,gizmodo.com,jalopnik.com,jezebel.com,kotaku.com,lifehacker.com,theroot.com##.inline-ad-container

! gordonua.com,strana.ua,24tv.ua##amp-iframe
gordonua.com##amp-iframe[src^="https://recreativ.ru/"]

!+ NOT_OPTIMIZED
24tv.ua##.within-ads
lifestyle.24tv.ua##div[class="within-ads"]

! m.lenta.ru##.b-banner-smi2
m.lenta.ru##amp-embed.b-banner-smi2

! gordonua.com,strana.ua,24tv.ua##amp-iframe
amp.strana.ua##amp-iframe[src^="https://mg.lentainform.com/"]

! m.sweclockers.com###topBanner
m.sweclockers.com##.header > .container > #topBanner

! dailywire.com##div[style^="width: 320px; height: 50px;"]
dailywire.com##article[class^="css-"] > div[style="width: 320px; height: 50px; margin: 0px auto 32px;"]

! detik.com##.footer_banner
m.detik.com##.footer_banner

! 9gag.com##.salt-container
m.9gag.com##section.salt-container

```

@ameshkov 