### PR TITLE
atlassian.com tracker

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -42,6 +42,8 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|tozlu.com|elleshoes.com|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com
 !
+||atlassian.com/gateway/api/*/batch
+||api.atlassian.com/metal/ingest
 ||e.m6web.fr/events
 ||ing.com.tr/assets/scripts/dataroid.websdk-
 ||d2jjzw81hqbuqv.cloudfront.net/assets/*/autotrack-


### PR DESCRIPTION
The first domain collects some basic information from the browser, api.atlassian.com seems to be doing some kind of benchmark :s

maybe it's also appropriate to block the js files that are loading these domains? (meta-metrics.js and client-errors.js)


<details><summary>Screenshots</summary>

![ksnip_tmp_TzGnKb](https://user-images.githubusercontent.com/47755037/141220128-8735b28b-f69d-4c89-bf7b-67f4973fa3eb.png)

![ksnip_tmp_AvRKdI](https://user-images.githubusercontent.com/47755037/141222170-63e072f2-cb4c-48db-8ea6-537bf399b6d6.png)

</details>

