### PR TITLE
The 10th large cleanup of JP filters

### DIFF
--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -201,9 +201,6 @@ avgle.com#@#a[href^="http://bongacams.com/track?"]
 !@@||ie8eamus.com/sfp.js$domain=avgle.com
 !@@||fingahvf.top/advertisers.js$domain=avgle.com
 @@||avgle.com/include/ajax/related_videos.php
-! no referrer
-@@||*.info/sc?u=
-@@||*.club/sc?u=
 !+ PLATFORM(ios, android, ext_android_cb)
 @@||static.avgle.com/media/av^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9125

--- a/JapaneseFilter/sections/general_url.txt
+++ b/JapaneseFilter/sections/general_url.txt
@@ -19,8 +19,6 @@
 /adcast01_
 /adContents_
 /adgetter.
-/AdLantis.
-/AdLantisLoader.
 /adparts/*
 /adSidebar.
 /advalue_

--- a/JapaneseFilter/sections/general_url.txt
+++ b/JapaneseFilter/sections/general_url.txt
@@ -8,7 +8,6 @@
 .jp/bannar/
 .jp/html.ng/
 .jp/image/ad/
-.jp/js.ng/cat=
 .jp/log.php?
 .jp/ufo/$script,third-party
 .jp/Zen?
@@ -25,18 +24,13 @@
 /adparts/*
 /adSidebar.
 /advalue_
-/banana/600x
 /banimg/*
-/images/gban/*
 /images/tamakuri
 /js/dlvRequest.
 /js/dlvRequest_
 /js/fix_ad.js?
 /js/ulizahtml5-advertising.
-/mini_ads.php?
 /parts/ad/*
-/popjs.asp
-/random_bnr/*
 /TextAD1.
 /top/head_bnr
 /openstrap/js/meerkat_side_double_ad.js


### PR DESCRIPTION
```
! All of them except for the last two are 0 hit in statistics
! comments are hits in publicwww

! 1 hit
.jp/js.ng/cat=

! 120 hits but essntially no hit (different paths)
/images/gban/*

! 4
/popjs.asp

! 13
/random_bnr/

! 0
/banana/600x

! 1
/mini_ads.php?

! Didn't remove for hits in publicwww, but I'm pretty sure these generic cosmetic filters should be removed from JPF
! 383 but mostly not JP (same goes for all the below)
! ###photo_ad_google

! 457
! ##.adsenseBox

! 377
! ###ad_interestmatch

! 378
! ###ad_interestmatch400

! 383
! ###photo_ad_google

! 396
! ###d4_ad_google02

! added by https://github.com/AdguardTeam/AdguardFilters/commit/0cbfead but looks obsolete
@@||*.club/sc?u=
@@||*.info/sc?u=
```