### PR TITLE
canalplus.com

### DIFF
--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -33,6 +33,8 @@ actu17.fr#%#//scriptlet("abort-on-property-write", "td_ad_background_click_link"
 jacquieetmicheltv.net#%#var _st = window.setTimeout; window.setTimeout = function(a, b) { if(!/target_url/.test(a)){ _st(a,b);}};
 ! https://forum.adguard.com/index.php?threads/22023/
 canalplus.fr#%#(function() { var w_open = window.open, regex = /smartadserver.com/; window.open = function(a, b) { if (typeof a !== 'string' || !regex.test(a)) { w_open(a, b); } }; })();
+! https://github.com/AdguardTeam/AdguardFilters/issues/83543
+canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
 ! http://forum.adguard.com/showthread.php?6907
 generation-nt.com#%#Object.defineProperty(window, 'AdvertBay', { get: function() { return []; } });
 !


### PR DESCRIPTION
# This PR:

- completely disables video ads via player configuration on `canalplus.com`. Using a scriptlet. :heavy_check_mark:
&nbsp;

# :camera_flash: Screenshots / Explanations :information_source:

## Context
![canalplus_001](https://user-images.githubusercontent.com/4764956/141113860-aeec8506-7296-415d-9eec-2a435582c37c.png)
&nbsp;

## Before this PR
![canalplus_002](https://user-images.githubusercontent.com/4764956/141113868-85bdb3d1-1f24-4ac2-ac20-0000afc560b9.png)
_English translation: "Advertising: Your content is loading"._
_When we click on the Play button, this is displayed for 1-2 seconds before moving on to content (i.e. the video of the show)._
&nbsp;

## After this PR
:arrow_right: Go straight to content instead.
:arrow_right: Avoid potential video ads that [some people](https://github.com/AdguardTeam/AdguardFilters/issues/83543) seem to have had recently or may have in the future.
&nbsp;

# Remarks

:memo: Thanks to their increasing centralization, should work on:
- https://www.canalplus.com/chaines/ _("Your live and replay channels in one place")_
- https://www.canalplus.com/pl/ _(Canal+ Poland) + other countries_
- https://kids.canalplus.com/ _(subdomain for kids)_
- …
- and, generally speaking, free content as well as premium content (including [novelties](https://www.nextinpact.com/lebrief/48747/canal-lance-cine-anime)) I would say. However, I cannot confirm with certainty for the latter, not being a premium customer myself.
&nbsp;

<details>
<summary><strong><code>Read more (less important stuff) …</code></strong></summary>
&nbsp;

# :one: Other remarks

#### :warning: Not directly linked to this PR but to take into account during your tests for the review of this PR … :warning:
Some content on this website uses [DRM](https://support.mozilla.org/en-US/kb/enable-drm) _(as Firefox indicates via the small icon on the left in the address bar)_. As specified in the FAQ of Canal+, due to this, in Firefox, these contents are not readable in private browsing mode or in permanent private browsing mode. [This](https://user-images.githubusercontent.com/4764956/141117450-86abf5f0-cc18-4af3-9983-eafefb28aabd.png) will be displayed instead of [this](https://user-images.githubusercontent.com/4764956/141117459-f247a703-04ab-4f35-a781-52b789029771.png).
&nbsp;

# :two: Technical details

Contained in web pages like this one: `[view-source:]`https://www.canalplus.com/actualites/william-a-midi-partie-1/h/9676668_50013
```html
<script>[…] window.__data={ […] "featPlayerAds":true […] }; […]</script>
```

… and on this JS file (_very_ quickly loaded after the HTML document): `https://www.canalplus.com/assets/main.[…].js` (currently valid link but for a short time only: https://www.canalplus.com/assets/main.ce93dc550e8ba4ef89c0.js)
```javascript
[…] delete window.__data […]
```
:arrow_right_hook: Anti-inspection protection method used by them. :relaxed:
&nbsp;

# :three: About the current rules in `antiadblock.txt`

Regarding the [two rules](https://github.com/AdguardTeam/AdguardFilters/commit/3c52baa9a3ed0fa5d64ea94889768d31f50ddb8c) added by @AdamWr in the `antiadblock.txt` file as well as the [additional rule](https://github.com/AdguardTeam/AdguardFilters/commit/2115e6ce3d70a2f2f35968f72e3bc08ffb85be49) added later by @Alex-302, they are technically no longer required on any system supporting scriptlets.

1) Indeed, to confirm this, if we add `,badfilter` to these 3 rules, we get their [error message](https://user-images.githubusercontent.com/4764956/141147359-91cb9cde-7877-4471-ad92-e8fe408a69f8.png) as expected and by just activating this scriptlet, no error message and we can [play the video](https://user-images.githubusercontent.com/4764956/141147490-5681a759-1ec8-4f4a-8bc2-59d71fc56338.png) without problem.

2) This is because when the advertising system is deactivated via player configuration, Canal+ doesn't even make these requests (instead of [this](https://user-images.githubusercontent.com/4764956/141150292-e2d4c71f-f951-43c1-9d34-e05626f64a49.png), we get [this result](https://user-images.githubusercontent.com/4764956/141150242-12776716-5ad4-498b-b192-3887f9d93a51.png) — no requests made). However, in the event that this scriptlet is not triggered for some reason, or becomes invalid one day, by leaving these rules, at least there will always be an alternative in place.
</details>
&nbsp;

___
Fixes #83543