### PR TITLE
pixel bridge from the dooca.com.br ecommerce

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -42,7 +42,6 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|tozlu.com|elleshoes.com|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com
 !
-||pixel.bridge.dooca.store^
 ||ing.com.tr/assets/scripts/dataroid.websdk-
 ||d2jjzw81hqbuqv.cloudfront.net/assets/*/autotrack-
 ||t.enuygun.com/assets/tracker.js

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -42,6 +42,7 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|tozlu.com|elleshoes.com|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com
 !
+||pixel.bridge.dooca.store^
 ||ing.com.tr/assets/scripts/dataroid.websdk-
 ||d2jjzw81hqbuqv.cloudfront.net/assets/*/autotrack-
 ||t.enuygun.com/assets/tracker.js

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -27,6 +27,7 @@
 ||telemetry.mozilla.org^
 !
 ||tracking.swogo.net^
+||pixel.bridge.dooca.store^
 ||pixels.ingbank.com.tr^
 ||dmc1acwvwny3.cloudfront.net^
 ||analytics.sports.ru^


### PR DESCRIPTION
Found on several websites of this ecommerce: https://dooca.com.br/
Some of them
https://www.usekahla.com/
https://loja.usetaberna.com.br/
https://www.donnaguerriera.com.br/
https://www.meusapatopreto.com.br/

The domain seems to work as a proxy to try to bypass ad blockers

<details><summary>Screenshot</summary>

![ksnip_20211110-135100](https://user-images.githubusercontent.com/47755037/141158816-9a72465d-9399-4d44-a505-a80ed7fe5455.png)

</details>