### PR TITLE
api.loganalytics.io

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -13,6 +13,7 @@
 !
 ! The list of bug-tracker services(Sentry, etc.)
 ! Add as commented rules. Will be used in additional list and/or strict DNS
+! ||api.loganalytics.io^
 ! ||crashlyticsreports-pa.googleapis.com^
 ! ||e.crashlytics.com^
 ! ||settings.crashlytics.com^


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/100486

I added this resource as a commented rule because we can't block analytics that not used for collecting users' data. But we will be use this bug-tracker service in additional list or strict DNS.
