### PR TITLE
www.tabletowo.pl

### DIFF
--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -5961,6 +5961,8 @@ roweroweporady.pl,tulodz.pl#@#.ad_container
 tabletowo.pl##.grad
 tabletowo.pl##.sticky--wrap .sidebar-wrap > .sidebar
 tabletowo.pl##.entry-content > div[style="min-height: 300px;text-align: center;"]
+! https://github.com/AdguardTeam/AdguardFilters/issues/96929
+tabletowo.pl##.block-html-content > div[style="min-height: 427px;"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/96537
 wizaz.pl##.c-ad-placement
 wizaz.pl###main #content .page div[id^="ecomm-placement-ssr-wrapper-"]


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/96929

removed leftover on top of the main text, but I can't reproduce right leftover with blue background

<details><summary>Screenshot:</summary>

![Снимок экрана 2021-10-15 в 16 28 11](https://user-images.githubusercontent.com/91964807/137494746-4e675048-6b9f-43b6-aeb7-4297a2d7bea8.png)

</details><br/>