### PR TITLE
Made the ad report template less incomprehensible for newcomers to fill out

### DIFF
--- a/.github/ISSUE_TEMPLATE/Ad_report.md
+++ b/.github/ISSUE_TEMPLATE/Ad_report.md
@@ -5,49 +5,49 @@ about: Report an issue with AdGuard Filters
 
 [//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)
 
-***Description***:
+———***Description***:———
 * **Current behaviour**: 
 
-[//]: # (Substitute this line with a description of the problem)
+•••Substitute this very line with a description of the problem.•••
 
-[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
 <details><summary>Screenshot:</summary>
 
-![image](%screenshot_url%)
+•••Replace this very line with a screenshot paste or link.•••
 </details><br/>
 
 * **Expected behaviour**: 
 
-[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)
+•••Replace this very line with a description of what should happen normally.•••
+
+[//]: # (If needed, provide a screenshot below, same as above)
 
 <details><summary>Screenshot:</summary>
 
-![image](%url_of_screenshot%)
+•••Replace this very line with a screenshot paste or link.•••
 </details><br/>
 
 ***Steps to reproduce the problem***:
 
-[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)
+•••Replace this very line with a step-by-step instruction how to reproduce the issue.•••
 
-***System configuration***
+———***System configuration***———
 
 **Filters:**
 
-[//]: # (Substitute this line with the list of your active filters, separated by commas)
+•••Replace this very line with a listing of your active filter(list)s, either by text or screenshot.•••
 
 [//]: # (Please enter the correct values for your case to the table below)
 
 Information                            | Value
 ---                                    | ---
 Operating system:                      | ?
-Operating system version (Android/iOS) | ?
+Operating system version               | ?
 Browser:                               | ?
-AdGuard version:                       | ?
-Filters enabled:                       | ?
+AdGuard/adblocker version:             | ?
 AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
 Filtering quality (Android only):      | High-quality / High-speed / Simplified
 HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
-Simplified filters (iOS only)          | On / Off
+Simplified filters (iOS / FilterLists.com only) | On / Off
 AdGuard DNS:                           | None / Default / Family Protection
 Stealth mode options (Windows only)    | ?
 Helpdesk ID (if exists):               | ?

--- a/.github/ISSUE_TEMPLATE/Ad_report.md
+++ b/.github/ISSUE_TEMPLATE/Ad_report.md
@@ -28,7 +28,7 @@ about: Report an issue with AdGuard Filters
 
 ***Steps to reproduce the problem***:
 
-•••Replace this very line with a step-by-step instruction how to reproduce the issue.•••
+•••Replace this very line with a step-by-step instruction on how to reproduce the issue.•••
 
 ———***System configuration***———
 

--- a/.github/ISSUE_TEMPLATE/Ad_report.md
+++ b/.github/ISSUE_TEMPLATE/Ad_report.md
@@ -48,7 +48,7 @@ AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
 Filtering quality (Android only):      | High-quality / High-speed / Simplified
 HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
 Simplified filters (iOS / FilterLists.com only) | On / Off
-AdGuard DNS:                           | None / Default / Family Protection
+AdGuard DNS:                           | None (or Non-filtering) / Default / Family Protection
 Stealth mode options (Windows only)    | ?
 Helpdesk ID (if exists):               | ?
 


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

I've noticed over the past 3 years that people who are new to AdGuard's GitHub repos, are usually rather confused about which lines in this very template to replace, or where (despite the `[//]` tags). So I decided to add better title headers and at least somewhat more clear guidelines.

It would've probably been even better to just as well convert the whole template to the new `.yml` form format, but I wasn't sure how to convert the system config information table in a way that wouldn't make it ≥1500px tall.

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](%screenshot_url%)
</details><br/>

* **Expected behaviour**: 

Laymen end-users, and even industry experts, are able to correctly use this repo's GitHub report system. Though to be frank, I presume roughly 75% of them will completely ignore the template anyway, sadly.

<details><summary>Screenshot:</summary>

![image](%url_of_screenshot%)
</details><br/>

***Steps to reproduce the problem***:

N/A

***System configuration***

**Filters:**

N/A

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Operating system version (Android/iOS) | 21H1 x64
Browser:                               | Chrome 92.0.4515.107 x64
AdGuard version:                       | N/A
Filters enabled:                       | N/A
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | N/A
HTTPS filtering (Android only):        | On
Simplified filters (iOS only)          | Off
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
