### PR TITLE
Block sectigo trust logo

### DIFF
--- a/AnnoyancesFilter/sections/annoyances.txt
+++ b/AnnoyancesFilter/sections/annoyances.txt
@@ -4425,3 +4425,4 @@ post-gazette.com#$##toolbar > #share-bar { display: none!important; }
 ||kfund-media.com/wp-content/uploads/2018/01/580h400_banner_telegram-min.png
 ||mayu-pravo.com/share/slider/
 ||u.today/img/satoshi-twitter.png
+||secure.trust-provider.com/trustlogo/javascript/trustlogo.js


### PR DESCRIPTION
***Description***:
Prevents the "sectigo" trust logos from being displayed.

* **Current behaviour**: 
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/6642109/127880785-f61a96a9-d285-4628-94c0-ab1f2a1b84b2.png)
</details><br/>

***How to reproduce***:
https://checkout.bluesnap.com/buynow/checkout?sku3565230=1