### PR TITLE
foreverproxy-*-info #94541

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -12213,6 +12213,8 @@ search.lycos.com###fixHolder
 zatnawqy.net###flash_pop
 easyvideo.me,play44.net,playpanda.net,videozoo.me###flowplayer > span[style*="z-index:"]
 al.ly###form-captcha > .ads
+4everproxy.com###foreverproxy-top-info
+4everproxy.com###foreverproxy-bottom-info
 youjizz.com###fotter > .contener
 freesoccer.in###freesoccer_ads
 uploading.site,uploadrocket.net###glasstop

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -12212,9 +12212,9 @@ dailymail.co.uk###fff-inline
 search.lycos.com###fixHolder
 zatnawqy.net###flash_pop
 easyvideo.me,play44.net,playpanda.net,videozoo.me###flowplayer > span[style*="z-index:"]
-al.ly###form-captcha > .ads
 4everproxy.com###foreverproxy-top-info
 4everproxy.com###foreverproxy-bottom-info
+al.ly###form-captcha > .ads
 youjizz.com###fotter > .contener
 freesoccer.in###freesoccer_ads
 uploading.site,uploadrocket.net###glasstop

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -12212,8 +12212,8 @@ dailymail.co.uk###fff-inline
 search.lycos.com###fixHolder
 zatnawqy.net###flash_pop
 easyvideo.me,play44.net,playpanda.net,videozoo.me###flowplayer > span[style*="z-index:"]
-4everproxy.com###foreverproxy-top-info
 4everproxy.com###foreverproxy-bottom-info
+4everproxy.com###foreverproxy-top-info
 al.ly###form-captcha > .ads
 youjizz.com###fotter > .contener
 freesoccer.in###freesoccer_ads


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/94541

Hide empty boxes (leftover/placeholder), sorry if:
- page no have visitors or 
- in wrong file (can be moved to sizes if we use `style` attr) or
- or should be move to top lines of file instead of middle/bottom
- EasyList fixed this faster than me.

---

Cookies bar maybe should be rejected or we treat every web proxy same as `web.archive.org` (often someone fix anti-adblock wall in archives).

> `##.CookiePolicy:not(body):not(html)`

> https://github.com/krystian3w/AdguardFilters/edit/patch-1/AnnoyancesFilter/sections/cookies_specific.txt