### PR TITLE
www.tf1.fr (2 of 2)

### DIFF
--- a/AnnoyancesFilter/sections/self-promo.txt
+++ b/AnnoyancesFilter/sections/self-promo.txt
@@ -1078,6 +1078,9 @@ gearbest.com##.siteFooter_banner
 banggood.com##.air_foot_slide_wrap
 banggood.com##.top_mt.datacube_banner
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+www.tf1.fr##div[class^="MaxBanner_container_"]
+!
 experts-exchange.com#$#.interceptReplaceElement { display: block!important; }
 experts-exchange.com##.interceptBackgroundBlocker
 experts-exchange.com##.adBanner-comment

--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -37,6 +37,14 @@ actu17.fr#%#//scriptlet("abort-on-property-write", "td_ad_background_click_link"
 jacquieetmicheltv.net#%#var _st = window.setTimeout; window.setTimeout = function(a, b) { if(!/target_url/.test(a)){ _st(a,b);}};
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83543
 canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
+! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
 ! http://forum.adguard.com/showthread.php?6907
 generation-nt.com#%#Object.defineProperty(window, 'AdvertBay', { get: function() { return []; } });
 !

--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -38,6 +38,7 @@ jacquieetmicheltv.net#%#var _st = window.setTimeout; window.setTimeout = functio
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83543
 canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+! https://gist.github.com/ameshkov/265f353a816110e8b9d5fc37ad66c31a
 prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
 ! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
 tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });

--- a/FrenchFilter/sections/replace.txt
+++ b/FrenchFilter/sections/replace.txt
@@ -8,3 +8,5 @@
 ! https://forum.adguard.com/index.php?threads/7957/page-2#post-90715
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i,important
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+||prod-player.tf1.fr/*/Player/Player.js$script,xmlhttprequest,other,replace=/_prerolls:!(0|1)\,_midrolls:!(0|1)/enable:!1\,_prerolls:!1\,_midrolls:!1/

--- a/FrenchFilter/sections/specific.txt
+++ b/FrenchFilter/sections/specific.txt
@@ -124,7 +124,11 @@ forumconstruire.com###ForumconstruireHB_ATF_300x600
 zone-annuaire.xyz##center > a[href="/telecharger.php"]
 expresso.1fr1.net##div[style*="height:90px;"][style*="728px"]
 lesoleil.com##div[omerlo-ad-formats]
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+! https://github.com/AdguardTeam/AdguardFilters/issues/50546
 ||delivery.tf1.fr/pub$media,domain=tf1.fr
+||dnl-adv-ssl.tf1.fr^$media,domain=tf1.fr
+||slpubmedias.tf1.fr^$media,domain=tf1.fr
 dl-protect.xyz##a#lang_download[href="/download"]
 1001ebooks.com##.stream-item > div[class="box download  aligncenter"]
 sciencesetavenir.fr##.header-banner .pubs

--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -264,4 +264,7 @@ adda247.com#@#div[id^="google_ads_iframe_"]
 @@||tpc.googlesyndication.com/simgad/$domain=adda247.com,image
 @@||adclick.g.doubleclick.net/pcs/click?xai=$popup
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+www.tf1.fr#@#div[class^="MaxBanner_container_"]
+!
 !#safari_cb_affinity


### PR DESCRIPTION
Hello, :relaxed:
&nbsp;

This is part 2 of 2 (MYTF1 **web app**), following [part 1](https://github.com/AdguardTeam/AdguardFilters/pull/101923) (MYTF1 **mobile app**).

Here, unlike the **mobile app** _(which seems to already have the **main** player configuration and only gets an **additional** player configuration through the network, only allowing us to disable "FreeWheel", their exclusive / quasi-exclusive ad provider)_, the **web app** has the **main** player configuration going through the network, allowing us to **fully** disable video ads (regardless of their chosen ad provider). :heavy_check_mark:
&nbsp;
&nbsp;

## Rule n°1 _&nbsp;—&nbsp; Limited to premium products (Win/Mac/Android) + FF add-on_
```
||prod-player.tf1.fr/*/Player/Player.js$script,xmlhttprequest,other,replace=/_prerolls:!(0|1)\,_midrolls:!(0|1)/enable:!1\,_prerolls:!1\,_midrolls:!1/
```
:information_source: [`xmlhttprequest` + `other`](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#xmlhttprequest-modifier) just to be future-proof.
&nbsp;
&nbsp;

## Rule n°2 _&nbsp;—&nbsp; Fallback solution for these products + main solution for others_
```javascript
prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
```
<details>
<summary>Show me the multi-line version … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

```javascript
(function() {
    let callCounter = 0;
    const nativeJSONParse = JSON.parse;

    const handler = {
        apply() {
            callCounter++;
            const obj = Reflect.apply(...arguments);

            if (callCounter <= 10) {
                if (obj.hasOwnProperty('env') && obj.env.hasOwnProperty('origin')) {
                    if (!obj.hasOwnProperty('ads')) {
                        obj.ads = {};
                    }

                    obj.ads.enable = false;
                    obj.ads._prerolls = false;
                    obj.ads._midrolls = false;
                }
            } else {
                JSON.parse = nativeJSONParse;
            }

            return obj;
        }
    };

    JSON.parse = new Proxy(JSON.parse, handler);
})();
```
###### :bulb: `ES6 / ECMAScript 2015` _simultaneously_ introduced the support of `Proxy` and the way to be able to write `apply() {` instead of `apply: function() {` (shorthand notation). Let's take advantage of this! :relaxed:
</details>
&nbsp;

<details>
<summary>Based on @ameshkov's <code>smart_json_override.js</code> … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

  - Accessible at [this address](https://gist.github.com/ameshkov/0c5148f243ffe9d8e40fd9ee11f142f4).
  - But for performance reasons, limited to `JSON.parse` and the first 10 calls (web app init stuff).
</details>
&nbsp;

<details>
<summary>Without going into too much detail … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

  - I convert [this](https://user-images.githubusercontent.com/4764956/144752260-773fb148-9879-4a2d-96f4-aca3357186d6.png) (producing [that](https://user-images.githubusercontent.com/4764956/144752274-57cb081e-d774-49b0-b947-330eec45e492.png)) into [that](https://user-images.githubusercontent.com/4764956/144752283-87c289c9-3e1b-45f6-93f1-0354cc271d26.png) (producing [that](https://user-images.githubusercontent.com/4764956/144752293-00bf4c59-64f2-4637-b824-a138c4e1b585.png) instead).
  - :arrow_right_hook: This JSON data corresponds to the **config** parameter of the player's iframe URL — `https://prod-player.tf1.fr/4.16.0/player/index.html?&config=%7B%22env%22%3A%7B%22origin%22%3A%22https%3A%2F%2Fwww.tf1.fr%22%7D%7D` — and is merged _over_ the main player configuration during initialization.
  - :bulb: **Remark:** Although changing the value of the **config** parameter of the URL directly instead should work, it leaves a server-side trace and can be easily blocked on the server side through simple detection. Better to proxify (the first 10 calls to) `JSON.parse` instead.
</details>
&nbsp;

<details>
<summary>Convertable later into a scriptlet … <strong><em>(click to unfold) {UPDATED}</em></strong></summary>
&nbsp;

  - Required, due to Manifest V3. Either to a potential `json-override` one if has a boolean parameter allowing us to force the creation of a JSON entry that doesn't (yet) exist or to a potential `json-add`, possibly an [`agtrusted-`](https://github.com/AdguardTeam/Scriptlets/issues/106) one, by adding the two functionalities mentioned in the above point about **smart_json_override.js**`*`.
&nbsp;
&nbsp;
  `*` I'll open an issue on this, i.e. about:

    - the ideal possibility of various modes including a `JSON.parse` only mode without `Response.prototype.json`;
    - the _more useful_ presence of an `exitMode` parameter which should allow IMHO at least the following values:

      - `once-found`:

        - for `json-override`: once found … the property to be overwritten;
        - for `json-add`: once found … a property we are looking for [i.e. a given condition] in order to add an additional property to its side or elsewhere.

      - `after-N-calls`:

        - allowing us to restore the native code after N calls to `JSON.parse` and/or `Response.prototype.json` _anyway_.

      &nbsp;
      :arrow_right_hook: **In fact, super optimized:** we can also imagine additionally a mix of both however; i.e., that despite the exit `once-found` (which _can_ be quick), **if _really_ never found after N calls**, we would want to give up. Sort of a _hard_ exit mode. (Something like … <code>once-found<em>-limited-to-N-calls</em></code> or <code>once-found<em>-max-100</em></code> or even <code>once-found<em>-100</em></code> to limit to 100 _anyway_ let's say.)

      :bulb: In this possibility, the easiest way would therefore be to have two separate/independent **options** instead however according to me: `exitOnceFound` used or not (value: 1/0 or true/false) + `exitAfterNCalls` used or not (value: N). :heavy_check_mark:
</details>
&nbsp;
&nbsp;

___
## Bonus n°1 _&nbsp;—&nbsp; Websites from the TF1 galaxy …_
<details>
<summary>Show content … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

```javascript
! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
```

Once https://github.com/AdguardTeam/Scriptlets/issues/65 fixed, will become:
```javascript
tf1.fr#%#//scriptlet('set-constant', 'tv.freewheel.SDK.Util.pingURLWithForm', 'trueFunc')
tf1.fr#%#//scriptlet('set-constant', 'tv.freewheel.SDK.Util.pingURLWithImage', 'trueFunc')
tf1.fr#%#//scriptlet('set-constant', 'tv.freewheel.SDK.Util.pingURLWithScript', 'trueFunc')
tf1.fr#%#//scriptlet('set-constant', 'tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', 'trueFunc')
tf1.fr#%#//scriptlet('set-constant', 'tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', 'trueFunc')
```

:information_source: In summary …
- Websites of the TF1 galaxy like `jpptv.fr` _— the website of a historical host of TF1 about the regions of France —_ include their videos in a large iframe with this URL for ex. (concrete example): https://www.tf1.fr/embedplayer/13832141
- The best solution here is to simply defuse the FreeWheel component in the iframe.
- The last two lines are only useful when a recent version of the FreeWheel component is used, not the case for all websites in the TF1 galaxy.
- **`www.tf1.fr` would be sufficient here indeed** but by using `tf1.fr`, it makes an extra fallback for the `MYTF1 web app` as a bonus (i.e. they also use `window.tv.[…]` on `prod-player.tf1.fr` — appears only once a video is loaded)!
&nbsp;
</details>

## Bonus n°2 _&nbsp;—&nbsp; Hides the [bottom banner](https://user-images.githubusercontent.com/4764956/144758258-e6a639df-49f6-4a52-bbab-36642ef81782.png) (self-promotion) …_
<details>
<summary>Show content … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

```
www.tf1.fr##div[class^="MaxBanner_container_"]
```
:arrow_right_hook: Especially since a link to the [`MYTF1 MAX`](https://www.tf1.fr/offre-max) paid offer is already present at the top, when logged in.
:arrow_right_hook: Added in [`usefulads.txt`](https://github.com/AdguardTeam/AdguardFilters/blob/master/UsefulAdsFilter/sections/usefulads.txt) ([KB](https://kb.adguard.com/en/general/search-ads-and-self-promotion)) too though, using `#@#`.
&nbsp;
</details>

## Bonus n°3 _&nbsp;—&nbsp; In order to be consistent :thumbsup: …_
<details>
<summary>Show content … <strong><em>(click to unfold)</em></strong></summary>
&nbsp;

```
||dnl-adv-ssl.tf1.fr^$media,domain=tf1.fr
||slpubmedias.tf1.fr^$media,domain=tf1.fr
```
Although now blocked in a more global way (thanks to this PR), video ads provided from the domain `tf1.fr` are currently redirected to `noopmp3` of `0.1s` because of the "Liste FR" (3 rules — :bulb: search `dnl-adv-ssl` in the ["AdGuard French filter" file](https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_16_French/filter.txt) to find them). "AdGuard French filter" adds in addition the blocking of those for products not supporting the [`$redirect`](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#redirect-modifier) modifier but adds only [one rule](https://github.com/AdguardTeam/AdguardFilters/commit/8bb343b3e640019f614f42239e8f8f373513af0d) out of the three. Fixed by adding the two missing ones.
&nbsp;
</details>

&nbsp;
&nbsp;
&nbsp;
___
**(Part 2/2)**

Fixes #100525