### PR TITLE
Remove obsolete filters

### DIFF
--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -15,10 +15,6 @@
 /^http:\/\/[0-9a-z]{8,}\.com\/[0-9a-z]{8,}\?(?:key|shu)=[0-9a-z]+/$subdocument,third-party
 /shrinker/js/h1j.js$script,~third-party
 /shrinker/js/h2j.js$script,~third-party
-! https://github.com/AdguardTeam/AdguardFilters/issues/70509
-.co/saber/
-.com/saber/
-.online/saber/
 !
 ! common TXXX network scripts
 /afon7.$script,~third-party


### PR DESCRIPTION
Added by https://github.com/AdguardTeam/AdguardFilters/commit/4ab6034428f3ce048115f9c6a238203505da8785 but looks to be obsolete, and causing FP at `https://www.kamen-rider-official.com/saber/`.