### PR TITLE
Blocked zhangxinxu.com homepage ads

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -570,6 +570,7 @@ hgtv.com#@#.showads
 !
 !
 zhangxinxu.com#?#body > *:not(div):not(script):matches-css(width:336px)
+zhangxinxu.com#?#[class^="col-left"] a[rel*="nofollow"], [class^="col-right"] a[rel*="nofollow"]
 miniwebtool.com###blocknotice
 miniwebtool.com#%#//scriptlet("set-constant", "adBlockEnabled", "false")
 deine-tierwelt.de#@#.adunit


### PR DESCRIPTION
***Description***:
* **Current behaviour**: 

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/17523360/130014574-5aec2ac2-310f-4959-85ba-c5dd22c5c58a.png)
</details><br/>

* **Expected behaviour**: 

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/17523360/130014632-8e099384-1edb-4dbc-a467-43cf02d4b315.png)
</details><br/>

***Steps to reproduce the problem***:

Visit https://www.zhangxinxu.com u can see

***System configuration***

**Filters:**

[//]: # (Substitute this line with the list of your active filters, separated by commas)

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | macOS
Operating system version (Android/iOS) | 11.5.2
Browser:                               | Google Chrome
AdGuard version:                       | 2.5.3.955
Filters enabled:                       | ?
AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
Filtering quality (Android only):      | High-quality / High-speed / Simplified
HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
Simplified filters (iOS only)          | On / Off
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
