### PR TITLE
QQMusic ads

### DIFF
--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -955,4 +955,4 @@ nfmovies.com##body div[id^="aaaDiv"]
 !+ PLATFORM(windows, mac, android)
 ||nfmovies.com/static/side.jpg$image,redirect=nooptext,domain=nfmovies.com
 ! https://github.com/AdguardTeam/AdguardFilters/pull/90035
-||pgdt.gtimg.cn/*/snscosdownload/
+||pgdt.gtimg.cn^$app=com.tencent.qqmusic

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -955,4 +955,4 @@ nfmovies.com##body div[id^="aaaDiv"]
 !+ PLATFORM(windows, mac, android)
 ||nfmovies.com/static/side.jpg$image,redirect=nooptext,domain=nfmovies.com
 ! https://github.com/AdguardTeam/AdguardFilters/pull/90035
-||pgdt.gtimg.cn^$app=com.tencent.qqmusic
+||pgdt.gtimg.cn/*/snscosdownload/*/reserved/$app=com.tencent.qqmusic

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -954,3 +954,5 @@ nfmovies.com##a[href][onclick^="openurl()"] img[src^="/static/"]
 nfmovies.com##body div[id^="aaaDiv"]
 !+ PLATFORM(windows, mac, android)
 ||nfmovies.com/static/side.jpg$image,redirect=nooptext,domain=nfmovies.com
+! https://github.com/AdguardTeam/AdguardFilters/pull/90035
+||pgdt.gtimg.cn/*/snscosdownload/


### PR DESCRIPTION
When you open QQ Music, you will find that the app has opening screen ads.
Ad address example: http://pgdt.gtimg.cn/141/20204/snscosdownload/SZ/reserved/60fff7c10000e95800000000261156090000008d00004eec?m=428400df768d80ecb881677ed75370ca&ck=428400df768d80ecb881677ed75370ca
![Screenshot_2021-08-04-08-41-53-804_com tencent qqmusic](https://user-images.githubusercontent.com/66902050/128103846-5ee4f0d6-ce8a-4679-a9a6-405bb4030136.jpg)
![Screenshot_2021-08-03-19-16-52-727_com adguard android](https://user-images.githubusercontent.com/66902050/128007984-14e3c41e-5c09-4b80-9fdf-dc4bcca45c26.jpg)