### PR TITLE
Remove widget.intercom.io

### DIFF
--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -332,7 +332,6 @@ macwelt.de,pcwelt.de#%#AG_setConstant('firebase.messaging', 'noopFunc');
 ||emarketingsuite.net^$third-party
 ||push.maribacaberita.com^
 ||iopushtech.com^$third-party
-||widget.intercom.io^$third-party,domain=~app.rezi.io|~intercom.com|~backerclub.co|~quidco.com|~green.energy
 ||pushpad.xyz^$third-party
 ||gagwebapi.com/api/webpush/$third-party
 ||foxpush.com^$third-party


### PR DESCRIPTION
widget.intercom.io is a common chat widget used by a lot of websites to facilitate chats between support staff and customers. Sometimes it is the only way of contacting support.

[SpinTel](https://spintel.net.au) is another website that makes use of this widget. It is not practical to have a growing and potentially very large exceptions list for this. The current rule already has 5 exceptions. It might be better to get rid of this rule entirely.

The widget typically appears at the bottom right of the viewport. Sometimes there is a slight delay and only loads after the rest of the page has fully loaded.