### PR TITLE
magazord.com.br ecommerce CMS

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -69,6 +69,8 @@
 ! Umami
 /umami.js
 !
+/tracking.set
+/cliente/trackRemote
 /dooanalytics/*$script
 /sranalytics.
 /sa.gif?

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -40,6 +40,7 @@
 !||i.snssdk.com/log/*
 !||i.snssdk.com/slardar/sdk.js
 !
+||sen.seg.br^
 ||t.metrilo.com^$third-party
 ||eye.rd.services^
 ||analytics.appsbnet.com.br^


### PR DESCRIPTION
These trackers are found on several websites that use the magazord.com.br platform: https://www.ladorosa.com.br/, https://www.wevans.com.br/, https://www.lojaprincipessa.com.br/ , https://www.sottilecasa.com.br/ and probably many others

sen.seg.br have anothers subdomains: `f.sen.seg.br` and `p.sen.seg.br` (called by the js script on the other sudomain)

<details><summary>Screenshots:</summary>

![ksnip_20211012-143417](https://user-images.githubusercontent.com/47755037/137002866-376af460-75dc-42ee-81a1-1e189a4240bf.png)

![ksnip_20211012-143418](https://user-images.githubusercontent.com/47755037/137002873-da4d5bc5-17f5-4732-9699-ff56f1f82579.png)

![ksnip_20211012-143420](https://user-images.githubusercontent.com/47755037/137002882-60a6a083-92a0-4008-8a9b-53a765ffd5fc.png)

</details>
