### PR TITLE
flipacoin.fun - placeholder

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -278,6 +278,8 @@ feetporno.com,familyporn.tv,freehardcore.com,webvoyeur.com,moviesand.com,momvids
 !
 !
 !
+flipacoin.fun##.rect_ad
+flipacoin.fun##.google_ad
 acronymfinder.com##.sc
 ||javbobo.com/little-hall-f39d/
 calmclinic.com##.sharp-block


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: Ad placeholders

[//]: # (Substitute this line with a description of the problem)

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>
<img alt="flipacoin.fun homepage with ad placeholders" src="https://user-images.githubusercontent.com/11537232/121904371-a7058c80-cd18-11eb-8099-443ba04f4c78.png" />
</details><br/>

***Steps to reproduce the problem***: visit https://flipacoin.fun