### PR TITLE
Duryytt patch 1

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -6,7 +6,7 @@
 ://i.resimyukle.xyz^$domain=rexfilmizle.com|unyenethaber.com
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5969
-/images/banner/*$domain=haberabd.com|haberinadresi.com|yalovagazetesi.com|superyenihaber.net|diyarinsesi.org|46haber.com|adanahaber.net|haber46.com.tr|cukurovaexpres.com|ciddigazete.com|karamangundem.com|tercihiniyap.net
+/images/banner/*$domain=haberabd.com|haberinadresi.com|yalovagazetesi.com|superyenihaber.net|diyarinsesi.org|46haber.com|haber46.com.tr|cukurovaexpres.com|ciddigazete.com|karamangundem.com|tercihiniyap.net
 !
 ! For URL shorteners or simple sites with frequently changed ad servers.
 ! Incorrectly blocked domains can be excluded using regex(synchronize this regexp in all filters)

--- a/TurkishFilter/sections/whitelist.txt
+++ b/TurkishFilter/sections/whitelist.txt
@@ -5,7 +5,7 @@
 @@||aj1907.online/*?cp.host=*&cp.adblock=$domain=turkturk.net
 @@||aj2178.online/*?cp.host=$domain=turkturk.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/86325
-one.com.tr#@#.social-box
+numberone.com.tr#@#.social-box
 ! https://github.com/AdguardTeam/AdguardFilters/issues/86183
 fullfilmizle.vip#@#.rkads
 ! wsommelier.com top images

--- a/TurkishFilter/sections/whitelist.txt
+++ b/TurkishFilter/sections/whitelist.txt
@@ -5,7 +5,7 @@
 @@||aj1907.online/*?cp.host=*&cp.adblock=$domain=turkturk.net
 @@||aj2178.online/*?cp.host=$domain=turkturk.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/86325
-numberone.com.tr#@#.social-box
+one.com.tr#@#.social-box
 ! https://github.com/AdguardTeam/AdguardFilters/issues/86183
 fullfilmizle.vip#@#.rkads
 ! wsommelier.com top images
@@ -132,8 +132,6 @@ adanaseshaber.com#@#.adsbygoogle
 4kfullhdfilmizle.net#@##reklamarkaplan
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53468
 gergerhaber.net#@#.adsbygoogle
-! https://github.com/AdguardTeam/AdguardFilters/issues/52039
-@@||numberone.com.tr/wp-content/themes/numberone/css/reklam-port/player_*.css
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50652
 hdfilmizlett1.com#@#div[class^="bireklam"]
 ! Fixing images
@@ -191,8 +189,6 @@ m.dizimob1.com#@##reklami
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=beinsports.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11431
 futbolcafetv6.org#@##reklam
-! https://github.com/AdguardTeam/AdguardFilters/issues/10088
-49.com.tr#@#.home-ad
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9755
 @@||akstatic.lcwaikiki.com/Resource
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8219
@@ -203,8 +199,6 @@ zxro.com#@#.splash-reklam
 @@||iatv.tmgrup.com.tr/*/advmanager.js$domain=atv.com.tr
 ! https://forum.adguard.com/index.php?threads/25057/
 @@||ads.pivol.net/campaign/$domain=dizifilm.com
-! https://forum.adguard.com/index.php?threads/adanahaber-net.21034/ - un-hiding logo
-@@||www.adanahaber.net/images/banner/15000
 ! https://forum.adguard.com/index.php?threads/haberler-com.19961/
 haberler.com#@#iframe[width="300"][height="250"]
 ! https://forum.adguard.com/index.php?threads/17091/


### PR DESCRIPTION
Removed obsolete rules

`@@||numberone.com.tr/wp-content/themes/numberone/css/reklam-port/player_*.css` removed because they changed their design.

`49.com.tr#@#.home-ad` It doesn't show up in hmtl.

`adanahaber.net/images/banner/15000` is not working.
`/images/banner/*$domain=adanahaber.net` removed because it was also blocking the logo of this site.
