### PR TITLE
www.6play.fr (+ derivatives)

### DIFF
--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -2,6 +2,9 @@
 !-------JS----------
 !-------------------
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/103930
+play.rtl.hr,rtlmost.hu#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled', 'appName')
+play.rtl.hr,rtlmost.hu#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.dai.enabled', 'appName')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53333
 crunchyroll.com#%#//scriptlet('json-prune', 'value.media.ad_breaks')
 !

--- a/FrenchFilter/sections/adservers.txt
+++ b/FrenchFilter/sections/adservers.txt
@@ -1,6 +1,7 @@
 !
 ! Section contains list of advertising networks
 !
+||be-rtl.videoplaza.tv^
 ||fristminyas.com^$third-party
 ||ukslphcgs.com^$third-party
 ||rozivpxtl.com^$third-party

--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -2,6 +2,23 @@
 !------- JS rules ---------------------!
 !--------------------------------------!
 !
+! French-language catch-up TV web apps
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/83543
+canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
+! https://github.com/AdguardTeam/AdguardFilters/issues/103930
+6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled', 'appName')
+6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.dai.enabled', 'appName')
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+! https://gist.github.com/ameshkov/265f353a816110e8b9d5fc37ad66c31a
+prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
+! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
+!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100793
 filmstreamy.com#%#//scriptlet("abort-on-property-read", "adsurgeNode")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/99580
@@ -35,17 +52,6 @@ lindependant.fr#%#//scriptlet("abort-on-property-read", "_adb")
 actu17.fr#%#//scriptlet("abort-on-property-write", "td_ad_background_click_link")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/13192
 jacquieetmicheltv.net#%#var _st = window.setTimeout; window.setTimeout = function(a, b) { if(!/target_url/.test(a)){ _st(a,b);}};
-! https://github.com/AdguardTeam/AdguardFilters/issues/83543
-canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
-! https://github.com/AdguardTeam/AdguardFilters/issues/100525
-! https://gist.github.com/ameshkov/265f353a816110e8b9d5fc37ad66c31a
-prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
-! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
 ! http://forum.adguard.com/showthread.php?6907
 generation-nt.com#%#Object.defineProperty(window, 'AdvertBay', { get: function() { return []; } });
 !

--- a/FrenchFilter/sections/replace.txt
+++ b/FrenchFilter/sections/replace.txt
@@ -1,12 +1,16 @@
 !
 ! The content replacement rules
 !
-! https://github.com/AdguardTeam/AdguardFilters/issues/43218
-||v.fwmrm.net/ad/g/1?$replace=/(tv\.freewheel\.SDK\._instanceQueue\['Context_[\s\S]*?'\][\s\S]*?\.requestComplete\(\{)[\s\S]*\}\);/\$1\}\);/,important,domain=01net.com
-! https://forum.adguard.com/index.php?threads/www-rtlplay-be-tvi-humour-rtl-tvi.29736
-||be-rtl.videoplaza.tv/proxy/distributor/$replace=/(\,"vast":\{)[\s\S]*(\}\}\])/\$1\$2/,important,domain=rtlplay.be
+!
+! French-language catch-up TV web apps
+!
 ! https://forum.adguard.com/index.php?threads/7957/page-2#post-90715
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i,important
+! https://forum.adguard.com/index.php?threads/www-rtlplay-be-tvi-humour-rtl-tvi.29736
+||be-rtl.videoplaza.tv/proxy/distributor/$replace=/(\,"vast":\{)[\s\S]*(\}\}\])/\$1\$2/,important,domain=rtlplay.be
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100525
 ||prod-player.tf1.fr/*/Player/Player.js$script,xmlhttprequest,other,replace=/_prerolls:!(0|1)\,_midrolls:!(0|1)/enable:!1\,_prerolls:!1\,_midrolls:!1/
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/43218
+||v.fwmrm.net/ad/g/1?$replace=/(tv\.freewheel\.SDK\._instanceQueue\['Context_[\s\S]*?'\][\s\S]*?\.requestComplete\(\{)[\s\S]*\}\);/\$1\}\);/,important,domain=01net.com

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -1,6 +1,17 @@
 !
 ! Section contains rules for specific applications
 !
+!
+! French-language catch-up TV mobile apps
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/103930
+||smartclip.net^$app=fr.m6.m6replay
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1
+!
 ! ru.yandex.metro
 ||extmaps-api.yandex.net/promo/api/
 ! ua.slando - fixing adverts
@@ -855,8 +866,3 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ! https://github.com/AdguardTeam/AdguardFilters/issues/89875
 ! com.gitvdemo.video
 ||cupid.ptqy.gitv.tv/mixer?$replace=/"adSlots"/"adSlots_"/,app=com.gitvdemo.video
-! https://github.com/AdguardTeam/AdguardFilters/issues/100525
-||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1


### PR DESCRIPTION
:new: **Small update n°1 (2021/12/28):** https://github.com/AdguardTeam/AdguardFilters/pull/104947/files :arrow_backward:
___
&nbsp;

#### Hello,

#### Here we go! :relaxed:
&nbsp;
&nbsp;

# _Web apps_
&nbsp;

**[+]** `FrenchFilter/sections/general_extensions.txt`
```
6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled', 'appName')
6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.dai.enabled', 'appName')
```

**[+]** `EnglishFilter/sections/general_extensions.txt`
```
play.rtl.hr,rtlmost.hu#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled', 'appName')
play.rtl.hr,rtlmost.hu#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.dai.enabled', 'appName')
```
&nbsp;

### :bulb: **Suggested cleaning _(for you later)_**

<details>
<summary>Click to unfold …</summary>
&nbsp;

- **`6play.fr`**
  - A few `w9.fr` replace rules (this domain name redirects to the centralized platform `6play.fr` nowadays).
  - _Possibly_ many rules related to `m6web.fr` (mainly `player.m6web.fr` ones). Tests required.
  &nbsp;
  - :arrow_right_hook: Generally speaking, search **locally** though (because using the GitHub search will return few results, missing the results from the _very long_ `EnglishFilter/sections/foreign.txt` file for example).

- **`rtlplay.be`**
  - **Speaking about this [global view](https://github.com/AdguardTeam/AdguardFilters/search?q=rtlplay):**
  &nbsp;
  - The replace rule can be removed _(still valid though, so can be kept as a fallback method or not)_.
  - The old blocking rule [`*.mp4`](https://github.com/AdguardTeam/AdguardFilters/blob/418e69adbe5800f2e058abbfabc2d22b134f34bd/FrenchFilter/sections/specific.txt#L191) is included in the new one [`/creatives/`](https://github.com/AdguardTeam/AdguardFilters/blob/418e69adbe5800f2e058abbfabc2d22b134f34bd/FrenchFilter/sections/specific.txt#L85).
  :bulb: _New one to be kept for `iOS < 15` users {or `iOS >= 15` users not Premium} (not supporting scriptlets)._
  - The whitelisting rule in `antiadblock.txt` should be kept.
  :bulb: _Both for `iOS < 15` users {or `iOS >= 15` users not Premium} (not supporting scriptlets) + if one day my scriptlets become invalid._
</details>
&nbsp;
&nbsp;

# _Mobile apps_
&nbsp;

## `6play.fr` mobile app :heavy_check_mark:
&nbsp;

**[+]** `MobileFilter/sections/specific_app.txt`

```
||smartclip.net^$app=fr.m6.m6replay
```

:information_source: Global rule `||smartclip.net^` is only present in [`AdGuard DNS filter`](https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_15_DnsFilter/filter.txt) _(imported from: <a href="https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_adservers.txt"><code>easylist_adservers.txt</code></a>)_ and not everybody uses this filter …

:information_source: Ad provider probably in use sometimes, at least present in their web app (as second provider, after FreeWheel, the main one):
`providers:{ […], smartX:{ host:"https://des.smartclip.net/ads", […] } }`
&nbsp;
&nbsp;

## `rtlplay.be` mobile app :heavy_check_mark:
&nbsp;

**[+]** `FrenchFilter/sections/adservers.txt`

```
||be-rtl.videoplaza.tv^
```

:bulb: CNAME to `adserving-edge.videoplaza.tv.`

:information_source: Added to block video ads in their main Android app (`com.tapptic.rtl.tvi`) + others from RTL Belgium like `be.rtl.info`.
:information_source: Put there instead of `MobileFilter` because subdomain not mobile-specific, i.e. also used by their _web app_ (although [partially whitelisted](https://github.com/AdguardTeam/AdguardFilters/blob/418e69adbe5800f2e058abbfabc2d22b134f34bd/FrenchFilter/sections/antiadblock.txt#L283) there because of the already present global rule `||videoplaza.tv^$third-party` [imported from EasyList](https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_2_English/filter.txt)).

:arrow_right: Unfortunately for **iOS users**, an **exclusion** at DNS level is required to avoid an anti-adblock message on their _web app_.
_(Although my scriptlets prevent this, not everyone will — or will be able to — use these.)_
&nbsp;

<details>
<summary><strong>:iphone: Tip to those iOS users reading me though … <em>(click to reveal)</em></strong></summary>
&nbsp;

##### :iphone: Do you have `iOS 15+` and a [recent `AdGuard for iOS` version](https://kb.adguard.com/en/ios/safari-web-extension) that supports [Scriptlet rules](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#scriptlets) ([4.3+](https://adguard.com/en/blog/adguard-4-3-for-ios.html) **Premium**)?
Then simply add this **DNS rule** locally on your side: `||be-rtl.videoplaza.tv^$important`
_(and you won't get any video ads in these mobile apps AND YET never an anti-adblock message on their _web app_ because _Videoplaza_ requests are not made when using my scriptlets.)_

##### :iphone: Do you have `iOS <= 14` or are you not **Premium**?
Only if you _mainly_ use any of these Belgian **mobile** apps instead of using `rtlplay.be` in your mobile web browser, and don't want video ads in them, add this **DNS rule** locally on your side: `||be-rtl.videoplaza.tv^$important`
&nbsp;
</details>
&nbsp;

<details>
<summary><strong>:iphone: Tip to Android FREE users reading me … <em>(click to reveal)</em></strong></summary>
&nbsp;

As in the free version of `AdGuard for Android` only browsers are filtered, you can block video ads in these Belgian mobile apps via **DNS** instead. Simply add this **DNS rule** locally on your side (in `DNS User filter` typically): `||be-rtl.videoplaza.tv^$important`
_(and you won't get any video ads in these mobile apps AND YET never an anti-adblock message on their _web app_ because _Videoplaza_ requests are not made when using my scriptlets.)_
&nbsp;
</details>
&nbsp;

:warning: **IMPORTANT QUESTION:** Regarding `AdGuardSDNSFilter`, can you confirm to me that [this current `videoplaza.tv`](https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/b8bfee91e4801fbbf0b5066ddf971bfb0d9e2ce5/Filters/exclusions.txt#L568) DNS exclusion rule will include any subdomain? This to know if I also have to add the **DNS exclusion rule** `||be-rtl.videoplaza.tv^` there or not.
&nbsp;
&nbsp;

## 3 rules NOT to be added :wink:
&nbsp;

<details>
<summary><strong>Click to unfold …</strong></summary>
&nbsp;

<pre>
<code>
# 1) <strong>[6play.fr mobile app]</strong> Already blocked via: <a href="https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_2_English/filter.txt"><code>filter_2_English/filter.txt</code></a> > <code>||fwmrm.net^</code> (`EasyList rules`)
||v.fwmrm.net^$app=fr.m6.m6replay  # effectively used: `7cbf2.v.fwmrm.net`

# 2) <strong>[play.rtl.hr mobile app]</strong> Already blocked via: <a href="https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_2_English/filter.txt"><code>filter_2_English/filter.txt</code></a> > <code>||iprom.net^</code> (`EasyList rules`)
||iprom.net^$app=com.nth.android.rtlsada  # effectively used: `adserver.iprom.net`

# 3) <strong>[rtlmost.hu mobile app]</strong> Already blocked via: <a href="https://github.com/AdguardTeam/AdguardFilters/blob/418e69adbe5800f2e058abbfabc2d22b134f34bd/MobileFilter/sections/adservers.txt#L534"><code>MobileFilter/sections/adservers.txt</code></a> > <code>||adocean.pl^</code>
||adocean.pl^$app=hu.telekomnewmedia.android.rtlmost  # effectively used: `gemhu.adocean.pl`
</code>
</pre>
</details>
&nbsp;

# _General remarks_
&nbsp;

<details>
<summary><strong>Click to unfold …</strong></summary>
&nbsp;

- As said before, unlike MYTF1, here `json-prune` is possible (versus the _need_ to set values to `false`). Currently at least.

- Note that they have a system to override these initial values afterwards (via JSON coming from these two unique sources for all: `customizer.6play.fr` and `d16w83149ahatb.6cloud.fr`, and this for both web and mobile apps), but currently seems little used (mainly to add some bonus options). They could counter by this means though, but I have other more advanced solutions if needed.

- :information_source: **Built on the same base currently:** `6play.fr`, `rtlplay.be`, `play.rtl.hr`, `rtlmost.hu` (and `salto.fr` too, but both `[…].ad.enabled` and `[…].ad.dai.enabled` [Dynamic Ad Insertion] values are already OK there — equal to `false` — because … for their part, they only offer a **paid** offer).
:arrow_right_hook: For information, I see in the code that the French dev team (in charge of this common base) is currently working on a v2 of `rtl.nl` (a refresh now using this base). I will therefore try to update this in the future.
</details>

&nbsp;
&nbsp;
&nbsp;
___
Fixes #103930, fixes #101778