### PR TITLE
Update popups.txt

### DIFF
--- a/AnnoyancesFilter/sections/popups.txt
+++ b/AnnoyancesFilter/sections/popups.txt
@@ -2712,7 +2712,7 @@ sanalyer.com##.content-bottom
 sibnet.ru##.sibnet-notifications
 rasthaber.com##.notification-box
 photoshoplady.com##.wph-modal
-ajanskarabuk.com,duzcepusula.com,denizlidesiyaset.com,malatyadan.com,egepolitik.com,izmiredair.com,kulishaber.com.tr,uretenankara.com,gunedogushaber.com,murekkephaber.com,edirnegazetesi.com.tr,abdpost.com,saatbasihaber.com,izmirhabermerkezi.com,ihbarajans.com,batialanya.com,mahalligundem.com,ashaber.com,thecruiselife.com.tr,ekrangazetesi.com,mansetizmir.com,denizliekspres.com.tr,banazguncelhaber.com,sakaryahaber.com,akdenizbulten.com,borsa365.com,haberankara.com,bakirkoygazetesi.com,ankaraport.net,aksehirpostasi.com,ilerigazetem.com,oncusehir.com,karamanca.net,kanalege.com.tr,turizmnews.com,sakinca.com,cayyolu.com.tr,trakyanews.com,ekonomidunya.com,spilhaber.com,marasnews.com,elazighakimiyethaber.com,tokathaber.com.tr,yeniakcakocahaber.com,gundogumu.com,batikaradeniz.net,larende.com,iskilipinsesi.com,gazete365.com,canakkaletv.com.tr,haber16.com,projemlak.com,turgutluyanki.com,teknolojic.com##.kosehbr
+ajanskarabuk.com,duzcepusula.com,egepolitik.com,kulishaber.com.tr,gunedogushaber.com,saatbasihaber.com,izmirhabermerkezi.com,mahalligundem.com,ashaber.com,thecruiselife.com.tr,mansetizmir.com,denizliekspres.com.tr,banazguncelhaber.com,akdenizbulten.com,ankaraport.net,aksehirpostasi.com,ilerigazetem.com,oncusehir.com,kanalege.com.tr,turizmnews.com,cayyolu.com.tr,trakyanews.com,ekonomidunya.com,spilhaber.com,marasnews.com,tokathaber.com.tr,yeniakcakocahaber.com,batikaradeniz.net,iskilipinsesi.com,projemlak.com,##.kosehbr
 dermoloji.com##.greensboro-background
 palitranews.az###exestylepopupdiv
 azertag.az##.notification-container


### PR DESCRIPTION
Dead domains
`ihbarajans.com,borsa365.com`

---

They don't use the `kosehbr` tool because they have a new design.
`ekrangazetesi.com,sakaryahaber.com,sakinca.com,elazighakimiyethaber.com,larende.com,teknolojic.com`

---

These sites no longer use the `kosehbr` widget. `kosehbr` not showing in the HTML and filtering log.
`denizlidesiyaset.com,malatyadan.com,izmiredair.com,uretenankara.com,murekkephaber.com,edirnegazetesi.com.tr,abdpost.com,batialanya.com,haberankara.com,bakirkoygazetesi.com,karamanca.net,gundogumu.com,gazete365.com,canakkaletv.com.tr,haber16.com,turgutluyanki.com`