### PR TITLE
Update popups.txt

### DIFF
--- a/AnnoyancesFilter/sections/popups.txt
+++ b/AnnoyancesFilter/sections/popups.txt
@@ -3114,7 +3114,7 @@ hdkinoshka.net,timeallnews.ru###bg_popup
 expertreviews.co.uk,autoexpress.co.uk,alphr.com,itpro.co.uk###block-dennis-newsletter-newsletter-block
 softpedia.com###bottombubble
 androidcanavari.net###cboxOverlay
-lafmacun.net,stilearte.it,windowsable.com,indirin.co,unikampus.net,kadinbilgiportali.com,sagligimicinhersey.com,sosyalmedyapazarlama.com,rockistasyonu.com,bs16.com,akittv.com.tr,hukukbook.com,baskadunyalardavar.com,hukukiterimler.com,havadiskibris.com,asksozlerimiz.com,hukukiblog.com,ankaram.net,kliniksaglik.com,ciltbilgi.com,kitapkafalar.com,iyiyemektarifleri.net,bodrumguncelhaber.com,codewk.com,elitbursa.com,gggmedya.com,trafiksozluk.com,kahvve.com,finanssepeti.com,borsarti.com,atifzafrak.com,kadinlarkulubu.com,besttechinfo.com,maksatbilgi.com,gamesforpublic.de,filmlinks4u.is,formatatmak.com,gaste.org,geziseli.com,gozdehaber.org,haberdan.com,sarkidinle.gen.tr,z-news.link###check-also-box
+lafmacun.net,windowsable.com,indirin.co,unikampus.net,sosyalmedyapazarlama.com,rockistasyonu.com,hukukbook.com,havadiskibris.com,asksozlerimiz.com,hukukiblog.com,ankaram.net,ciltbilgi.com,iyiyemektarifleri.net,bodrumguncelhaber.com,codewk.com,borsarti.com,besttechinfo.com,gamesforpublic.de,filmlinks4u.is,geziseli.com,z-news.link###check-also-box
 fishki.net###chrome_popup
 bilecikhaber.com.tr###cm-social-overlay
 androidcanavari.net,dnepr24.com.ua###colorbox


### PR DESCRIPTION
Deleted because dead domains.

`kadinbilgiportali.com,hukukiterimler.com,kitapkafalar.com,gggmedya.com,finanssepeti.com,atifzafrak.com,haberdan.com,sarkidinle.gen.tr`

---

They do not use the `###check-also-box` widget due to the redesign.

`sagligimicinhersey.com,akittv.com.tr,baskadunyalardavar.com,elitbursa.com,kahvve.com,maksatbilgi.com,gaste.org,gozdehaber.org`

---

These sites no longer use the `###check-also-box` widget. `###check-also-box` not showing in the HTML and filtering log.

`stilearte.it,bs16.com,kliniksaglik.com,trafiksozluk.com,kadinlarkulubu.com,formatatmak.com`