### PR TITLE
hosterion.ro

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -1019,7 +1019,7 @@ shoppingcidademaringa.com.br##.MuiSnackbar-anchorOriginBottomCenter
 adrenalinecyber.ru##.wrapper > main ~ div > div[class^="_"]
 gamefuelmasters.ru##.wrapper > div.content ~ div > div[class^="_"]
 thairath.co.th##.cookiewrap
-arabesque-distributie.ro###cookieConsentStickyFooter
+profitshare.ro,arabesque-distributie.ro###cookieConsentStickyFooter
 mathaus.ro###cookieOptionsFooter
 okazii.ro#$#body { overflow: visible !important; }
 okazii.ro#$##overlayc { display: none !important; }


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/96320
Removed cookie on website from issue screenshot: https://profitshare.ro/  
The website form title has low visitors: https://hosterion.ro/
<details><summary>Screenshot:</summary>
<img width="1437" alt="Снимок экрана 2021-10-08 в 12 40 35" src="https://user-images.githubusercontent.com/91964807/136534511-51dab657-2b11-44bb-85fe-f637361ffea7.png">
</details><br/>