### PR TITLE
add regex filter removed from EL

### DIFF
--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -40,7 +40,7 @@
 /\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{4,9}\.js$/$script
 !
 ! ex. https://d3a00ifauhjdp.cloudfront.net/?afiad=933423
-/^https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=[0-9]{4,8}$/$script,third-party
+/^https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=\d{4,8}$/$script,third-party
 !
 .xyz/1clkn/
 .club/1clkn/

--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -39,6 +39,9 @@
 ! Sample URL: ||js.passaro-de-fogo.biz/t/113/750/a1113750.js
 /\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{4,9}\.js$/$script
 !
+! ex. https://d3a00ifauhjdp.cloudfront.net/?afiad=933423
+/^https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=[0-9]{4,8}$/$script,third-party
+!
 .xyz/1clkn/
 .club/1clkn/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65588

--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -40,7 +40,7 @@
 /\/t\/[0-9]{3}\/[0-9]{3}\/a[0-9]{4,9}\.js$/$script
 !
 ! ex. https://d3a00ifauhjdp.cloudfront.net/?afiad=933423
-/^https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=\d{4,8}$/$script,third-party
+/^https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=\d{4,8}$/$script,xmlhttprequest,third-party
 !
 .xyz/1clkn/
 .club/1clkn/


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

Related issue: https://github.com/AdguardTeam/AdguardFilters/issues/101390

The regex is a slight modification of a rule removed from EL for unknown reason (maybe just to reduce the number of regex filters or file size), but I have been observing this to catch those missed by EL/Base. It's already added to uAssets (see https://github.com/uBlockOrigin/uAssets/issues/1835#issuecomment-917437303) and no breakage reported.

* **Expected behaviour**: 

Those revolving cloudfront server should be blocked by regex.

***Steps to reproduce the problem***:

Visit `hakaraw.com` with `||d3a00ifauhjdp.cloudfront.net^$badfilter` as I already added the domain blocking rule.

***System configuration***

**Filters:**

Base, Spyware, and Japanese

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Firefox 94.0.2
AdGuard version:                       | 3.6.16
Filters enabled:                       | ?
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | Disabled
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
