### PR TITLE
obsolete rules

### DIFF
--- a/AnnoyancesFilter/sections/popups.txt
+++ b/AnnoyancesFilter/sections/popups.txt
@@ -1675,7 +1675,7 @@ profesor10demates.com###elementor-popup-modal-5929
 kocaelihaberci.com###emanset
 taz.de##div[id^="tzi-paywahl-"]
 pickpoint.ru##.a-popup
-mustafabukulmez.com,teknobird.com,ultrabilgi.com,buneymis.net,teknoxhaber.com,kirtkirtla.com,muglaweather.com,oyuncukuru.org##.more-in-category
+mustafabukulmez.com,teknobird.com,buneymis.net,kirtkirtla.com##.more-in-category
 103.194.171.75,idtube.me##.overlay.bm
 creative-beast.com##div.mo-has-name-email.moModal
 systweak.com###SubscribePopUpBox
@@ -2623,7 +2623,7 @@ masmotors.ru###block-webform-client-block-5816.block-webform
 masmotors.ru###block-webform-client-block-7622.block-webform
 itcrumbs.ru##.check-also-right
 hse24.de##div#hse-modal[data-src="/cmsresources/html-layer/include-snippet-first-visit-newsletter-registation.html"]
-lojistiknews.com,yenimuhalefet.com,tedavievde.com###yanilgi
+lojistiknews.com,yenimuhalefet.com###yanilgi
 delo.ua###formEmail
 themarker.com,haaretz.co.il##.modal-wrapper.js-subscription-popups
 babaszoba.hu#$#body.modal-open { overflow: visible!important; }
@@ -2708,7 +2708,7 @@ seriesgato.tv,sportstream.tv##body > div[style^="z-index: 99999999; width: 100%;
 yeniisfikirleri.net##.scrollbox-popup
 euroinvision.ru###fancybox-overlay
 euroinvision.ru##.fancybox-desktop[style*="width: 420px; height: auto;"]
-haber1461.com,boyabatsonhaber.com,haberaramizda.com,airlinehaber.com,guneydoguguncel.com###ilgisistemi
+boyabatsonhaber.com###ilgisistemi
 camgirlbay.net,camwhores.video,camwhores.tv,cambabe.me##.hola_top_element
 ||creativecommons.org/wp-content/uploads/pum/
 vm.ru##.subscribe--container
@@ -2797,7 +2797,7 @@ rynek-kolejowy.pl##.popupModal
 rynek-kolejowy.pl##.popupElement
 price.ru##div[data-region="bumerang_email"]
 budsgunshop.com##.popupboxnewoffer
-siporcu.com,gunbasi.com,magazinlife.com,tavsanlihaber.com.tr,imzagazetesi.com.tr,hurdusun.com,bodrumtime.net,yurthaber61.com,61medya.net,aksamhaberleri.com.tr,superkulup.com,capakcurgazetesi.com.tr,adanaulus.com,kanal42haber.com,turkiyeaktuel.com,medyayenigun.net,tarsusbeyazhaber.com,gercekkarabuk.com,superligyolu.com,guclukarabuk.com,mebajans.com,haberege.com.tr,kibrisgercek.com,keyfgazetesi.com,pasada.com.tr,medyahanesi.com,fisiltimedyahaber.com,koroglugazetesi.com,ukraynahayat.com###socialslide
+siporcu.com,tavsanlihaber.com.tr,hurdusun.com,bodrumtime.net,capakcurgazetesi.com.tr,turkiyeaktuel.com,koroglugazetesi.com,ukraynahayat.com###socialslide
 52av.tv###fwin_popad_7ree
 eodev.com##.sg-overlay
 gearpatrol.com##.frame-container.picreel-element


### PR DESCRIPTION
`##.more-in-category`

- Dead domains - `ultrabilgi.com,teknoxhaber.com`
- `muglaweather.com` no longer use the `more-in-category` tool because it has a new design.
- `oyuncukuru.org` no longer use the `more-in-category` widget. `more-in-category` not showing in the HTML and filtering log. 


---

`###yanilgi`


 - `tedavievde.com` no longer use the `yanilgi` tool because it has a new design.
---

`###ilgisistemi`

 - Dead domain - `haber1461.com`

 - `guneydoguguncel.com` no longer use the `ilgisistemi` widget. `ilgisistemi` not showing in the HTML and filtering log. 

 - They don't use the `ilgisistemi` tool because they have a new design. - `haberaramizda.com,airlinehaber.com`

---

`###socialslide`


- Dead domains:
`gunbasi.com,tarsusbeyazhaber.com,gercekkarabuk.com,superligyolu.com,guclukarabuk.com`

- They don't use the `socialslide` tool because they have a new design.
`magazinlife.com,imzagazetesi.com.tr,yurthaber61.com,61medya.net,aksamhaberleri.com.tr,kanal42haber.com,medyayenigun.net,kibrisgercek.com,keyfgazetesi.com,pasada.com.tr,medyahanesi.com,fisiltimedyahaber.com`

- These sites no longer use the `socialslide` widget. `socialslide` not showing in the HTML and filtering log. 
`superkulup.com,adanaulus.com,mebajans.com,haberege.com.tr`




