### PR TITLE
Fix empty space on 01net.com mobile

### DIFF
--- a/FrenchFilter/sections/specific.txt
+++ b/FrenchFilter/sections/specific.txt
@@ -2,6 +2,7 @@
 !-------------------- Specific rules --------------------!
 !--------------------------------------------------------!
 !
+01net.com##.mrf-adv__wrapper
 jeuxvideo.com##.sideWootbox
 actu-environnement.com##.module_annonce
 orange.fr##.autopromo-prospect


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***: Blank space on https://www.01net.com/actualites/windows-11-mort-de-mcafee-et-chronologie-des-medias-le-resume-de-l-actu-tech-de-la-semaine-2045147.html mobile UA.
* **Current behaviour**: 


![123507376-4d328a00-d669-11eb-9f24-878b72cf13d7](https://user-images.githubusercontent.com/1659004/123513354-ec469880-d6e0-11eb-9950-f179795409a2.png)



***Steps to reproduce the problem***:

[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)

***System configuration***

**Filters:**

`Reported here:`

https://github.com/brave/brave-browser/issues/16629




