### PR TITLE
Replace AG_abortOnPropertyRead rules - part 1

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -1117,7 +1117,6 @@ aamulehti.fi#$#.ad-div.mainos.rectangle-ad.ALMACR-container { display: block!imp
 015.by##.bung-container
 ||thelibertydaily.com/*/adtoniq/js/niqon.js
 10play.com.au#%#//scriptlet("abort-on-property-read", "adsStatus")
-lavoz.com.ar#%#AG_abortOnPropertyRead('cX');
 lavoz.com.ar#%#//scriptlet("abort-on-property-read", "cX")
 abc.es#@#.div-gpt-ad
 123moviestoday.net#%#(function(){var b=window.alert;window.alert=function(a,c){if(!/please disable your ad blocker/.test(a.toString()))return b(a,c)};})();
@@ -1187,7 +1186,7 @@ readcomiconline.to#%#AG_setConstant('alb', 'false');
 bgr.com#@##adBanner
 @@||amazonaws.com/ads^$domain=americanlookout.com
 telestar.fr##.dfp-slot-megaban
-sme.sk#%#AG_abortOnPropertyRead('GoogleContributor');
+sme.sk#%#//scriptlet("abort-on-property-read", "GoogleContributor")
 @@||questtime.net/js/adverts.js
 @@||cdn.hanime.tv/exoclick.ads*.js
 @@||androidplanet.nl/*/ads.js

--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -784,10 +784,7 @@ officelife.media#$##subscribePushModal ~ div.modal-backdrop { display: none !imp
 officelife.media#$#body { overflow: visible !important; }
 !+ NOT_OPTIMIZED
 015.by###push-panel
-!+ NOT_PLATFORM(windows, mac, android)
 filmweb.pl#%#//scriptlet("abort-on-property-read", "webPushPublicKey")
-!+ PLATFORM(windows, mac, android)
-filmweb.pl#%#AG_abortOnPropertyRead('webPushPublicKey');
 !+ NOT_OPTIMIZED
 armeniasputnik.am,sputniknewslv.com##.modal-push
 !

--- a/AnnoyancesFilter/sections/tweaks.txt
+++ b/AnnoyancesFilter/sections/tweaks.txt
@@ -1404,10 +1404,7 @@ quotev.com#%#//scriptlet("remove-attr", "onselectstart|ondragstart|unselectable"
 quotev.com#%#AG_onLoad(function() { document.body.onselectstart = document.body.ondragstart = function() { return true; }; });
 flying-lines.com,fssp.gov.ru#%#Object.defineProperties(document,{oncontextmenu:{get:function(){},set:function(){}},onselectstart:{get:function(){},set:function(){}}});
 psycabi.net#%#//scriptlet("abort-on-property-read", "addLink")
-!+ NOT_PLATFORM(windows, mac, android)
-e-marineeducation.com#%#//scriptlet('abort-on-property-read', 'disableSelection')
-!+ PLATFORM(windows, mac, android)
-e-marineeducation.com,waktusehat.xyz,viralogic.xyz,anisubindo.video,portalwrc.pl#%#AG_abortOnPropertyRead('disableSelection');
+e-marineeducation.com,waktusehat.xyz,viralogic.xyz,anisubindo.video,portalwrc.pl#%#//scriptlet('abort-on-property-read', 'disableSelection')
 orangespotlight.com#%#//scriptlet("remove-attr", "data-protect", "body[data-protect]")
 as-selection.net,gembel9.xyz,gembelcit.net#%#//scriptlet("remove-attr", "oncontextmenu|ondragstart|onkeydown|onmousedown|onselectstart", "body")
 mangaku.in,pisap.tk,salahstream.ml#%#AG_abortInlineScript(/contextmenu/, '$');
@@ -1422,7 +1419,7 @@ poisonous-raspberry-fields.blogspot.com#%#//scriptlet("remove-attr", "onmousedow
 wattpad.com#%#window.addEventListener("contextmenu",function(a){a.stopPropagation()},!0); window.addEventListener("copy",function(a){a.stopPropagation()},!0);
 kanalmaras.com#%#AG_onLoad(function() { document.body.ondragstart = document.body.onselectstart = document.body.oncontextmenu = function() { return true; }; });
 kentdeha.com.tr,phoneinfo.com.br#%#AG_onLoad(function() { document.ondragstart = document.onselectstart = document.oncontextmenu = document.onmousedown = function() { return true; }; });
-waktusehat.xyz,viralogic.xyz#%#AG_abortOnPropertyRead('mousedwn');
+waktusehat.xyz,viralogic.xyz#%#//scriptlet("abort-on-property-read", "mousedwn")
 voxc.org,irisbuddies.blogspot.com,4kfilmizle.org,panditfiles.pro,animesrbija.com#%#AG_onLoad(function() { document.oncontextmenu = function() { return true; }; });
 papahd.live#%#AG_onLoad(function() { document.onkeydown = document.body.oncontextmenu = document.oncontextmenu = function() { return true; }; });
 ouo.io#%#AG_onLoad(function() { setTimeout(function() { var form = document.querySelector("#form-captcha > #captcha > button"); if(form) { form.click(); } ; }, 300); });

--- a/ChineseFilter/sections/antiadblock.txt
+++ b/ChineseFilter/sections/antiadblock.txt
@@ -89,7 +89,7 @@ javfree.club#$##adisblock { display: none!important; }
 javfree.club##.loaded-popup-wrapper
 javfree.club#%#(function() { var w_open = window.open, regex = /agxclick\.com/; window.open = function(a, b) { if (typeof a !== 'string' || !regex.test(a)) { w_open(a, b); } }; })();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33643
-papalah.com#%#AG_abortOnPropertyRead('adBlockDetected');
+papalah.com#%#//scriptlet("abort-on-property-read", "adBlockDetected")
 @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=papalah.com
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||papalah.com^$generichide

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -3921,7 +3921,7 @@ abs-cbn.com#@#.adsbox
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 @@.png#-$domain=pharmaguideline.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35670
-kitploit.com#%#AG_abortOnPropertyRead('adB');
+kitploit.com#%#//scriptlet("abort-on-property-read", "adB")
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=kitploit.com
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=kitploit.com
@@ -4347,7 +4347,7 @@ manyak.info$$script[tag-content="[][(![]+[])[+[]]"][min-length="15000"][max-leng
 @@||manyak.info^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33870
 @@||123link.biz/js/blockadblock.js
-123link.biz#%#AG_abortOnPropertyRead('showAdsBlock');
+123link.biz#%#//scriptlet("abort-on-property-read", "showAdsBlock")
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||123link.biz^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33932
@@ -7058,7 +7058,7 @@ forum.hackinformer.com#@#.adsbygoogle
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=fcportables.com
 fcportables.com##body > div[id^="ai-adb-"][style^="position: fixed; top:"][style*="z-index: 9999"]
-fcportables.com#%#AG_abortOnPropertyRead('ai_check_block');
+fcportables.com#%#//scriptlet("abort-on-property-read", "ai_check_block")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13888
 !+ PLATFORM(ios, ext_android_cb)
 @@||funimation.com^$generichide
@@ -7631,7 +7631,7 @@ masseurporn.com#@#.ad-body
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33815
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23999
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8168
-next-episode.net#%#AG_abortOnPropertyRead('tryCheckB32');
+next-episode.net#%#//scriptlet("abort-on-property-read", "tryCheckB32")
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=next-episode.net
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb)

--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -1241,10 +1241,7 @@ lingea.sk#?#.container > div.col-sm-9 > div.bx-wrapper:has(> div.bx-viewport > d
 ||rsz.sk^$third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45430
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=svetandroida.cz
-!+ NOT_PLATFORM(windows, mac, android)
 svetandroida.cz#%#//scriptlet("abort-on-property-read", "detectAdBlocker")
-!+ PLATFORM(windows, mac, android)
-svetandroida.cz#%#AG_abortOnPropertyRead('detectAdBlocker');
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=svetandroida.cz
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44916
@@ -1316,8 +1313,6 @@ sector.sk#$#body > .frstop[style="margin-top:250px"] { margin-top: 45px!importan
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39754
 volvo-club.cz#$##obalovydiv { display: block!important; }
 volvo-club.cz#%#//scriptlet("abort-on-property-read", "gaFailedToLoad")
-!+ PLATFORM(windows, mac, android)
-volvo-club.cz#%#AG_abortOnPropertyRead('gaFailedToLoad');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38683
 auto.cz##body > video[id^="vided-"][src^="data:video/webm"]
 auto.cz#?#.right-col > #sticky-wrapper:has( > div[id^="sticky-banner-"])
@@ -3470,7 +3465,6 @@ shvoong.co.il#$##ppsPopupBgOverlay  { display: none!important; }
 shvoong.co.il#$#html[style="overflow: hidden;"] { overflow: visible!important; }
 shvoong.co.il#$#body[style="overflow: hidden;"] { overflow: visible!important; }
 shvoong.co.il#$#html > body { background-image: none!important; cursor: default!important; }
-shvoong.co.il#%#AG_abortOnPropertyRead('bg_backgrounds');
 shvoong.co.il#%#//scriptlet("abort-on-property-read", "bg_backgrounds")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37946
 haaretz.co.il###pageRoot > div > section > div > a[href^="http://bit.ly"]
@@ -4510,8 +4504,6 @@ gugomah.tistory.com,ilsangt.tistory.com#$#.adsense-area { height: 1px!important;
 ilsangt.tistory.com#@#.adsense-area
 ! https://github.com/AdguardTeam/AdguardFilters/issues/48056
 gugomah.tistory.com#%#//scriptlet("abort-on-property-read", "checkAds")
-! https://github.com/AdguardTeam/AdguardFilters/issues/34623
-web1907.tistory.com#%#AG_abortOnPropertyRead('blockCode');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34577
 moroa.tistory.com#%#AG_setConstant('adsbygoogle.loaded', 'true');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72172
@@ -7296,7 +7288,7 @@ shinden.pl###spolSticky
 shinden.pl##.spolecznoscinet
 shinden.pl##iframe[src^="https://reklama.shinden.eu/adpeeps.php?"]
 shinden.pl#$?#.ads { remove: true; }
-shinden.pl#%#AG_abortOnPropertyRead('popjs.init');
+shinden.pl#%#//scriptlet("abort-on-property-read", "popjs.init")
 shinden.pl#%#Object.defineProperty(window, 'PopAds', { get: function() { return; } });
 shinden.pl#%#window.iFrameResize = function() {};
 shinden.pl#%#window.sas_noad = true;
@@ -7867,7 +7859,7 @@ jizz99.com,bonbonyou.com###inplayer
 goodav17.com##.ads_pc
 goodav17.com###sticky_ads
 goodav17.com##div[id$="content"] > div[style="margin: 0 auto; text-align:center; margin-top:30px; width:90%;"]
-goodav17.com#%#AG_abortOnPropertyRead('popunder');
+goodav17.com#%#//scriptlet("abort-on-property-read", "popunder")
 goodav17.com$$script[tag-content="getPopunderCookie"][max-length="2500"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35953
 league-funny.com##.player_bb
@@ -8392,7 +8384,6 @@ opuree.com#%#window.detector_active = true;
 @@||opuree.com/scr/detector/adsbygoogle.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41681
 ||ksubthai.co^$popup,domain=kseries.tv
-kseries.tv#%#AG_abortOnPropertyRead('tabUnder');
 kseries.tv#%#//scriptlet("abort-on-property-read", "tabUnder")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18059
 kod-hd.com##center > a[href][target="_blank"][rel="nofollow"] > img
@@ -8741,7 +8732,6 @@ kingphim.net##a[href^="https://bit.ly/"][target="_blank"] > div[style]
 ||kingphim.net/play/*.xml|
 ||iamcdn.net/players/jwplayer/*/plugins/vast.js$domain=kingphim.net
 kingphim.net#%#//scriptlet("abort-on-property-read", "popunder")
-kingphim.net#%#AG_abortOnPropertyRead('popunder');
 ! https://github.com/AdguardTeam/AdguardFilters/issues/41731
 ! https://github.com/AdguardTeam/AdguardFilters/issues/40545
 ||jbovn.com^$popup,domain=animetvn.tv


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/88860

`web1907.tistory.com#%#AG_abortOnPropertyRead('blockCode');` is not needed, because there is already - `tistory.com#%#//scriptlet("abort-on-property-read", "blockCode")`