### PR TITLE
www.tf1.fr (1 of 2)

### DIFF
--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -535,6 +535,7 @@
 ||adotube.com^
 ||vm5apis.com^
 ||adprotected.com^
+||adproxy.tf1.fr^
 ||adpublisher.s3.amazonaws.com^
 ||adquota.com^
 ||ads.ad2iction.com^

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -854,7 +854,6 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ! com.gitvdemo.video
 ||cupid.ptqy.gitv.tv/mixer?$replace=/"adSlots"/"adSlots_"/,app=com.gitvdemo.video
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100525
-@@||imasdk.googleapis.com^$app=fr.tf1.mytf1
 ||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
 ||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
 ||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -853,3 +853,9 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ! https://github.com/AdguardTeam/AdguardFilters/issues/89875
 ! com.gitvdemo.video
 ||cupid.ptqy.gitv.tv/mixer?$replace=/"adSlots"/"adSlots_"/,app=com.gitvdemo.video
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+@@||imasdk.googleapis.com^$app=fr.tf1.mytf1
+||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1

--- a/MobileFilter/sections/whitelist.txt
+++ b/MobileFilter/sections/whitelist.txt
@@ -394,3 +394,5 @@ deviantart.com#@#.mobile-ad
 @@||play.google.com/store/apps/$document
 ! Youtube & Samsung issue: https://github.com/AdguardTeam/AdguardForAndroid/issues/986
 @@||googleadservices.com^|$app=com.google.android.youtube
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+@@||imasdk.googleapis.com^$app=fr.tf1.mytf1


### PR DESCRIPTION
**Hello team,** :wave:
&nbsp;

First of all, sorry for the delay. But, I like things done right and I wanted overall consistency in the user experience (which includes: MYTF1 web app + MYTF1 mobile app for Android AND iOS + the various websites in the TF1 galaxy).

In the continuity of my previous [PR for Canal+](https://github.com/AdguardTeam/AdguardFilters/pull/99565) and after a thorough analysis, here is my first PR related to TF1: this one is about the **mobile app** before the next one which will be about the **web app**. :thumbsup:
&nbsp;
&nbsp;

# MYTF1 mobile app (Android + iOS)
&nbsp;

## Preamble

:information_source: Tested only on my non-rooted Android 6.0.1 tablet.

:warning: Based on a cold analysis, they don't seem to accept user certificates [unfortunately](https://adguard.com/en/blog/android-nougat-release-and-what-does-it-mean-for-adguard-users.html) (for non-rooted Android 7+ users).
:bulb: _(Solution for them + for AdGuard for iOS users + for AdGuard Home/DNS users in `Show QUESTIONS …` below though.)_

:information_source: Rule(s) n°1/2/3 added to the following file: `MobileFilter/sections/specific_app.txt`
&nbsp;

## Situation prior to treatment

- The video ads were not blocked _at all_, when using the MYTF1 mobile app ([Android](https://play.google.com/store/apps/details?id=fr.tf1.mytf1) / [iOS](https://apps.apple.com/fr/app/mytf1-tv-en-direct-et-replay/id407248490)).
- **Even more problematic:** the live channels did not work, except in rare moments (only Android users should be affected).
&nbsp;

## Rule(s) n°1

`@@||imasdk.googleapis.com^$app=fr.tf1.mytf1`

<details>
<summary>Show details …</summary>
&nbsp;

**In summary:**
This rule fixes the problem of live channels not working most of the time (infinite loading problem when launching a tv channel: TF1, TMC, etc.).

:information_source: Request was blocked by this rule: [`||imasdk.googleapis.com^`](https://github.com/AdguardTeam/AdguardFilters/blob/1d1df41c3e4a56d61b7ccc10c194357f9def46ca/MobileFilter/sections/adservers.txt#L769) coming from `MobileFilter/sections/adservers.txt`.
:information_source: Classic whitelisting, identical to [this rule for CBS app](https://github.com/AdguardTeam/AdguardFilters/blob/1d1df41c3e4a56d61b7ccc10c194357f9def46ca/MobileFilter/sections/specific_app.txt#L462) and many other apps.
:information_source: iOS users should [already be OK](https://github.com/AdguardTeam/AdGuardSDNSFilter/commit/4c7ce6da1ede74d2f879a1998b57387d28dc1db1).
</details>
&nbsp;

## Rule(s) n°2

```
||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
```

<details>
<summary>Show details …</summary>
&nbsp;

**In summary:**
Go to content _quickly_.
By preventing video ads coming from TF1(.fr) _themselves_.  _(Using redirections to noopmp3 of 0.1s.)_

**In details:**
Same as the rules just below, coming from the "Liste FR" and intended for the web app, but for the Android app:
```
||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,domain=tf1.fr
||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,domain=tf1.fr
||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,domain=tf1.fr
```
:bulb: Search `dnl-adv-ssl` in the ["AdGuard French filter" file](https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_16_French/filter.txt) to find them.
</details>
&nbsp;

## Rule(s) n°3

```
||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1
```

<details>
<summary>Show details …</summary>
&nbsp;

**In summary:**
Go to content **directly**.
By preventing video ads coming from them _or not_. _(By preventing a specific request from even being made.)_
**BONUS:** Corresponding ad overlay / ad companion around the video won't even appear, even for a fraction of a second here.

**In details:**
As issue https://github.com/AdguardTeam/AdguardFilters/issues/100525 shows, the three rules of the previous section (the "noopmp3" ones) prevent only _most_ ads: those coming from the tf1.fr domain. But their (exclusive / quasi-exclusive) **FreeWheel** ad provider, a **Comcast Company**, sometimes provides ads to them via other URLs.

Therefore, this rule prevents the `xmlhttprequest` POST request (_note:_ also added — after the main one — `script` and `other` content-type because of [this warning](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#xmlhttprequest-modifier) in the KB) to `https://adproxy.tf1.fr/mytf1-mobile-android/ad/p/1` from even occuring when loading a video/live, by rewriting in the appropriate configuration file …
**this:** `"fw":{ […] `&nbsp;**`"url":"https://adproxy.tf1.fr/mytf1-mobile-android/ad/p/1"`**&nbsp;` […] }`
**by this:** `"fw":{ […] `&nbsp;**`"url":""`**&nbsp;` […] }`. 

For info, this URL appears to be the equivalent of the GET request to `https://7b9de.v.fwmrm.net/ad/g/1?[…]` on the web app.

**To note:** Unlike the smarter solutions that can be done on the web app (see next PR), here it works as long as they allow this more basic workaround though … Rule to watch closely (user feedback over time) therefore. :eyes:

The advantage is that the video/live starts instantly (no multiple redirections via noopmp3 with the message that the video will start in a few moments + no flashing at each ad companion change around the video when present) and above all, that this blocks _any_ video ads coming from their FreeWheel ad provider (not only those coming from TF1(.fr) themselves).
&nbsp;
</details>

<details>
<summary>Show QUESTIONS …</summary>
&nbsp;

**However,** the only way to get the same result on **iOS** (and in fact the only way to get video ads blocked at all) _but_ also on **non-rooted Android 7+** is this rule: `||adproxy.tf1.fr^` (very broad but `adproxy.tf1.fr` seems to be used only on the mobile app and only for the request shown above, at least on Android, so no problem I would say). Although same remark applies here too: rule to watch closely (user feedback over time). :eyes:

1) Are you OK for me to add in an additional commit the following rule then: `||adproxy.tf1.fr^`?
2) To target both iOS and non-rooted Android 7+ users (the latter not always using AdGuardSDNSFilter …), should the entry be added both [here in "Ads" part](https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/master/Filters/rules.txt) and [there](https://github.com/AdguardTeam/AdguardFilters/blob/master/MobileFilter/sections/adservers.txt)?
3) The first one (AdGuardSDNSFilter) seems unnecessary because [possibly (mostly at least) generated automatically](https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/master/README.md) from the second (among others), you confirm?

###### Thank you for your clarification for the next step. :relaxed:
</details>

&nbsp;
&nbsp;
&nbsp;
___
**(Part 1/2)**

Fixes #100525