### PR TITLE
Exchange redirect modifiers part 2

### DIFF
--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -466,7 +466,7 @@ xdarom.com#%#//scriptlet('prevent-setTimeout', 'mdp-deblocker')
 !#safari_cb_affinity
 !
 ! 'sidearm-adblock'
-/components/js/analytics.js?bust=$~third-party,script,redirect=nooptext
+/components/js/analytics.js?bust=$~third-party,script,redirect=noopjs
 /common/templates/dfp/dfp-component-template.html$~third-party,other,xmlhttprequest,redirect=nooptext
 @@/common/templates/dfp/dfp-component-template.html$~third-party,domain=usrowing.org|bigten.org|gousfbulls.com
 usrowing.org,stevensducks.com##.sidearm-adblock
@@ -753,7 +753,7 @@ latesthdmovies.*,123moviesgo.*##body > div[style^="background-color: black; heig
 vc.ru##.layout__right-column > div[class*=" "][style="--offset-top:16px;"]
 blackhatworld.com#%#//scriptlet("abort-current-inline-script", "navigator.userAgent", "AdBlockOn")
 hifivision.com##.samSupportUs
-||htlbid.com/*/motherjones.com/htlbid.js$domain=motherjones.com,redirect=nooptext,important
+||htlbid.com/*/motherjones.com/htlbid.js$domain=motherjones.com,redirect=noopjs,important
 zelka.org##.blocker-form
 zelka.org##div[onclick^="$('.blocker-form')"]
 motoroids.com###abmsgdilog
@@ -981,7 +981,7 @@ txxx.com##.header-blocked-ad
 ||fkrkkmxsqeb5bj9r.s3.amazonaws.com/*.js
 venge.io/905193.json$replace=/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":true\,/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":false\,/,domain=venge.io
 good-football.org###player_block
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duolingo.com,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duolingo.com,redirect=noopjs,important
 abazero.com#$#.mfp-bg { display: none!important; }
 abazero.com#$#.mfp-wrap { display: none!important; }
 abazero.com#$#html { overflow: visible!important; }
@@ -1024,7 +1024,7 @@ ctrlv.cz#%#//scriptlet('set-constant', 'adsAllowed2', 'true')
 tileman.io#$#.adbanner#adt { display: block!important; }
 ||smedata.sk/monitor/bundles/smeblockmanagerapi/build/js/gfcc.js
 ||s.yimg.com/*/bundle_basic_mail_affiliate_partner_$domain=mail.yahoo.com
-||an.yandex.ru/system/context.js$xmlhttprequest,redirect=nooptext,domain=glav.su
+||an.yandex.ru/system/context.js$xmlhttprequest,redirect=noopjs,domain=glav.su
 glav.su$$script[tag-content="Nosferatu"][max-length="6000"]
 oneman.gr#%#//scriptlet("abort-current-inline-script", "atob", "-10000px")
 evades.io#%#//scriptlet("set-constant", "adBlockerDetected", "false")
@@ -2735,7 +2735,7 @@ thesouthern.com,poststar.com,wcfcourier.com##.tnt-ads-container
 business.financialpost.com##.widget_postmedia_layouts_ad
 !#endif
 !+ NOT_PLATFORM(ext_edge, ios, ext_android_cb, ext_safari)
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$redirect=nooptext,domain=nv.ua
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=nv.ua
 !+ PLATFORM(ext_edge, ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=nv.ua
 1001tracklists.com#%#//scriptlet("set-constant", "showAds", "true")

--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -753,7 +753,7 @@ latesthdmovies.*,123moviesgo.*##body > div[style^="background-color: black; heig
 vc.ru##.layout__right-column > div[class*=" "][style="--offset-top:16px;"]
 blackhatworld.com#%#//scriptlet("abort-current-inline-script", "navigator.userAgent", "AdBlockOn")
 hifivision.com##.samSupportUs
-||htlbid.com/*/motherjones.com/htlbid.js$domain=motherjones.com,redirect=noopjs,important
+||htlbid.com/*/motherjones.com/htlbid.js$script,redirect=noopjs,domain=motherjones.com,important
 zelka.org##.blocker-form
 zelka.org##div[onclick^="$('.blocker-form')"]
 motoroids.com###abmsgdilog
@@ -981,7 +981,7 @@ txxx.com##.header-blocked-ad
 ||fkrkkmxsqeb5bj9r.s3.amazonaws.com/*.js
 venge.io/905193.json$replace=/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":true\,/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":false\,/,domain=venge.io
 good-football.org###player_block
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duolingo.com,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duolingo.com,redirect=nooptext,important
 abazero.com#$#.mfp-bg { display: none!important; }
 abazero.com#$#.mfp-wrap { display: none!important; }
 abazero.com#$#html { overflow: visible!important; }

--- a/AnnoyancesFilter/sections/antiadblock.txt
+++ b/AnnoyancesFilter/sections/antiadblock.txt
@@ -1024,7 +1024,7 @@ ctrlv.cz#%#//scriptlet('set-constant', 'adsAllowed2', 'true')
 tileman.io#$#.adbanner#adt { display: block!important; }
 ||smedata.sk/monitor/bundles/smeblockmanagerapi/build/js/gfcc.js
 ||s.yimg.com/*/bundle_basic_mail_affiliate_partner_$domain=mail.yahoo.com
-||an.yandex.ru/system/context.js$xmlhttprequest,redirect=noopjs,domain=glav.su
+||an.yandex.ru/system/context.js$xmlhttprequest,redirect=nooptext,domain=glav.su
 glav.su$$script[tag-content="Nosferatu"][max-length="6000"]
 oneman.gr#%#//scriptlet("abort-current-inline-script", "atob", "-10000px")
 evades.io#%#//scriptlet("set-constant", "adBlockerDetected", "false")

--- a/AnnoyancesFilter/sections/cookies_whitelist.txt
+++ b/AnnoyancesFilter/sections/cookies_whitelist.txt
@@ -239,7 +239,7 @@ olympics.com#@##onetrust-consent-sdk
 digital-fuer-deutschland.de#@##cookiebanner
 ! https://github.com/AdguardTeam/AdguardFilters/issues/93013
 !+ PLATFORM(windows, mac, android)
-||consent.cookiebot.com/uc.js$redirect=nooptext,domain=compo.de
+||consent.cookiebot.com/uc.js$script,redirect=noopjs,domain=compo.de
 ! https://github.com/AdguardTeam/AdguardFilters/issues/92817
 bremerhaven.de#@#.cookie-banner:not(body):not(html)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/92951

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -40,7 +40,7 @@ filecr.com#@#.text-ad
 filecr.com#@#.text_ad
 ||googleads.g.doubleclick.net/pagead/id$domain=filecr.com,redirect=nooptext,important
 !+ NOT_PLATFORM(ext_ublock)
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=filecr.com,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=filecr.com,important
 ! In case of DNS filtering
 sachiepvien.net,mhdtvworld.xyz,libri.link#%#(function(){var b=document.addEventListener;document.addEventListener=function(c,a,d){if(a&&-1==a.toString().indexOf("adsBlocked"))return b(c,a,d)}.bind(window)})();
 ||filecr.com/wp-content/cache/autoptimize/js/autoptimize_*.js$replace=/adsSrc='[\s\S]*?';/adsSrc='';/
@@ -1630,7 +1630,7 @@ pewgame.com#%#AG_defineProperty('app_vars.counter_value', {value: 5, writable: f
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81273
 animedao.to#%#//scriptlet("abort-current-inline-script", "document.createElement", "adblock")
 @@||s.yimg.com/dy/ads/native.js$domain=animedao.to
-||s.yimg.com/dy/ads/native.js$domain=animedao.to,redirect=noopjs,important
+||s.yimg.com/dy/ads/native.js$script,redirect=noopjs,domain=animedao.to,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81280
 jacquieetmicheltv.net#%#//scriptlet('set-constant', 'is_adblocked', 'false')
 @@||jacquieetmicheltv.net/statics/js/popunder.js.
@@ -2435,7 +2435,7 @@ dongknows.com#%#//scriptlet("abort-on-property-read", "gothamBatAdblock")
 ! uploadbank.com
 @@||uploadbank.com^$generichide
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com,redirect=nooptext,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68616
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=googlesyndication-adsbygoogle,domain=mr9soft.com,important
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=mr9soft.com
@@ -6183,7 +6183,7 @@ itopmusic.com#%#//scriptlet("set-constant", "jQuery.adblock", "false")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24835
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org,redirect=nooptext,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24683
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||egyption-gy.net^$generichide
@@ -6905,10 +6905,10 @@ goodtoknow.co.uk#%#//scriptlet("abort-current-inline-script", "IPCCoreQueue", "b
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18523
 ksnews.me,kisstvshow.to,kissasian.li$$script[tag-content="Please disable AdBlock"][max-length="2500"]
 ksnews.me,kisstvshow.to,kissasian.li,kissasian.li#%#//scriptlet("set-constant", "alb", "false")
-||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
-||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
-||propellerads.com/wp-content/themes/Zephyr/framework/js/jquery.simpleplaceholder.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
-||pubmatic.com/wp-content/themes/pubmatic/js/jquery.alignHeight.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
+||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
+||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
+||propellerads.com/wp-content/themes/Zephyr/framework/js/jquery.simpleplaceholder.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
+||pubmatic.com/wp-content/themes/pubmatic/js/jquery.alignHeight.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb)
 @@||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li
 @@||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li
@@ -7527,7 +7527,7 @@ kissanime.ac#%#window.check_adblock = true;
 @@||techtunes.com.bd^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13024
 kmlviewer.nsspot.net#%#Object.defineProperty(window, 'gadb', { value: false });
-||pagead2.googlesyndication.com/pagead/show_ads.js$domain=kmlviewer.nsspot.net,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/show_ads.js$script,redirect=noopjs,domain=kmlviewer.nsspot.net,important
 !+ PLATFORM(ios, ext_android_cb)
 @@||pagead2.googlesyndication.com/pagead/show_ads.js$domain=kmlviewer.nsspot.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13006
@@ -8181,7 +8181,7 @@ au.tv.yahoo.com#@#.y7-advertisement
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7382
 pornshare.org###adblockplus
 ! https://forum.adguard.com/index.php?threads/last-fm-anti-adblock.16897/
-||static.doubleclick.net/instream/ad_status.js$domain=last.fm,redirect=noopjs,important
+||static.doubleclick.net/instream/ad_status.js$domain=last.fm,redirect=nooptext,important
 ! https://forum.adguard.com/index.php?threads/26715/
 @@||e-vdo.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7493

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -2011,7 +2011,7 @@ linkpoi.me,bevru.club,arurio.club,exey.io,eririo.club,freshi.site,cookuve.com,sr
 @@||googletagmanager.com/gtag/js$domain=linkpoi.me|bevru.club|arurio.club|exey.io|eririo.club|freshi.site|cookuve.com|srek.net|exe.app
 !#safari_cb_affinity
 ! ytmp3.eu/en45/ anti-adblock
-||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party,redirect=noopjs,important
+||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party,redirect=nooptext,important
 @@||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73849
 @@||player.clevercast.com/players/video-js/video-js-plugins/videojs.ads.min.js
@@ -4568,7 +4568,7 @@ nekopoi.care#%#//scriptlet("set-constant", "popjs", "noopFunc")
 sinagritbabasworkshop.com##body > #mbd1
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32134
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=di.fm
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,important,domain=di.fm
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,important,domain=di.fm
 di.fm#%#//scriptlet('set-constant', 'di.VAST.XHRURLHandler', 'noopFunc')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35674
 @@||newser.com/javascript/*/adblock.js
@@ -8969,7 +8969,7 @@ pokehunter.co#@#.afs_ads
 ! https://forum.adguard.com/index.php?threads/flacplayer-ehubsoft-net-anti-ad-block-ubo-on-chrome.23131/
 ehubsoft.net#%#//scriptlet("set-constant", "gadb", "false")
 !+ NOT_PLATFORM(ios, ext_android_cb)
-||pagead2.googlesyndication.com/pagead/show_ads.js^$script,redirect=noopjs,important,domain=ehubsoft.net
+||pagead2.googlesyndication.com/pagead/show_ads.js$script,redirect=noopjs,important,domain=ehubsoft.net
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/show_ads.js^$domain=ehubsoft.net
 !+ PLATFORM(ext_ublock)

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -1609,9 +1609,9 @@ yoshare.net#%#//scriptlet("abort-on-property-read", "gothamBatAdblock")
 game3rb.com#%#//scriptlet("abort-on-property-read", "plzdisa")
 game3rb.com#%#//scriptlet("abort-current-inline-script", "loadScript", ")]['innerHTML'")
 game3rb.com#%#//scriptlet("prevent-fetch", "/pagead2\.googlesyndication\.com|cloudfront\.net\/\?.*=/")
-||cloudfront.net/?*=$script,xmlhttprequest,other,redirect=nooptext,domain=game3rb.com
+||cloudfront.net/?*=$script,xmlhttprequest,other,redirect=noopjs,domain=game3rb.com
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,xmlhttprequest,other,redirect=noopjs,domain=game3rb.com
-||cloudfront.net/?besed=$script,other,redirect=nooptext,domain=game3rb.com
+||cloudfront.net/?besed=$script,other,redirect=noopjs,domain=game3rb.com
 ||googletagmanager.com/gtag/js$script,other,redirect=noopjs,domain=game3rb.com
 @@||static.doubleclick.net/instream/ad_status.js$domain=game3rb.com
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb)
@@ -3966,7 +3966,7 @@ mac-torrent-download.net#%#//scriptlet("set-constant", "glxopen", "noopFunc")
 ! Temporary rule for Macos app only
 ! https://github.com/AdguardTeam/CoreLibs/issues/1311
 !+ PLATFORM(mac)
-14617$xmlhttprequest,script,other,redirect=nooptext,third-party,domain=mac-torrent-download.net
+14617$xmlhttprequest,script,other,redirect=noopjs,third-party,domain=mac-torrent-download.net
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 ||mac-torrent-download.net/wp-content/themes/stinger8-child/js/glafs.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44314

--- a/EnglishFilter/sections/antiadblock.txt
+++ b/EnglishFilter/sections/antiadblock.txt
@@ -40,7 +40,7 @@ filecr.com#@#.text-ad
 filecr.com#@#.text_ad
 ||googleads.g.doubleclick.net/pagead/id$domain=filecr.com,redirect=nooptext,important
 !+ NOT_PLATFORM(ext_ublock)
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=filecr.com,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=filecr.com,redirect=noopjs,important
 ! In case of DNS filtering
 sachiepvien.net,mhdtvworld.xyz,libri.link#%#(function(){var b=document.addEventListener;document.addEventListener=function(c,a,d){if(a&&-1==a.toString().indexOf("adsBlocked"))return b(c,a,d)}.bind(window)})();
 ||filecr.com/wp-content/cache/autoptimize/js/autoptimize_*.js$replace=/adsSrc='[\s\S]*?';/adsSrc='';/
@@ -90,7 +90,7 @@ sudoroot.net,netfile.cc,uvnc.com,vijesti.me,automotur.club,techmody.io,mcrypto.c
 /blockadblock-$script,redirect=prevent-fab-3.2.0
 !
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=mshares.co
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$redirect=nooptext,domain=mshares.co,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=mshares.co,important
 suj.nu#%#//scriptlet("abort-current-inline-script", "adBlockNotDetected", "fuckAdBlock")
 @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.js
 @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/*/fuckadblock.min.js
@@ -334,7 +334,7 @@ beforeitsnews.com#%#//scriptlet("abort-on-property-write", "__reg_events")
 @@||rddywd.com/adcode.png$domain=canadafreepress.com|thelibertydaily.com|writerscafe.org|populist.press|welovetrump.com|grammarist.com|protrumpnews.com|concomber.com|videogamesblogger.com|gamersheroes.com|letocard.fr|100percentfedup.com|thepalmierireport.com|kresy.pl|beforeitsnews.com
 @@||rddywd.com/advertising.js$domain=canadafreepress.com|thelibertydaily.com|writerscafe.org|populist.press|welovetrump.com|grammarist.com|protrumpnews.com|concomber.com|videogamesblogger.com|gamersheroes.com|letocard.fr|100percentfedup.com|thepalmierireport.com|kresy.pl|beforeitsnews.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=canadafreepress.com|thelibertydaily.com|writerscafe.org|populist.press|welovetrump.com|grammarist.com|protrumpnews.com|concomber.com|videogamesblogger.com|gamersheroes.com|letocard.fr|100percentfedup.com|thepalmierireport.com|kresy.pl|beforeitsnews.com
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$redirect=nooptext,important,domain=canadafreepress.com|thelibertydaily.com|writerscafe.org|populist.press|welovetrump.com|grammarist.com|protrumpnews.com|concomber.com|videogamesblogger.com|gamersheroes.com|letocard.fr|100percentfedup.com|thepalmierireport.com|kresy.pl|beforeitsnews.com
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,important,domain=canadafreepress.com|thelibertydaily.com|writerscafe.org|populist.press|welovetrump.com|grammarist.com|protrumpnews.com|concomber.com|videogamesblogger.com|gamersheroes.com|letocard.fr|100percentfedup.com|thepalmierireport.com|kresy.pl|beforeitsnews.com
 ! With CSP rule ads are not blocked
 @@||videogamesblogger.com^$csp
 !
@@ -1048,7 +1048,7 @@ animet.tv#$#.textads.banner-ads.banner_ads.adsbox { display: block !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/92911
 link.rota.cc#%#//scriptlet("abort-on-property-read", "adBlocked")
 link.rota.cc#%#//scriptlet("abort-on-property-read", "adssBlocked")
-||securepubads.g.doubleclick.net/tag/js/gpt.js$redirect=nooptext,important,domain=link.rota.cc
+||securepubads.g.doubleclick.net/tag/js/gpt.js$script,redirect=noopjs,important,domain=link.rota.cc
 !+ PLATFORM(ios, ext_android_cb)
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$xmlhttprequest,domain=link.rota.cc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/93328
@@ -1610,9 +1610,9 @@ game3rb.com#%#//scriptlet("abort-on-property-read", "plzdisa")
 game3rb.com#%#//scriptlet("abort-current-inline-script", "loadScript", ")]['innerHTML'")
 game3rb.com#%#//scriptlet("prevent-fetch", "/pagead2\.googlesyndication\.com|cloudfront\.net\/\?.*=/")
 ||cloudfront.net/?*=$script,xmlhttprequest,other,redirect=nooptext,domain=game3rb.com
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,xmlhttprequest,other,redirect=nooptext,domain=game3rb.com
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,xmlhttprequest,other,redirect=noopjs,domain=game3rb.com
 ||cloudfront.net/?besed=$script,other,redirect=nooptext,domain=game3rb.com
-||googletagmanager.com/gtag/js$script,other,redirect=nooptext,domain=game3rb.com
+||googletagmanager.com/gtag/js$script,other,redirect=noopjs,domain=game3rb.com
 @@||static.doubleclick.net/instream/ad_status.js$domain=game3rb.com
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb)
 @@||cloudfront.net/?*=$xmlhttprequest,domain=game3rb.com
@@ -1630,7 +1630,7 @@ pewgame.com#%#AG_defineProperty('app_vars.counter_value', {value: 5, writable: f
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81273
 animedao.to#%#//scriptlet("abort-current-inline-script", "document.createElement", "adblock")
 @@||s.yimg.com/dy/ads/native.js$domain=animedao.to
-||s.yimg.com/dy/ads/native.js$domain=animedao.to,redirect=nooptext,important
+||s.yimg.com/dy/ads/native.js$domain=animedao.to,redirect=noopjs,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81280
 jacquieetmicheltv.net#%#//scriptlet('set-constant', 'is_adblocked', 'false')
 @@||jacquieetmicheltv.net/statics/js/popunder.js.
@@ -2011,7 +2011,7 @@ linkpoi.me,bevru.club,arurio.club,exey.io,eririo.club,freshi.site,cookuve.com,sr
 @@||googletagmanager.com/gtag/js$domain=linkpoi.me|bevru.club|arurio.club|exey.io|eririo.club|freshi.site|cookuve.com|srek.net|exe.app
 !#safari_cb_affinity
 ! ytmp3.eu/en45/ anti-adblock
-||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party,redirect=nooptext,important
+||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party,redirect=noopjs,important
 @@||ytmp3.eu/en45/pagead/js/adsbygoogle.js$xmlhttprequest,~third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/73849
 @@||player.clevercast.com/players/video-js/video-js-plugins/videojs.ads.min.js
@@ -2435,7 +2435,7 @@ dongknows.com#%#//scriptlet("abort-on-property-read", "gothamBatAdblock")
 ! uploadbank.com
 @@||uploadbank.com^$generichide
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=uploadbank.com,redirect=noopjs,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68616
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=googlesyndication-adsbygoogle,domain=mr9soft.com,important
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=mr9soft.com
@@ -2664,7 +2664,7 @@ downloadrepack.com#%#//scriptlet('prevent-addEventListener', 'load', '"gads"')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64916
 ||animefever.tv/themes/app/assets/dist/client/app.*.js$replace=/(Request\(")https:\/\/ssl\.p\.jwpcdn\.com\/player\/plugins\/vast\/v\/[\s\S]*?\/vast\.js"/\$1"/
 !+ PLATFORM(windows, mac, android)
-||p.jwpcdn.com/player/plugins/vast/v/*/vast.js$redirect=nooptext,domain=animefever.tv
+||p.jwpcdn.com/player/plugins/vast/v/*/vast.js$script,redirect=noopjs,domain=animefever.tv
 !+ NOT_PLATFORM(windows, mac, android)
 @@||p.jwpcdn.com/player/plugins/vast/v/*/vast.js$domain=animefever.tv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64828
@@ -4568,7 +4568,7 @@ nekopoi.care#%#//scriptlet("set-constant", "popjs", "noopFunc")
 sinagritbabasworkshop.com##body > #mbd1
 ! https://github.com/AdguardTeam/AdguardFilters/issues/32134
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=di.fm
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,important,domain=di.fm
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,important,domain=di.fm
 di.fm#%#//scriptlet('set-constant', 'di.VAST.XHRURLHandler', 'noopFunc')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35674
 @@||newser.com/javascript/*/adblock.js
@@ -6183,7 +6183,7 @@ itopmusic.com#%#//scriptlet("set-constant", "jQuery.adblock", "false")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24835
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=temp-mail.org,redirect=noopjs,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24683
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 @@||egyption-gy.net^$generichide
@@ -6905,10 +6905,10 @@ goodtoknow.co.uk#%#//scriptlet("abort-current-inline-script", "IPCCoreQueue", "b
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18523
 ksnews.me,kisstvshow.to,kissasian.li$$script[tag-content="Please disable AdBlock"][max-length="2500"]
 ksnews.me,kisstvshow.to,kissasian.li,kissasian.li#%#//scriptlet("set-constant", "alb", "false")
-||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
-||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
-||propellerads.com/wp-content/themes/Zephyr/framework/js/jquery.simpleplaceholder.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
-||pubmatic.com/wp-content/themes/pubmatic/js/jquery.alignHeight.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=nooptext,important
+||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
+||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
+||propellerads.com/wp-content/themes/Zephyr/framework/js/jquery.simpleplaceholder.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
+||pubmatic.com/wp-content/themes/pubmatic/js/jquery.alignHeight.js$domain=ksnews.me|kisstvshow.to|kissasian.li,redirect=noopjs,important
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb)
 @@||bebi.com/js/plugins.js$domain=ksnews.me|kisstvshow.to|kissasian.li
 @@||propellerads.com/wp-content/plugins/radiantthemes-addons/tabs/js/radiantthemes-tab-element-four.js$domain=ksnews.me|kisstvshow.to|kissasian.li
@@ -7527,7 +7527,7 @@ kissanime.ac#%#window.check_adblock = true;
 @@||techtunes.com.bd^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13024
 kmlviewer.nsspot.net#%#Object.defineProperty(window, 'gadb', { value: false });
-||pagead2.googlesyndication.com/pagead/show_ads.js$domain=kmlviewer.nsspot.net,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/show_ads.js$domain=kmlviewer.nsspot.net,redirect=noopjs,important
 !+ PLATFORM(ios, ext_android_cb)
 @@||pagead2.googlesyndication.com/pagead/show_ads.js$domain=kmlviewer.nsspot.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13006
@@ -8181,7 +8181,7 @@ au.tv.yahoo.com#@#.y7-advertisement
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7382
 pornshare.org###adblockplus
 ! https://forum.adguard.com/index.php?threads/last-fm-anti-adblock.16897/
-||static.doubleclick.net/instream/ad_status.js$domain=last.fm,redirect=nooptext,important
+||static.doubleclick.net/instream/ad_status.js$domain=last.fm,redirect=noopjs,important
 ! https://forum.adguard.com/index.php?threads/26715/
 @@||e-vdo.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7493
@@ -8969,7 +8969,7 @@ pokehunter.co#@#.afs_ads
 ! https://forum.adguard.com/index.php?threads/flacplayer-ehubsoft-net-anti-ad-block-ubo-on-chrome.23131/
 ehubsoft.net#%#//scriptlet("set-constant", "gadb", "false")
 !+ NOT_PLATFORM(ios, ext_android_cb)
-||pagead2.googlesyndication.com/pagead/show_ads.js^$redirect=nooptext,important,domain=ehubsoft.net
+||pagead2.googlesyndication.com/pagead/show_ads.js^$script,redirect=noopjs,important,domain=ehubsoft.net
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/show_ads.js^$domain=ehubsoft.net
 !+ PLATFORM(ext_ublock)

--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -42,7 +42,7 @@ egbest1.xyz#%#//scriptlet("abort-current-inline-script", "document.createElement
 ||player.octivid.com/*/video?*&custom_ads=$removeparam=custom_ads,domain=kooora.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99417
 cimanow.cc#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,domain=cimanow.cc
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,domain=cimanow.cc
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=cimanow.cc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99034
@@ -113,7 +113,7 @@ octanime.net##.adsense_section
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82841
 alrakoba.net##.stream-item-widget
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81533
-||googletagmanager.com/gtag/js$redirect=nooptext,important,domain=rotana.net
+||googletagmanager.com/gtag/js$redirect=noopjs,important,domain=rotana.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81136
 @@||almayadeen.net/Content/VideoJS/js/videoPlayer/VideoAds.js$domain=almayadeen.net
 almayadeen.net#%#//scriptlet("set-constant", "videojsIma", "noopFunc")
@@ -229,7 +229,7 @@ orangespotlight.com#%#//scriptlet("abort-on-property-read", "adBlockDetected")
 @@||cdnjs.cloudflare.com/ajax/libs/fuckadblock/3.2.1/fuckadblock.min.js$domain=orangespotlight.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/48622
 !+ NOT_PLATFORM(ext_edge, ios, ext_android_cb, ext_safari)
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$redirect=nooptext,domain=animesanka.com
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=animesanka.com
 !+ PLATFORM(ext_edge, ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=animesanka.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/45355
@@ -2866,7 +2866,7 @@ cnbcindonesia.com#?##ArtikelTerkaitContainer > .col_mob_4 > .native-ads-d:upward
 duit.cc#$##ignielAdBlock { display: none !important; }
 duit.cc#$#body[style*="overflow:"] { overflow: visible !important; }
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duit.cc
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duit.cc,redirect=nooptext,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duit.cc,redirect=noopjs,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82509
 @@||mangalist.org/url/lib/adbanner.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/80388
@@ -6100,7 +6100,7 @@ roweroweporady.pl,tulodz.pl#@#.ad_container
 ||cdn.files.smcloud.net/t/adquesto_beszamel_se_pl.js
 ||weszlo.com/wp-content/themes/weszlo/questpass.js
 ||request.dqst.pl/v*/$xmlhttprequest
-||lib.wtg-ads.com/prebid/prebid_*.js$xmlhttprequest,redirect=nooptext
+||lib.wtg-ads.com/prebid/prebid_*.js$xmlhttprequest,redirect=noopjs
 !+ PLATFORM(ios, ext_android_cb)
 @@||lib.wtg-ads.com/prebid/prebid_*.js$domain=tvn.pl
 !
@@ -7865,7 +7865,7 @@ filmweb.pl#$#.lightboxNEW:not(.fullscreen)[style] { top: 0!important; }
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
 ||go.eu.bbelements.com/please/code|$domain=filmweb.pl,redirect=nooptext,important
 ||cz.search.etargetnet.com/|$domain=filmweb.pl,redirect=nooptext,important
-||sk.adocean.pl/files/js/ado.js|$domain=filmweb.pl,redirect=nooptext,important
+||sk.adocean.pl/files/js/ado.js|$domain=filmweb.pl,redirect=noopjs,important
 !#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70948
 !+ PLATFORM(ios, ext_android_cb)

--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -113,7 +113,7 @@ octanime.net##.adsense_section
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82841
 alrakoba.net##.stream-item-widget
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81533
-||googletagmanager.com/gtag/js$redirect=noopjs,important,domain=rotana.net
+||googletagmanager.com/gtag/js$script,redirect=noopjs,important,domain=rotana.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81136
 @@||almayadeen.net/Content/VideoJS/js/videoPlayer/VideoAds.js$domain=almayadeen.net
 almayadeen.net#%#//scriptlet("set-constant", "videojsIma", "noopFunc")
@@ -2866,7 +2866,7 @@ cnbcindonesia.com#?##ArtikelTerkaitContainer > .col_mob_4 > .native-ads-d:upward
 duit.cc#$##ignielAdBlock { display: none !important; }
 duit.cc#$#body[style*="overflow:"] { overflow: visible !important; }
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duit.cc
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=duit.cc,redirect=noopjs,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=duit.cc,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82509
 @@||mangalist.org/url/lib/adbanner.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/80388
@@ -7865,7 +7865,7 @@ filmweb.pl#$#.lightboxNEW:not(.fullscreen)[style] { top: 0!important; }
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
 ||go.eu.bbelements.com/please/code|$domain=filmweb.pl,redirect=nooptext,important
 ||cz.search.etargetnet.com/|$domain=filmweb.pl,redirect=nooptext,important
-||sk.adocean.pl/files/js/ado.js|$domain=filmweb.pl,redirect=noopjs,important
+||sk.adocean.pl/files/js/ado.js|$domain=filmweb.pl,redirect=nooptext,important
 !#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70948
 !+ PLATFORM(ios, ext_android_cb)

--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -1160,7 +1160,7 @@ najserialy.to#@#[id^="etarget"]
 najserialy.to#%#AG_onLoad(function() {var b=new MutationObserver(function() {var c=document.querySelector('div[id="etarget-hb-wrap"] > div.close-ad'); c&&(b.disconnect(),c.click()) });b.observe(document, {childList: !0,subtree: !0});setTimeout(function() {b.disconnect()}, 2E4)});
 najserialy.to#%#//scriptlet('prevent-window-open')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/96840
-||trackad.cz/adtrack.php$script,other,redirect=nooptext,domain=nova.cz
+||trackad.cz/adtrack.php$script,other,redirect=noopjs,domain=nova.cz
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||trackad.cz/adtrack.php$domain=nova.cz
 ! https://github.com/AdguardTeam/AdguardFilters/issues/95920
@@ -1306,7 +1306,7 @@ freeserial.to##div[class^="reklama"]
 freeserial.to##div[class^="adv"]
 freeserial.to##a[href^="https://s.click.aliexpress.com/"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65452
-||trackad.cz/adtrack.php$script,other,redirect=nooptext,domain=markiza.sk
+||trackad.cz/adtrack.php$script,other,redirect=noopjs,domain=markiza.sk
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||trackad.cz/adtrack.php$domain=markiza.sk
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65003
@@ -8217,7 +8217,7 @@ fanatik.ro##.strawberry-ads-manager-container
 ! https://github.com/AdguardTeam/AdguardFilters/issues/87954
 serialeonline.su#?##sidebars > div[id^="text-"]:has(> h3:contains(/ADS|Advertisement/))
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82382
-||trackad.cz/adtrack.php$script,other,redirect=nooptext,domain=protvplus.ro
+||trackad.cz/adtrack.php$script,other,redirect=noopjs,domain=protvplus.ro
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||trackad.cz/adtrack.php$domain=protvplus.ro
 ! ziarulevenimentul.ro - ads

--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -42,7 +42,7 @@ egbest1.xyz#%#//scriptlet("abort-current-inline-script", "document.createElement
 ||player.octivid.com/*/video?*&custom_ads=$removeparam=custom_ads,domain=kooora.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99417
 cimanow.cc#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,domain=cimanow.cc
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,domain=cimanow.cc
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=cimanow.cc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99034
@@ -6100,7 +6100,7 @@ roweroweporady.pl,tulodz.pl#@#.ad_container
 ||cdn.files.smcloud.net/t/adquesto_beszamel_se_pl.js
 ||weszlo.com/wp-content/themes/weszlo/questpass.js
 ||request.dqst.pl/v*/$xmlhttprequest
-||lib.wtg-ads.com/prebid/prebid_*.js$xmlhttprequest,redirect=noopjs
+||lib.wtg-ads.com/prebid/prebid_*.js$xmlhttprequest,redirect=nooptext
 !+ PLATFORM(ios, ext_android_cb)
 @@||lib.wtg-ads.com/prebid/prebid_*.js$domain=tvn.pl
 !

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -642,7 +642,7 @@ babestare.com##.horizontal-zone
 babestare.com##.right-column
 txxx.com,txxx.tube##.video-content a[href="#"]
 txxx.com,txxx.tube##.video-content a[href="#"] + div.text
-/tag.min.js$domain=vipleague.tv,important,redirect=noopjs
+/tag.min.js$script,redirect=noopjs,domain=vipleague.tv,important
 &aab=$domain=vipleague.tv,important,redirect=nooptext
 nytimes.com##div[data-testid="StandardAd"]
 daily-stop.com##.category-banners

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -12233,7 +12233,7 @@ haxoff.info##article div > center > center > a[href^="https://href.li"]
 techsupportforum.com###TechSupportForum_com_300x250_TopRight_TECH_Forum
 ||windowscentral.com/sites/all/modules/mbn_offers/
 ||gebadu.com/apu.php$redirect=nooptext,important
-||popads.net/pop.js^$script,redirect=noopjs,important
+||popads.net/pop.js$script,redirect=noopjs,important
 express.co.uk,apkmirror.com##.OUTBRAIN
 tnaflix.com##.pInterstitialx
 tnaflix.com##.padAdvx

--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -642,7 +642,7 @@ babestare.com##.horizontal-zone
 babestare.com##.right-column
 txxx.com,txxx.tube##.video-content a[href="#"]
 txxx.com,txxx.tube##.video-content a[href="#"] + div.text
-/tag.min.js$domain=vipleague.tv,important,redirect=nooptext
+/tag.min.js$domain=vipleague.tv,important,redirect=noopjs
 &aab=$domain=vipleague.tv,important,redirect=nooptext
 nytimes.com##div[data-testid="StandardAd"]
 daily-stop.com##.category-banners
@@ -12233,7 +12233,7 @@ haxoff.info##article div > center > center > a[href^="https://href.li"]
 techsupportforum.com###TechSupportForum_com_300x250_TopRight_TECH_Forum
 ||windowscentral.com/sites/all/modules/mbn_offers/
 ||gebadu.com/apu.php$redirect=nooptext,important
-||popads.net/pop.js^$redirect=nooptext,important
+||popads.net/pop.js^$script,redirect=noopjs,important
 express.co.uk,apkmirror.com##.OUTBRAIN
 tnaflix.com##.pInterstitialx
 tnaflix.com##.padAdvx

--- a/FrenchFilter/sections/antiadblock.txt
+++ b/FrenchFilter/sections/antiadblock.txt
@@ -307,7 +307,7 @@ nordpresse.be#@#.an-sponsored
 @@||jetanime.co/assets/js/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18974
 ultimate-catch.eu#%#//scriptlet("abort-current-inline-script", "document.getElementById", "adback")
-||static.criteo.net/js/px.js^$script,redirect=noopjs,important,domain=ultimate-catch.eu
+||static.criteo.net/js/px.js$script,redirect=noopjs,important,domain=ultimate-catch.eu
 ||cas.criteo.com/delivery/ajs.php^$redirect=nooptext,important,domain=ultimate-catch.eu
 !+ PLATFORM(ios, ext_android_cb)
 @@||static.criteo.net/js/px.js^$domain=ultimate-catch.eu

--- a/FrenchFilter/sections/antiadblock.txt
+++ b/FrenchFilter/sections/antiadblock.txt
@@ -307,7 +307,7 @@ nordpresse.be#@#.an-sponsored
 @@||jetanime.co/assets/js/advertisement.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/18974
 ultimate-catch.eu#%#//scriptlet("abort-current-inline-script", "document.getElementById", "adback")
-||static.criteo.net/js/px.js^$redirect=nooptext,important,domain=ultimate-catch.eu
+||static.criteo.net/js/px.js^$script,redirect=noopjs,important,domain=ultimate-catch.eu
 ||cas.criteo.com/delivery/ajs.php^$redirect=nooptext,important,domain=ultimate-catch.eu
 !+ PLATFORM(ios, ext_android_cb)
 @@||static.criteo.net/js/px.js^$domain=ultimate-catch.eu

--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -89,7 +89,7 @@ crefan.jp#%#//scriptlet('prevent-setTimeout', 'objDef.resolve', '3000')
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||googlesyndication.com/pagead/show_ads.js$domain=crefan.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/79141
-||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,important,domain=uploader.xzy.pw
+||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,important,domain=uploader.xzy.pw
 @@||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=uploader.xzy.pw
 ! https://github.com/AdguardTeam/AdguardFilters/issues/77997
 javmix.tv#@#.afs_ads

--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -89,7 +89,7 @@ crefan.jp#%#//scriptlet('prevent-setTimeout', 'objDef.resolve', '3000')
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||googlesyndication.com/pagead/show_ads.js$domain=crefan.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/79141
-||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=noopjs,important,domain=uploader.xzy.pw
+||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=nooptext,important,domain=uploader.xzy.pw
 @@||googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=uploader.xzy.pw
 ! https://github.com/AdguardTeam/AdguardFilters/issues/77997
 javmix.tv#@#.afs_ads

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -778,7 +778,7 @@ virtualbrest.ru##body > div.rounded + div[style^="width:"] > a[target="_blank"] 
 m.vz.ru##.header-banner
 dkoding.in,iheartintelligence.com,revistaforum.com.br##.mrf-sticky-wrapper
 dkoding.in,iheartintelligence.com,fortressofsolitude.co.za,aysetolga.com,revistaforum.com.br,diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper
-||googleadservices.com/pagead/conversion_async.js$redirect=nooptext,domain=orcd.co
+||googleadservices.com/pagead/conversion_async.js$script,redirect=noopjs,domain=orcd.co
 news.rambler.ru##._1ErId
 wonderzine.com,the-village.com.ua##.banners
 novelmultiverse.com##.adace-slideup-slot-wrap

--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -311,7 +311,7 @@ minecraft20.ru#@#.adsBox
 ! https://github.com/AdguardTeam/AdguardFilters/issues/46073
 !+ NOT_PLATFORM(windows, mac, android)
 @@||pixel.adtelligent.com/player/adblock$domain=player.starlight.digital
-||static.adtelligent.com/static/jsvpaid.js^$redirect=nooptext,important,domain=stb.ua|novy.tv|ictv.ua|teleportal.ua
+||static.adtelligent.com/static/jsvpaid.js^$script,redirect=noopjs,important,domain=stb.ua|novy.tv|ictv.ua|teleportal.ua
 ictv.ua#@##adblock
 @@||geo-service.adtelligent.com^|$domain=ictv.ua
 !#if (adguard_ext_edge || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
@@ -1220,7 +1220,7 @@ overclockers.ru$$script[tag-content="enable_page_level_ads"]
 forums.overclockers.ru#%#AG_onLoad(function() { window.chkA = function() {}; window.chkB = function() {}; });
 ~forums.overclockers.ru,overclockers.ru#%#//scriptlet("abort-on-property-read", "cardinals")
 !
-||overclockers.ru/static/js/app-pip.js|$redirect=nooptext,important
+||overclockers.ru/static/js/app-pip.js|$redirect=noopjs,important
 forums.overclockers.ru#@##yandex_ad_1
 !#if (adguard_ext_android_cb || adguard_app_ios || adguard_ext_safari)
 @@||js.mamydirect.com/js/$domain=overclockers.ru

--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -1220,7 +1220,7 @@ overclockers.ru$$script[tag-content="enable_page_level_ads"]
 forums.overclockers.ru#%#AG_onLoad(function() { window.chkA = function() {}; window.chkB = function() {}; });
 ~forums.overclockers.ru,overclockers.ru#%#//scriptlet("abort-on-property-read", "cardinals")
 !
-||overclockers.ru/static/js/app-pip.js|$redirect=noopjs,important
+||overclockers.ru/static/js/app-pip.js|$script,redirect=noopjs,important
 forums.overclockers.ru#@##yandex_ad_1
 !#if (adguard_ext_android_cb || adguard_app_ios || adguard_ext_safari)
 @@||js.mamydirect.com/js/$domain=overclockers.ru

--- a/RussianFilter/sections/antiadblock.txt
+++ b/RussianFilter/sections/antiadblock.txt
@@ -311,7 +311,7 @@ minecraft20.ru#@#.adsBox
 ! https://github.com/AdguardTeam/AdguardFilters/issues/46073
 !+ NOT_PLATFORM(windows, mac, android)
 @@||pixel.adtelligent.com/player/adblock$domain=player.starlight.digital
-||static.adtelligent.com/static/jsvpaid.js^$script,redirect=noopjs,important,domain=stb.ua|novy.tv|ictv.ua|teleportal.ua
+||static.adtelligent.com/static/jsvpaid.js$script,redirect=noopjs,important,domain=stb.ua|novy.tv|ictv.ua|teleportal.ua
 ictv.ua#@##adblock
 @@||geo-service.adtelligent.com^|$domain=ictv.ua
 !#if (adguard_ext_edge || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)

--- a/SpanishFilter/sections/antiadblock.txt
+++ b/SpanishFilter/sections/antiadblock.txt
@@ -61,7 +61,7 @@ ouniversodatv.com#%#//scriptlet("set-constant", "easySettings.adblock", "0")
 @@||animefire.net/js/blockadblock.*.min.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99094
 short-link.one#@#.adsbygoogle
-||ads-twitter.com/uwt.js$xmlhttprequest,redirect=nooptext,domain=recetasdelaabuela.me,important
+||ads-twitter.com/uwt.js$xmlhttprequest,redirect=noopjs,domain=recetasdelaabuela.me,important
 @@||ads-twitter.com/uwt.js$xmlhttprequest,domain=recetasdelaabuela.me
 ! https://github.com/AdguardTeam/AdguardFilters/issues/98360
 @@||pobre.tv/wp-banners.js
@@ -287,7 +287,7 @@ meuwindows.com#%#//scriptlet("abort-on-property-write", "ai_front")
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=anihub.tv
 ||st.bebi.com/bebi_v*.js$script,redirect=noopjs,domain=anihub.tv
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
-@@||st.bebi.com/bebi_v*.js$redirect=nooptext,domain=anihub.tv
+@@||st.bebi.com/bebi_v*.js$script,redirect=noopjs,domain=anihub.tv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57785
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=googlesyndication-adsbygoogle,important,domain=funzen.net
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=funzen.net
@@ -302,7 +302,7 @@ mundocracking.net#@#.adsbygoogle
 mundocracking.net#$#.adsbygoogle { position: absolute!important; left: -3000px!important; }
 mundocracking.net#%#//scriptlet("prevent-setTimeout", "test.offsetHeight")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57292
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$redirect=nooptext,domain=geeksweb.net,important
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=geeksweb.net,important
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=geeksweb.net
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57124
 pcbolsa.com#@#.adsbygoogle

--- a/SpanishFilter/sections/antiadblock.txt
+++ b/SpanishFilter/sections/antiadblock.txt
@@ -61,7 +61,7 @@ ouniversodatv.com#%#//scriptlet("set-constant", "easySettings.adblock", "0")
 @@||animefire.net/js/blockadblock.*.min.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99094
 short-link.one#@#.adsbygoogle
-||ads-twitter.com/uwt.js$xmlhttprequest,redirect=noopjs,domain=recetasdelaabuela.me,important
+||ads-twitter.com/uwt.js$xmlhttprequest,redirect=nooptext,domain=recetasdelaabuela.me,important
 @@||ads-twitter.com/uwt.js$xmlhttprequest,domain=recetasdelaabuela.me
 ! https://github.com/AdguardTeam/AdguardFilters/issues/98360
 @@||pobre.tv/wp-banners.js

--- a/SpanishFilter/sections/specific.txt
+++ b/SpanishFilter/sections/specific.txt
@@ -2366,7 +2366,7 @@ mangahost2.com##.adsbygoogle
 !#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28150
 !+ PLATFORM(windows, mac, android)
-||p.jwpcdn.com/*/vast.js$redirect=nooptext,important,domain=pokyun.tv
+||p.jwpcdn.com/*/vast.js$script,redirect=noopjs,important,domain=pokyun.tv
 ! https://github.com/AdguardTeam/AdguardFilters/issues/28092
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari)
 nerdmaldito.com##.adsbygoogle

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -545,7 +545,7 @@ insider.com##.taboola
 ||dacota.tw/wp-content/plugins/wp-mop-analytics/
 ||cn.ntdtv.com/assets/themes/ntd/js/article_ads.js
 the-ans.jp##.side-reccomend
-||googleadservices.com/pagead/conversion_async.js$redirect=nooptext,domain=orcd.co
+||googleadservices.com/pagead/conversion_async.js$script,redirect=noopjs,domain=orcd.co
 ||cdn.omuz.com.tr/connect/pub-min.js
 ||trrsf.com.br/metrics/
 ||static.solarwinds.com/referrer-cookie.js
@@ -2443,7 +2443,7 @@ link.gmapp*.net$image
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
 ||cdn.optimizely.com^$redirect=nooptext,domain=alaskaair.com
 ||cdn.appdynamics.com/adrum$redirect=nooptext,domain=alaskaair.com
-||alaskaair.com/javascripts/adrum.js$redirect=nooptext,domain=alaskaair.com
+||alaskaair.com/javascripts/adrum.js$script,redirect=noopjs,domain=alaskaair.com
 !#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53722
 ||google-analytics.com/analytics.js$important,domain=unique-tutorials.info|getintopc.com|solvetube.site|tech-platform.info

--- a/SpywareFilter/sections/whitelist.txt
+++ b/SpywareFilter/sections/whitelist.txt
@@ -275,7 +275,7 @@ pizzakiosk.ee#@#img[width="88"][height="31"]
 @@||lptag.liveperson.net/lptag/api^$domain=freedommobile.ca
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90683
 @@||googletagmanager.com/gtag/js?id=$domain=rotana.net
-||googletagmanager.com/gtag/js?id=$script,other,redirect=nooptext,domain=rotana.net,important
+||googletagmanager.com/gtag/js?id=$script,other,redirect=noopjs,domain=rotana.net,important
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90157
 @@||cdn.questionpro.com^$domain=questionpro.*
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90601
@@ -375,7 +375,7 @@ woman.excite.co.jp#%#//scriptlet('remove-attr', 'data-woman-ex', 'a[href][data-w
 @@||online-metrix.net/*/check.js$domain=secure.getcreditscore.com.au
 ! https://github.com/AdguardTeam/AdguardFilters/issues/84989
 @@||googletagmanager.com/gtag/js?id=$domain=kawasaki.com
-||googletagmanager.com/gtag/js?id=$script,other,redirect=nooptext,domain=kawasaki.com,important
+||googletagmanager.com/gtag/js?id=$script,other,redirect=noopjs,domain=kawasaki.com,important
 ! https://github.com/hirorpt/filters/commit/f6ea71e03627835457aea64b622ef3f61b066191
 @@||googletagmanager.com/gtm.js$script,domain=viviennewestwood-tokyo.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/84479


### PR DESCRIPTION
**ISSUE URL** #99316

**FIXES**

Changed `redirect=nooptext` to `redirect=noopjs` for:

- resources with `script` and `other` modifiers

- resources `without` modifiers and with `xmlhttprequest` modifier