### PR TITLE
Add new regex to catch emerging revolving adservers

### DIFF
--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -2,6 +2,10 @@
 ! This is an interesting case.
 ! This is a part of the URL used by an Indian ISP called BSNL
 ! to inject ads into HTTP pages
+!
+! https://github.com/easylist/easylist/pull/9330
+! Example URL: https://2fe5885777.b370db8cb7.com/75ef9b49bd156e7615885ad2fbc87f82.js
+/^https:\/\/[0-9a-f]{10}\.[0-9a-f]{10}\.com\/[0-9a-f]{32}\.js$/$script,third-party
 ! Example URL: http://117.254.84.212:3000/getjs?nadipdata=%7B%22url%22%3A%22%2F%22%2C%22referer%22%3A%22%22%2C%22host%22%3A%22h2020.myspecies.info%22%2C%22categories%22%3A%5B100%5D%2C%22reputations%22%3A%5B1%5D%2C%22nadipdomain%22%3A1%2C%22policyid%22%3A0%7D&screenheight=1120&screenwidth=1792&tm=1603925840327&lib=true&method2=true
 !
 /getjs?nadipdata$third-party,replace=/[\s\S]+openOriginalUrl[\s\S]+/openOriginalUrl()/


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

A new family of revolving adservers have been missed and currently addressed by scriptlet filter `#%#//scriptlet('abort-current-inline-script', 'EventTarget.prototype.addEventListener', '0x')` for each case. These servers change daily so adding domain is futile. See also https://listauthorschat.slack.com/archives/C010N14G4TF/p1633848850256700

* **Expected behaviour**: 

They should be blocked by regex unless it causes false positive.

***Steps to reproduce the problem***:

Use any link in https://github.com/easylist/easylist/pull/9330 and turn the scriptlet filter off.

***System configuration***

**Filters:**

Base
