### PR TITLE
Remove obsolete filters

### DIFF
--- a/SpywareFilter/sections/whitelist.txt
+++ b/SpywareFilter/sections/whitelist.txt
@@ -2894,9 +2894,6 @@ mozilla-russia.org#@#img[width="88"][height="31"]
 @@||tablica.pl^*/xtcore.js
 ! Portuguese
 @@||77.91.202.130/js/20050/xiti.js$domain=custojusto.pt
-@@||dfdbz2tdq3k01.cloudfront.net/js/2.1.0/IbtRealTimeSJ/IbtRealTimeSJ.js?$domain=social.economico.pt
-@@||dfdbz2tdq3k01.cloudfront.net/js/2.1.0/IbtRealTimeSJ/IbtRealTimeSJCore.js?$domain=social.economico.pt
-@@||dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js$domain=social.economico.pt
 @@||google-analytics.com/urchin.js$domain=record.xl.pt
 ! Russian
 @@||afisha.ru/proxy/videonetworkproxy.ashx?$xmlhttprequest


### PR DESCRIPTION
social.economico.pt is NXDOMAIN.