### PR TITLE
actualnews.org redirects to yandex-turbo

### DIFF
--- a/RussianFilter/sections/specific.txt
+++ b/RussianFilter/sections/specific.txt
@@ -906,7 +906,7 @@ bel.biz,realmadrid.ru##.banner-240
 ||expclan.org/styles/banners/gamehub.jpg
 bhf.io,bhf.im##.main-rblock
 ||bhf.*/other/*.gif$domain=bhf.io|bhf.im
-bhf.io,bhf.im##.uix_sidebar--scroller > div[class="block"] > a[target="_blank"] 
+bhf.io,bhf.im##.uix_sidebar--scroller > div[class="block"] > a[target="_blank"]
 dpchas.com.ua,dedicatet.com##.block-rec
 ||i.ibb.co^$domain=dedicatet.com
 iamcook.ru##div[class="hr"][style^="margin:"]
@@ -1676,7 +1676,7 @@ officelife.media##.top_banner
 ||soft-windows.info/t*.js
 soft-windows.info###dle-content center > a[target="_blank"] > img
 ||gorod.lv/coupons/banner
-gorod.lv##div[id^="tunt-ad-"] 
+gorod.lv##div[id^="tunt-ad-"]
 ||sdamgia.ru/adv/$image
 ||softoffice.org/templates/softoffice/assets/images/monetization/
 l2on.net##a[target="_blank"][rel="nofollow"][style*="background: url("]
@@ -8773,6 +8773,7 @@ www.ex.ua/*/index.css
 ||naurfo.ru/images/banners/Banner_
 ||nautilus.ru/banners/
 ||naviny.by/services/banner/
+||naydex.net^$domain=actualnews.org
 ||nebesa.mobi/img/bnn.gif
 ||neftegaz.ru/ban_adm/
 ||nest.ru.net^$domain=bigcinema.to
@@ -10459,7 +10460,7 @@ kino.mail.ru##.rb_3417
 kino.mail.ru##.p-commercial
 !
 lady.mail.ru##.m-fixed-panel_top[style^="transform: translate"]
-lady.mail.ru##.m-fixed-panel[style^="transform: translate"] 
+lady.mail.ru##.m-fixed-panel[style^="transform: translate"]
 lady.mail.ru##div[data-module="SlotModel"][data-adq-id]
 lady.mail.ru##.js-popup_banner
 !
@@ -10709,7 +10710,7 @@ yandex.md,yandex.by,yandex.com,yandex.com.tr,yandex.fr,yandex.kz,yandex.ru,yande
 yandex.*##body[data-bem*="turbo"] div[class*="_type_"][class*="aside-"][data-name][data-log-node]
 yandex.*##body[data-bem*="turbo"] div[class*="auto"][data-name][data-log-node]
 yandex.*##body[data-bem*="turbo"] div.turbo-advert
-yandex.*##body[data-bem*="turbo"] div[data-name="advert"] 
+yandex.*##body[data-bem*="turbo"] div[data-name="advert"]
 ! Yandex.Turbo sites
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44110
 yandex.*##body[data-bem*="turbo?text="] div.advert-sticks


### PR DESCRIPTION
https://github.com/AdguardTeam/DisableAMP/issues/4#issuecomment-903293028

> FYI бесконечный редирект при переходе на эту turbo-страницу:
> https://yandex.ru/turbo/s/actualnews.org/exclusive/404639-v-obychnoj-kashe-nashli-skrytye-poleznye-svojstva-dlja-kishechnika-i-serdca.html