### PR TITLE
Bilibili (bilibili.com) URL tracking parameter

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -350,17 +350,17 @@ $removeparam=dclid
 ! Daraz & Shop (Samesite)
 ||daraz.*$removeparam=/spm=|scm=|from=|keyori=|sugg=|search=|mp=|c=|^abtest|^abbucket|pos=|themeID=|algArgs=|clickTrackInfo=|acm=|item_id=|version=|up_id=|pvid=/
 ! Bilibili
-||*.bilibili.com^$removeparam=from
-||*.bilibili.com^$removeparam=seid
-||*.bilibili.com^$removeparam=share_source
-||*.bilibili.com^$removeparam=spm_id_from
-||*.bilibili.com^$removeparam=from_spm_id
-||*.bilibili.com^$removeparam=share_medium
-||*.bilibili.com^$removeparam=share_plat
-||*.bilibili.com^$removeparam=share_session_id
-||*.bilibili.com^$removeparam=share_source
-||*.bilibili.com^$removeparam=share_tag
-||*.bilibili.com^$removeparam=timestamp
-||*.bilibili.com^$removeparam=unique_k
+||bilibili.com^$removeparam=from
+||bilibili.com^$removeparam=seid
+||bilibili.com^$removeparam=share_source
+||bilibili.com^$removeparam=spm_id_from
+||bilibili.com^$removeparam=from_spm_id
+||bilibili.com^$removeparam=share_medium
+||bilibili.com^$removeparam=share_plat
+||bilibili.com^$removeparam=share_session_id
+||bilibili.com^$removeparam=share_source
+||bilibili.com^$removeparam=share_tag
+||bilibili.com^$removeparam=timestamp
+||bilibili.com^$removeparam=unique_k
 ||search.bilibili.com^$removeparam=from_source
 !

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -350,12 +350,16 @@ $removeparam=dclid
 ! Daraz & Shop (Samesite)
 ||daraz.*$removeparam=/spm=|scm=|from=|keyori=|sugg=|search=|mp=|c=|^abtest|^abbucket|pos=|themeID=|algArgs=|clickTrackInfo=|acm=|item_id=|version=|up_id=|pvid=/
 ! Bilibili
-||www.bilibili.com^$removeparam=share_source
-||www.bilibili.com^$removeparam=spm_id_from
-||www.bilibili.com^$removeparam=share_medium
-||www.bilibili.com^$removeparam=share_plat
-||www.bilibili.com^$removeparam=share_session_id
-||www.bilibili.com^$removeparam=share_source
-||www.bilibili.com^$removeparam=share_tag
-||www.bilibili.com^$removeparam=unique_k
+||*.bilibili.com^$removeparam=share_source
+||*.bilibili.com^$removeparam=spm_id_from
+||*.bilibili.com^$removeparam=share_medium
+||*.bilibili.com^$removeparam=share_plat
+||*.bilibili.com^$removeparam=share_session_id
+||*.bilibili.com^$removeparam=share_source
+||*.bilibili.com^$removeparam=share_tag
+||*.bilibili.com^$removeparam=timestamp
+||*.bilibili.com^$removeparam=unique_k
+||search.bilibili.com^$removeparam=from_source
+||space.bilibili.com^$removeparam=from
+||space.bilibili.com^$removeparam=seid
 !

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -350,6 +350,8 @@ $removeparam=dclid
 ! Daraz & Shop (Samesite)
 ||daraz.*$removeparam=/spm=|scm=|from=|keyori=|sugg=|search=|mp=|c=|^abtest|^abbucket|pos=|themeID=|algArgs=|clickTrackInfo=|acm=|item_id=|version=|up_id=|pvid=/
 ! Bilibili
+||*.bilibili.com^$removeparam=from
+||*.bilibili.com^$removeparam=seid
 ||*.bilibili.com^$removeparam=share_source
 ||*.bilibili.com^$removeparam=spm_id_from
 ||*.bilibili.com^$removeparam=share_medium
@@ -360,6 +362,4 @@ $removeparam=dclid
 ||*.bilibili.com^$removeparam=timestamp
 ||*.bilibili.com^$removeparam=unique_k
 ||search.bilibili.com^$removeparam=from_source
-||space.bilibili.com^$removeparam=from
-||space.bilibili.com^$removeparam=seid
 !

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -354,6 +354,7 @@ $removeparam=dclid
 ||*.bilibili.com^$removeparam=seid
 ||*.bilibili.com^$removeparam=share_source
 ||*.bilibili.com^$removeparam=spm_id_from
+||*.bilibili.com^$removeparam=from_spm_id
 ||*.bilibili.com^$removeparam=share_medium
 ||*.bilibili.com^$removeparam=share_plat
 ||*.bilibili.com^$removeparam=share_session_id

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -349,4 +349,13 @@ $removeparam=dclid
 ||search.yahoo.co.jp^$removeparam=fr
 ! Daraz & Shop (Samesite)
 ||daraz.*$removeparam=/spm=|scm=|from=|keyori=|sugg=|search=|mp=|c=|^abtest|^abbucket|pos=|themeID=|algArgs=|clickTrackInfo=|acm=|item_id=|version=|up_id=|pvid=/
+! Bilibili
+||www.bilibili.com^$removeparam=share_source
+||www.bilibili.com^$removeparam=spm_id_from
+||www.bilibili.com^$removeparam=share_medium
+||www.bilibili.com^$removeparam=share_plat
+||www.bilibili.com^$removeparam=share_session_id
+||www.bilibili.com^$removeparam=share_source
+||www.bilibili.com^$removeparam=share_tag
+||www.bilibili.com^$removeparam=unique_k
 !


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

[Bilibili](https://www.bilibili.com/) (a Chinese Niconico-like video website) have multiple tracking parameters:
 - `from` tracking
 - `seid` possibly come with searching
 - `share_source` when sharing from PC website
 - `spm_id_from` added by JavaScript of the website
 - `from_source` when searching
 - `share_medium` (and follows) when sharing from Bilibili mobile application
 - `share_plat`
 - `share_session_id`
 - `share_source`
 - `share_tag`
 - `timestamp`
 - `unique_k`

<details><summary>Screenshot:</summary>

![img1](https://user-images.githubusercontent.com/29778171/141367322-5bba1aac-495b-4212-a6b3-8b294de784af.png)
![img2](https://user-images.githubusercontent.com/29778171/141367820-60e287be-6852-4880-b62b-7d32c225d855.png)

</details><br/>

* **Expected behaviour**: 

Tracking parameters are removed
