### PR TITLE
Replace AG_abortInlineScript rules - part 8

### DIFF
--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -247,7 +247,7 @@ poli-vsp.ru#@##adSense
 @@||ad.mail.ru/vast/$domain=khl.ru
 ||ad.mail.ru/vast/*&duration=$domain=khl.ru,xmlhttprequest,redirect=noopvast-2.0,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42735
-minecraft20.ru#%#AG_abortInlineScript(/ad_element/, 'document.body.appendChild');
+minecraft20.ru#%#//scriptlet("abort-current-inline-script", "document.body.appendChild", "ad_element")
 !#if (adguard_ext_firefox || adguard_ext_opera || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
 minecraft20.ru#@#.adsBox
 @@||minecraft20.ru/templates/minecraft/adbd/fuckadblock.js
@@ -356,7 +356,7 @@ anitokyo.tv#$#.adsbox.ads.new-ads.sb-ad { height: 1px!important; }
 !+ NOT_PLATFORM(windows, mac, android)
 anitokyo.tv#%#//scriptlet("set-constant", "Object.prototype.adblockDetector", "falseFunc")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37527
-sebeadmin.ru#%#AG_abortInlineScript('script', 'document.createElement');
+sebeadmin.ru#%#//scriptlet("abort-current-inline-script", "document.createElement", "AdBlock")
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 @@||ddnk.advertur.ru/v1/s/loader.js$domain=sebeadmin.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35125
@@ -364,7 +364,6 @@ pornobomba.cc#@#.ads-iframe
 !+ NOT_PLATFORM(windows, mac, android)
 @@||pornobomba.cc/player/player_ads.html$domain=pornobomba.cc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39117
-riwkus.pro#%#AG_abortInlineScript(/abisuq/, 'document.addEventListener');
 riwkus.pro#%#//scriptlet("abort-current-inline-script", "document.addEventListener", "/abisuq/")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37660
 @@||green-way.com.ua/themes/greenway/assets/javascript/ads.js
@@ -394,7 +393,7 @@ hacking-games.ru##body aside.adbd-popup
 ! https://github.com/AdguardTeam/AdguardFilters/issues/37257
 ||xenforo.icu/js/wutime_adblock/*
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33852
-draug.ru#%#AG_abortInlineScript('AdSense', 'Math.floor');
+draug.ru#%#//scriptlet("abort-current-inline-script", "Math.floor", "AdSense")
 !#if (adguard_ext_firefox || adguard_ext_opera || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
 draug.ru#@#.AdSense
 draug.ru#@#img[width="728"][height="90"]
@@ -561,10 +560,6 @@ investgazeta.ua###please2
 @@/clickunder.js$domain=happy-hack.ru
 @@||happy-hack.ru/*.js
 @@/popunder.js$domain=happy-hack.ru
-! https://github.com/AdguardTeam/AdguardFilters/issues/19599
-qaru.site#%#AG_abortInlineScript(/script.onerror/, 'document.addEventListener');
-@@||cse.google.com/adsense/search/async-ads.js$domain=qaru.site
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=qaru.site
 ! https://github.com/AdguardTeam/AdguardFilters/issues/19774
 @@||kodik.cc/*/adsbygoogle.js
 @@||bright-basketball.party/asset/js/adsbygoogle.js
@@ -727,32 +722,31 @@ newsyou.info,4mama.ua,autoua.net,censor.net,eurointegration.com.ua,gagadget.com,
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/12917
 opnevmonii.ru,zemlyaki.name,sonnikonline.club$$script[tag-content=".com/rotator-v2/"][max-length="800"]
-opnevmonii.ru,bodytrain.ru,vvinograd.ru,zemlyaki.name,felomena.com#%#AG_abortInlineScript(/onerror/, 'document.addEventListener');
+opnevmonii.ru,bodytrain.ru,vvinograd.ru,zemlyaki.name,felomena.com#%#//scriptlet("abort-current-inline-script", "document.addEventListener", "onerror")
 !+ PLATFORM(windows, mac, android)
 ://block.*.com/rotator-v2/*.js
 !
 !+ NOT_PLATFORM(windows, mac, android)
-zaxid.net,simpsonsua.com.ua,tabfilm.ru,kurs.com.ru,isport.ua,lostfilm-online.org,24tv.ua,ria-m.tv,kaztorka.org,segodnya.ua,allboxing.ru#%#AG_abortInlineScript(/!function\(\)/, 'String.fromCharCode');
+zaxid.net,simpsonsua.com.ua,tabfilm.ru,kurs.com.ru,isport.ua,lostfilm-online.org,24tv.ua,ria-m.tv,kaztorka.org,segodnya.ua,allboxing.ru#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "!function()")
 !+ NOT_PLATFORM(windows, mac, android)
-dengi.ua,kino-hd720.net,kinoskala.net,mirknig.su,112.ua,kinopad.net,kp.ua,kino-fs.ucoz.net,ex-fs.net,hvylya.net#%#AG_abortInlineScript(/\/\*[0-9a-f]{40}\*\//, 'String.fromCharCode');
+dengi.ua,kino-hd720.net,kinoskala.net,mirknig.su,112.ua,kinopad.net,kp.ua,kino-fs.ucoz.net,ex-fs.net,hvylya.net#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "/\/\*[0-9a-f]{40}\*\//")
 !+ NOT_PLATFORM(windows, mac, android)
-zemlyaki.name,sonnikonline.club#%#AG_abortInlineScript(/\/rotator/, 'document.addEventListener');
+zemlyaki.name,sonnikonline.club#%#//scriptlet("abort-current-inline-script", "document.addEventListener", "/rotator")
 ! <script id="cc-support-script" / spAsyncScript / ClicksCloud.net / `load([e(atob(host)`
 !+ NOT_PLATFORM(windows, mac, android)
-maxpark.com,y-story.ru,primamedia.ru,sobakada.ru,aftershock.news,it-tehnik.ru,modernfirearms.net#%#AG_abortInlineScript(/^new \(function\(\)/, 'String.fromCharCode');
+maxpark.com,y-story.ru,primamedia.ru,sobakada.ru,aftershock.news,it-tehnik.ru,modernfirearms.net#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "/^new \(function\(\)/")
 !
 ! <script src="data:text/javascript;base64
 ! <script>var _0x
-tabfilm.ru,kinocoin.online#%#AG_abortInlineScript(/var/, 'String.fromCharCode');
 !+ NOT_PLATFORM(windows, mac, android)
 @@||loadercdn.com^
 !
 ! `cc-support-script`
-alau.kz#%#AG_abortInlineScript(/addEventListener/, 'String.fromCharCode');
+alau.kz#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "addEventListener")
 /^.*\.ru\/[\w\d]{5,12}/$xmlhttprequest,other,third-party,domain=sovsport.ru|trud.ru|politros.com
 sovsport.ru#%#//scriptlet("abort-on-property-write", "__XABStatus")
 !+ NOT_PLATFORM(windows, mac, android)
-ogodom.ru,progorod59.ru,car.ru,mainavi.ru,yconsult.ru,zakonprost.ru,sadovodu.com,adderall.ru,km.ru,proroofer.ru,aftershock.news,bigbangserial.ru,darkside.ru,farap.ru,gryadki.com.mnogo-krolikov.ru,it-tehnik.ru,lostseries.ru,modernfirearms.net,pravda.ru,primamedia.ru,sobakada.ru,sonnikonline.club,sovsport.ru,y-story.ru,сельхозпортал.рф#%#AG_abortInlineScript(/load\(\[e\(atob\(host\)/, 'String.fromCharCode');
+ogodom.ru,progorod59.ru,car.ru,mainavi.ru,yconsult.ru,zakonprost.ru,sadovodu.com,adderall.ru,km.ru,proroofer.ru,aftershock.news,bigbangserial.ru,darkside.ru,farap.ru,gryadki.com.mnogo-krolikov.ru,it-tehnik.ru,lostseries.ru,modernfirearms.net,pravda.ru,primamedia.ru,sobakada.ru,sonnikonline.club,sovsport.ru,y-story.ru,сельхозпортал.рф#%#//scriptlet("abort-current-inline-script", "String.fromCharCode", "/load\(\[e\(atob\(host\)/")
 ogodom.ru,progorod59.ru,car.ru,mainavi.ru,yconsult.ru,zakonprost.ru,sadovodu.com,adderall.ru,km.ru,proroofer.ru,aftershock.news,bigbangserial.ru,darkside.ru,farap.ru,gryadki.com.mnogo-krolikov.ru,it-tehnik.ru,lostseries.ru,modernfirearms.net,pravda.ru,primamedia.ru,sobakada.ru,sonnikonline.club,sovsport.ru,y-story.ru,сельхозпортал.рф$$script[tag-content="load([e(atob(host)"][max-length="3500"]
 !
 $$script[tag-content="cc-support-script"][max-length="8000"]
@@ -765,9 +759,9 @@ comp-profi.com#%#//scriptlet('abort-current-inline-script', 'SharedWorker', 'cc-
 $$script[id="cc-support-script-b"][max-length="350"]
 $$script[id="cc-support-script"][min-length="30000"][max-length="150000"]
 trud.ru,7days.ru,car.ru,svpressa.ru,radikal.ru$$script[id="cc-support-script"][min-length="40000"][max-length="60000"]
-imperiyanews.ru,svpressa.ru#%#AG_abortInlineScript(/new \(function/, 'Ma_random');
-radikal.ru#%#AG_abortInlineScript(/^new \(function/, 'Math.random');
-7days.ru#%#AG_abortInlineScript(/try\{var Math_random/, 'Math_random');
+imperiyanews.ru,svpressa.ru#%#//scriptlet("abort-current-inline-script", "Ma_random", "new (function")
+radikal.ru#%#//scriptlet("abort-current-inline-script", "Math.random", "/^new \(function/")
+7days.ru#%#//scriptlet("abort-current-inline-script", "Math_random", "try{var Math_random")
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25761
 ||logist.uxxo.ru/static/libs/adetector/overlay.js


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/88860

I changed a bit rule for `sebeadmin.ru`, because it seems that it was breaking a Google search widget.
It seems that `qaru.site`, `tabfilm.ru` and `kinocoin.online` are dead, so I removed rules for these websites.