### PR TITLE
Fix linximpulse.net

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -138,7 +138,7 @@
 ||pensebig.com.br^$third-party
 ||tracking.m6r.eu^$third-party
 ||analytics.ratopanda.com^$third-party
-||suite*.linximpulse.net^$third-party
+||linximpulse.net^$third-party
 ||retargeter.com.br^$third-party
 ||shotarget.co.uk^$third-party
 ||shopback.net^$third-party


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

The current rule is not blocking subdomains, and it looks like that domain has several. and they are all a bunch of shit
