### PR TITLE
Update push-notifications.txt

### DIFF
--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -747,7 +747,7 @@ indiatimes.com###pushSec
 24tv.ua###pushSubscribeModal
 ntv.ru###push_alert
 qrz.ru###qrzpush-prompt-widget
-bandirmasehir.com,gunlukbakis.com,karabukgundem.com,durusthaber.com,siporcu.com,balikesirhaber.net,manisahalkhaber.com,silopigazetesi.com.tr,gundemankara.net,15temmuzgazetesi.com,akcakocagazetesi.com,yenibizimadana.com,kumlucaweb.com,mkphaber.com,gazetecorlu.com,pasinlerhaber.com,gundogmusgazetesi.com,kirikhangazetesi.net,haberyaziyorum.com,edeajans.com.tr,tasimapostasi.com,bitlisdogruhaber.com,hamlegazetesi.com.tr,businesschannel.com.tr,gunbasi.com,magazinlife.com,tavsanlihaber.com.tr,imzagazetesi.com.tr,hurdusun.com,yurthaber61.com,61medya.net,medyaayvalik.com,macadogru.com.tr,kanal42haber.com,brtv.com.tr,kanalurfa.com,kibrisgercek.com,tekkocaeli.com,parlamentohaber.com,medyahanesi.com,amasyagazetesi.com,aksamhaberleri.com.tr,fisiltimedyahaber.com,ukraynahayat.com,koroglugazetesi.com,habertam.com,nededik.com##.alerttt
+bandirmasehir.com,gunlukbakis.com,karabukgundem.com,siporcu.com,manisahalkhaber.com,silopigazetesi.com.tr,yenibizimadana.com,gazetecorlu.com,gundogmusgazetesi.com,haberyaziyorum.com,edeajans.com.tr,tasimapostasi.com,bitlisdogruhaber.com,tavsanlihaber.com.tr,hurdusun.com,medyaayvalik.com,brtv.com.tr,kanalurfa.com,parlamentohaber.com,amasyagazetesi.com,ukraynahayat.com##.alerttt
 trinixy.ru##.b-notification-push
 gittigidiyor.com##.gg-subscribe-container
 anews.com.tr,yeniasir.com.tr,aspor.com.tr,fotomac.com.tr,fikriyat.com,ahaber.com.tr,sabah.com.tr,takvim.com.tr##.notBar


### PR DESCRIPTION
- Dead domains or expired

`kumlucaweb.com,pasinlerhaber.com,kirikhangazetesi.net,gunbasi.com,macadogru.com.tr,fisiltimedyahaber.com,nededik.com`

---

- These sites no longer use the `alerttt` widget. 
`alerttt` not showing in the HTML and filtering log.

`durusthaber.com,15temmuzgazetesi.com,hamlegazetesi.com.tr,aksamhaberleri.com.tr,koroglugazetesi.com,habertam.com`

---

- They no longer use the `alerttt` tool because they have a new design.

`balikesirhaber.net,gundemankara.net,akcakocagazetesi.com,mkphaber.com,businesschannel.com.tr,magazinlife.com,imzagazetesi.com.tr,yurthaber61.comi61medya.net,kanal42haber.com,kibrisgercek.com,tekkocaeli.com,medyahanesi.com`