### PR TITLE
another generic facebook url

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -87,6 +87,7 @@
 /js/ad_insight/*
 .com/s.gif?
 /facebookPixel.
+/facebook-conversion.
 /ajax/fdlogger/send
 /PhoenixGoogleAnalytics.min.js
 /.bootscripts/analytics.min.js


### PR DESCRIPTION
Will fix this on futfanatics.com.br, I believe on other sites too

![ksnip_tmp_RqpTHr](https://user-images.githubusercontent.com/47755037/136968004-64037743-32ca-422d-98e6-0ad7824cb402.png)


