### PR TITLE
Scrolling fix for bhvr.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -3071,7 +3071,6 @@ argenta.be#$#.cookie-popup { display: none!important; }
 argenta.be#$#.modal--activeNoScroll { position: unset!important; }
 bhvr.com#$#.pum-overlay { display: none!important; }
 bhvr.com#$#body { overflow-x: visible!important; }
-bhvr.com#$#html { overflow: visible!important; }
 filmon.com##body > #design-switcher
 bip.kprm.gov.pl##body > .JSWrapper
 siparis.mcdonalds.com.tr##body > .alert-dismissible.notification[role="alert"]


### PR DESCRIPTION
Rule "bhvr.com#$#html { overflow: visible!important; }" from cookies_specific.txt in AdGuard Annoyances filter prevents scrolling on any page on [bhvr.com](bhvr.com).

***Description***:
* **Current behaviour**: 

Cannot scroll any page at [bhvr.com](bhvr.com) while subscribed to AdGuard Annoyances filter on uBlock Origin. Note the lack of a scrollbar on the right in the current behaviour screenshot vs expected behaviour.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/9457934/116847677-5f2a1a80-ac2e-11eb-85a3-f91e75706bfc.png)

</details>

* **Expected behaviour**: 

Should be able to scroll down on any page at [bhvr.com](bhvr.com) while subscribed to AdGuard Annoyances filter. Note the presence of a scrollbar on the right in the expected behaviour screenshot vs current behaviour.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/9457934/116847799-a31d1f80-ac2e-11eb-96c1-ca28c54e61b0.png)

</details>

***Steps to reproduce the problem***:

1. Subscribe to AdGuard Annoyances filter on any content blocker.
2. Go to any page on bhvr.com with content exceeding vertical monitor space and try to scroll down.

***System configuration***

**Filters:**

uBlock filters, uBlock filters - Badware risks, uBlock filters - Privacy, uBlock filters - Resource abuse, uBlock filters - Unbreak, AdGuard Base, EasyList, AdGuard Tracking Protection, EasyPrivacy, Online Malicious URL Blocklist, Spam404, **AdGuard Annoyances**, Fanboy's Annoyance, uBlock filters - Annoyances, Dan Pollock's hosts file, MVP HOSTS, Peter Lowe's Ad and tracking server list.

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Operating system version (Android/iOS) | Version 20H2 OS Build 19042.928
Browser:                               | Mozilla Firefox 88
AdGuard version:                       | N/A
Filters enabled:                       | Already listed above.
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | N/A
HTTPS filtering (Android only):        | N/A
Simplified filters (iOS only)          | N/A
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | N/A
Helpdesk ID (if exists):               | N/A