### PR TITLE
cnbeta.com hide the "disable adblock" banner

### DIFF
--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -46,6 +46,7 @@ sogou.com###emailLogin > div.hd-slider
 wenxuecity.com##.otherposts > ul > li > a[target="_blank"]
 ||huiji-fs.oss-cn-qingdao.aliyuncs.com/huijiad/
 cnbeta.com##div[style="width:285px;height:360px;background:#fff;"]
+cnbeta.com##div[style$="z-index:99999"]
 jable.tv##.text-center > a[target="_blank"] > img
 ||mypianku.net/ajax/MyJs/
 ||fmgmh.com/template/wap/default/js/lunbo.js


### PR DESCRIPTION
***Description***:
* **Current behaviour**: 

A red banner is shown at the bottom of the article pages, e.g. https://hot.cnbeta.com/articles/movie/1144351.htm .

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/8171899/123230636-09753e80-d50a-11eb-9ee4-9176ad44ba07.png)

</details><br/>

* **Expected behaviour**: 

The banner is hidden.
