### PR TITLE
unsplash.com ads server

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -42,6 +42,7 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|tozlu.com|elleshoes.com|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com
 !
+||unsplash.com/nabc^
 ||pa.7w.ro/js/trk.js
 ||paypal.com/tagmanager/pptm.js
 ||dap.dmm.co.jp/imp?


### PR DESCRIPTION
This domain seems to be loading some advertisement, I just couldn't find where (maybe it's already being hidden by some css rule?).



<details><summary>Screenshots</summary>

![ksnip_tmp_kXZWYM](https://user-images.githubusercontent.com/47755037/141788287-0496177c-fbc9-4915-8de1-6e16b2a8c0a0.png)

</details>