### PR TITLE
Inspired by #107129

### DIFF
--- a/SocialFilter/sections/general_elemhide.txt
+++ b/SocialFilter/sections/general_elemhide.txt
@@ -1075,3 +1075,307 @@ designboom.com,livescience.com,pbtech.co.nz,peoplesworld.org,space.com##.fa-face
 ##.sns_share_area
 ##.sns_twit
 ##.sns_view
+! From «Dandelion Sprout's Annoyances List»
+###add_like_bar
+###batchsdk-ui-alert
+###btn-send-fb
+###contents > yt-share-target-renderer:nth-of-type(1n+2)
+###ctoolbar
+###diaspora-button-container
+###divShare
+###fb-share
+###fb_share
+###inline-share-links
+###likebuttons
+###mashfbar-header
+###new-social-share
+###p-sharing
+###pinterest
+###rail-share-bar
+###share-tool
+###share-unit
+###share_bar
+###ShareEntryPoint
+###social-share
+###ss-floating-bar
+###story-socials
+###tell-a-friend
+###top_share
+##.addthis_button_more
+##.addthis_counter
+##.addtoany_content
+##.addtoany_list
+##.addtoany_share
+##.album-dialog__image-share
+##.ArevicoModal-bg
+##.ArevicoModal
+##.basicsSocialActions-socialIcons
+##.blog-post-single-share
+##.btn--facebook
+##.btn-facebook-like
+##.btn-google-plus
+##.btn-messenger
+##.btn-tweet
+##.btn-twitter
+##.button--share
+##.button__facebook
+##.button__instagram
+##.button__linkedin
+##.button__twitter
+##.c-article__byline-social
+##.c-share-tools
+##.dre-share-band
+##.et_social_icons_container
+##.face-share
+##.facebook-like-box
+##.facebook-messenger-share
+##.facebook-page-plugin
+##.facebook-share
+##.facebook[href*="/sharer/"]
+##.facebook_share
+##.facebook_top
+##.fb-page-plugin
+##.fbbsb-button
+##.figure-share
+##.floating-share-bar
+##.follow_like_module
+##.footerSocial
+##.Gallery-Share
+##.globalSharing
+##.googleplusshare
+##.i-more-share
+##.icon--facebook
+##.icon--twitter
+##.js-share-btn
+##.js-share-pinterest
+##.js-share-stumble
+##.js-share-twitter
+##.jw-sharing-icon
+##.like_facebook
+##.linkedinShare
+##.loader-container.shares
+##.mashsb-box
+##.news-share-link
+##.news_share
+##.post_social
+##.product-sharing
+##.recentsocial
+##.sbtn_main
+##.sd-sharing
+##.share-actions
+##.share-after
+##.share-bar
+##.share-before
+##.share-icon
+##.share-icons
+##.share-it
+##.share-item-plus
+##.share-link.js-require-widget
+##.share-list
+##.share-metas
+##.share-networks
+##.share-nw
+##.share-other
+##.share-social
+##.share-telegram
+##.share-this
+##.share-toggle
+##.share-trigger
+##.share-tumblr
+##.share-twitter
+##.share-twttr
+##.share-whatsapp
+##.share__list
+##.share_area
+##.share_btn
+##.share_icon_area
+##.Share_Icons
+##.share_toggle
+##.sharea
+##.shareBottom
+##.sharebtns
+##.shareFacebook
+##.shares-badge
+##.shareToggle
+##.sharing-btn
+##.sharing-container
+##.sharing-links
+##.sharing
+##.shr-badge__button
+##.shr-opn
+##.shr.btn
+##.single-share
+##.soc-list
+##.social-action[test-id*=facebook]
+##.social-btns
+##.social-footer
+##.social-icon
+##.social-likes
+##.social-share-sidebar-component
+##.social-sharing-buttons
+##.social-sharing
+##.social-wrap
+##.social.shares
+##.social_buttons
+##.social_media
+##.social_widget__reactions_icons
+##.SocialArticleIcons
+##.socialbuttons
+##.socialmedia-btns
+##.socialmedia
+##.spotheader__sharing
+##.ssk-group
+##.swp-hover-pin-button
+##.twit_share_button
+##.twitter[href*="/share?"]
+##.twitter_share
+##.wpusb
+##[app=addtoany]
+##[class*=facebookShare i]
+##[class*=fb-share]
+##[class*=share-facebook]
+##[class*=share-toolbar]
+##[class*=socialshare i]
+##[data-flip-widget=shareflip]
+##[socialshare]
+##a[appshareclick]
+##a[class$=-sharing-button__link]
+##a[class$=sharebtn]
+##a[class*=-sharing-popup]
+##a[class*=-socials__item]
+##a[class*=addthis_button]
+##a[class*=BtnShare]
+##a[class*=google_plus_share]
+##a[class*=share__button]
+##a[class=facebook i][title="Share this"]
+##a[class^=pagetools][class*=icon--twitter]
+##a[class^=pinterest-save]
+##a[class^=share_btn]
+##a[class^=sharing-popup-]
+##a[class^=socialbutton i][onclick*="window.open"]
+##a[data-ga-event-action^="share:"]
+##a[data-js=facebook-share]
+##a[data-js=twitter-share]
+##a[data-pin-do=buttonPin]
+##a[data-plugin^=sharingButtons]
+##a[data-share$=Facebook i]
+##a[data-sharer=facebook]
+##a[data-sharer=twitter]
+##a[data-ss-ss-type]
+##a[data-tooltip^="Share on "]
+##a[data-type=sharing-button]
+##a[href*=".cmd=addShare"]
+##a[href*="/share-newsletter/"]
+##a[href*="/social_plugins/share"]
+##a[href*="://plus.google.com/share?url="]
+##a[href*="addtoany.com/add_to/"]
+##a[href*="api.addthis.com"]:not([href*="/email/"])
+##a[href*="plusone.google.com"]
+##a[href*="telegram.me/share/url?"]
+##a[href*=share-tools]
+##a[href="#javascript"][class*=social-link]
+##a[href="/#facebook"]
+##a[href="/#messenger"]
+##a[href="/#pinterest"]
+##a[href^="/sharer/sharer.php?"] > button[type=submit]
+##a[href^="javascript:fb_share('"]
+##a[href^="javascript:fbShare"]
+##a[href^="javascript:sendSns('"]
+##a[href^="javascript:tw_share('"]
+##a[id*=share-][id*=-button]
+##a[id^=share_btn]
+##a[onclick*="pinterest.com/pin/create/"]
+##a[onclick*="plus.google.com/share?"]
+##a[onclick^="share_toggle("]
+##a[onclick^="var share"]
+##a[onclick^="window.open('http"][onclick*="facebook.com/sharer"]
+##a[onclick^=ShowShareDialog]
+##a[onmouseover^="return addthis_open"]
+##a[title="Share on Baidu" i]
+##a[title="Share on Facebook" i]
+##a[title="Share on LinkedIn" i]
+##a[title="Share on Pinterest" i]
+##a[title="Share on Reddit" i]
+##a[title="Share on Telegram" i]
+##a[title="Share on Tumblr" i]
+##a[title="Share on Twitter" i]
+##a[title="Share on VKontakte" i]
+##a[title="Share on WhatsApp" i]
+##a[title^="Share to "]
+##amedia-share
+##button[aria-controls=ShareContainer]
+##button[class*=_fbshare]
+##button[class*=ShareOverlayButton i]
+##button[class*=SharesButton i]
+##button[class^=share-module__share]
+##button[data-a-target^=share]
+##button[data-arctrac*=socialShare i]
+##button[data-fatal-attraction*=":share"]
+##button[data-share-url]
+##button[ng-click^=shareOn]
+##button[onclick^=socialsharing_]
+##button[title^="Del på "]
+##button[title^="Share this "]
+##div[button=share]
+##div[class$=-share-single]
+##div[class*=_share_button]
+##div[class*=addthis]
+##div[class*=article-share]
+##div[class*=box--share]
+##div[class*=footer__share]
+##div[class*=FooterShare i]
+##div[class*=iconShare]
+##div[class*=lp_sharing]
+##div[class*=post-sharing]
+##div[class*=share-article]
+##div[class*=share-box]
+##div[class*=sharer-tool]
+##div[class*=sharethisbutton i]
+##div[class*=shareToolbar]
+##div[class*=social-panel]
+##div[class*=social][class*=sharing]
+##div[class*=social_sidebar]
+##div[class*=social_slide]
+##div[class*=socials-share]
+##div[class=instagram-Share i]
+##div[class=instagram_Share i]
+##div[class=instagramShare i]
+##div[class=twitterShare i]
+##div[class^=container_NotificationsBanner_]
+##div[class^=fbshare i]
+##div[class^=icon-share-]
+##div[class^=share-options]
+##div[class^=shareLinks]
+##div[class^=social-like]
+##div[class^=social-media-container]
+##div[class^=twittshare]
+##div[data-aop^=sharingtoolbar]
+##div[data-hook=social-sharing]
+##div[href*="plus.google.com/share?url="]
+##div[id$=_sharethis]
+##div[id^=btnShare i]
+##div[id^=dpsp-]
+##div[id^=sthoverbuttons]
+##div[pw\:twitter-via]
+##div[tmp^="Share on "]
+##h2[class*=share-links]
+##h4[class*=social-share-label]
+##ksf-sharing
+##label[for*=ShareModal]
+##li[aria-label=facebook]
+##li[class$=-share-toggle]
+##li[class*=link_facebook]
+##li[data-share=facebook]
+##li[data-share=linkedin]
+##li[data-share=twitter]
+##p[class^=del-artikel]
+##share-grid
+##span[class*=-social-share-]
+##span[class*=share-icon]
+##span[class^=share_btn]
+##span[data-lnkd-debug]
+##ul[aria-label=Del]
+##ul[class*=-share-buttons]
+##ul[class^=share-action]
+##ul[class^=sociale-ikoner-del]
+##ytm-share-target-renderer

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -7118,3 +7118,11 @@ bildderfrau.de##.article--sticky
 ! Not visible on desktop - so should be NOT_OPTIMIZED
 !+ NOT_OPTIMIZED
 betanews.com##.social-links-wrap
+!
+! Sites with "$generichide" in AdGuard Base Filter
+history.com,aetv.com##.share-this
+history.com,aetv.com##.share-facebook
+history.com,aetv.com##.share-twitter
+thefreedictionary.com##.social-networks > li > a[title^="Share on"]
+thefreedictionary.com##.share-block
+wikinews.org###social_bookmarks

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -7126,3 +7126,49 @@ history.com,aetv.com##.share-twitter
 thefreedictionary.com##.social-networks > li > a[title^="Share on"]
 thefreedictionary.com##.share-block
 wikinews.org###social_bookmarks
+! Sites with "$generichide" in other AdGuard filters
+antenne.de,fnp.de,fr.de,oglobo.globo.com##.sharing
+autobild.de##.socialmedia
+bloomberg.com##div[class^="share-article-button__"]
+bludv.com###smthemes_share
+!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
+bludvfilmes.com###smthemes_share
+businessinsider.de,elpais.com.uy,epochtimes.de,forbes.com,newsletter.co.uk,onet.pl,ovaciondigital.com.uy,sports.ru##.social-share
+cracxsoftwares.com##.shareit
+cracxsoftwares.com##.addtoany_share_save_container
+cyclingnews.com,prosieben.de,ran.de,sat1.de##.share-buttons
+formatatmak.com##.share-post
+formel1.de##.shariff-button
+fullstuff.co##.share-icons > div.entry-comment-count ~ a
+fullstuff.co##.sd-sharing
+!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
+gamesandroidhvga.net,techmoviles.com##.td-post-sharing
+gamestar.de###socialshare
+geo.de##.social-bar
+golem.de##.social-tools
+hackintosh.computer##.nc_socialPanel
+horoscopes.rambler.ru##.rambler-share
+journalstar.com##.social-share-links
+kabeleins.de,prosieben.de,sixx.de##.social-wrapper
+kino.mail.ru##.sharelist
+mangarock.com##a[href^="https://twitter.com/intent/tweet?"]
+mangarock.com##a[href^="https://www.facebook.com/sharer/sharer.php"]
+n-tv.de##.article__share > a
+neowin.net##.article-share
+pcwelt.de##.social_media_buttons
+radiohamburg.de##.social-networks
+sabishiidesu.com##.share-box
+sat1.de##.social-wrapper
+seriesgato.com##.fb-share
+!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
+seriesgato.net##.fb-share
+snopes.com##.share-links
+spiegel.de##.social-bar-wrapper
+m.cyber.sports.ru,m.sports.ru##.b-social-buttons
+tf1.fr##div[class^="ShareButton_shareButtonContainer_"]
+tichyseinblick.de##.sharing.bar
+track24.ru##.b-share
+tz.de##.id-Actionbox-items-el--whatsapp
+usapoliticstoday.com##.td-post-sharing
+wired.com##.social-share-sidebar-component
+zeit.de##.article-sharing

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -9,7 +9,6 @@ icc-cricket.com,smartasset.com,min2win.ru,kurashiru.com,rejetweb.jp,help-patriot
 ! ###share
 pokemon.co.jp,kingdom-anime.com,browsehappy.com,fireforce-anime.jp,tdupress.jp,blic.rs,hqbabes.com,sipri.org,booklog.jp,aqweeb.com,goblins-online.ru,onepiece100we-are-one.com,tvoidrug.com,keisoshobo.co.jp,xxxlmusic.com,agilites.com,id2call.com,yemeklerimiz.com,simpsonsua.com.ua,diyetspor.com,hqsluts.com,speed-down.org,astromeridian.ru,sociumin.com,gecbunlari.com,tribunnews.com,it-doc.info,v-androide.com,erkiss.live,igromania.ru,realnyezarabotki.com,healthhacks.ru,wd-x.ru,jianshu.com,memuplay.com,kino-teatr.ru,astrakhan-24.ru,rockstargame.su,hobbyits.com,eatcells.com,imgview.pw,abdullinru.ru,magazin.1001kadin.com,lingust.ru,1kinobig.ru,goblin-online.ru,it-tehnik.ru,netzpolitik.org,istasyongazetesi.com,kemergozcu.com,itop-gear.ru,golbasiguncel.com,haberamasya.com,suluovagazetesi.com,yesilirmakgazetesi.com,haberodasi.tv,amasyagazetesi.com,duzgunhaber.com.tr,geek.com,greasyfork.org,gunebakis.com.tr,hackworthy.blogspot.de,sarki-sozlerii.com,wunderground.com,zagrandok.ru###share
 ! ##.sharing
-capiche.com,mannheimer-morgen.de,naointendo.com.br,texasobserver.org,bigleaguepolitics.com,zebra-tv.ru,numberempire.com,infobyip.com,pingvin.pro,currenttime.tv,webqc.org,noodlemagazine.com,mos.ru,sbs.com.au,xelent.ru,fussball.de,gamezebo.com,fr.de,sovsport.ru,oglobo.globo.com,metrolyrics.com,ad.nl,life.ru,mopo.de,antenne.de,m.health.chosun.com,fnp.de,android.gs,bbc.co.uk,blackberry.com,boostinspiration.com,celebritybabyscoop.com,cityam.com,core77.com,creatorrepublic.com,download.cnet.com,futurity.org,hackaday.com,investopedia.com,kg-portal.ru,metacritic.com,minimaxir.com,pgatour.com,pigeonsandplanes.com,tab.co.uk,techfounder.net,thesun.co.uk,tmz.com##.sharing
 ! ##.facebook
 cashless.pl,hardreset.info,dramacool.so,gemlikbasinhaber.com,vichy.com.tr,driving.ca,ilkfullfilmlerizle.org,ceptenmp3.net,kwejk.pl,businessinsider.com,digitaltrends.com,elle.com.tr,gazetemanset.com,haberdesondurum.com,kickstarter.com,milliyetemlak.com,sabah.com.tr##.facebook
 ! ##.twitter
@@ -19,9 +18,7 @@ notebookcheck-hu.com,notebookcheck-ru.com,notebookcheck-tr.com,notebookcheck.biz
 ! ##.socialbar
 areamobile.de,bildderfrau.de,derstandard.at,chosunonline.com,godmode-trader.de,futurezone.de,thebody.com,mobil.news.at,bild.de,www-pcgameshardware-de.cdn.ampproject.org,www-pcgames-de.cdn.ampproject.org,m-bild-de.cdn.ampproject.org,gamingcfg.com,m.bild.de,morgenpost.de,cs.ingame.de,derwesten.de##.socialbar
 ! ###social-share
-lewdgamer.com,zet.com,clubhunters.ru,multiplayer.it,www-m.cnn.com,edition-m.cnn.com,ampproject.org,drom.ru,haberler.com,daenischesbettenlager.at,daenischesbettenlager.de,jysk.al,jysk.am,jysk.ba,jysk.be,jysk.bg,jysk.by,jysk.ca,jysk.co.id,jysk.co.uk,jysk.com,jysk.com.cy,jysk.com.kw,jysk.com.mt,jysk.ch,jysk.cz,jysk.dk,jysk.ee,jysk.es,jysk.fi,jysk.fr,jysk.ge,jysk.gr,jysk.hr,jysk.hu,jysk.ie,jysk.it,jysk.kz,jysk.lt,jysk.lv,jysk.nl,jysk.md,jysk.me,jysk.mk,jysk.no,jysk.pl,jysk.pt,jysk.ro,jysk.rs,jysk.se,jysk.si,jysk.sk,jysk.ua,jysk.vn,jysk-ks.com,jyskthailand.com,pisiffik.gl,rumfatalagerinn.is,skemman.fo###social-share
 ! ##.social-share
-onet.pl,ovaciondigital.com.uy,elpais.com.uy,epochtimes.de,businessinsider.de,newsletter.co.uk,heraldo.es,infowars.com,goodtoknow.co.uk,trustedreviews.com,sports.ru,gsmarena.com,lifewire.com,ndtv.com,forbes.com,indiangaysite.com##.social-share
 ! ##.post_share
 shubz.in,elearn.interviewgig.com,euro-pulse.ru,smallacademy.co,techashi.com,motoroctane.com,tboost.xyz,unipack.pl,xiaomitoday.it,moveout.in,gadgetmir.org,simply.reviews,smarttvnews.ru,gurudroid.net,softolet.ru,isimtescil.net,memohaber.com,paytmtodayoffer.com,iguides.ru,mashable.com##.post_share
 ! ##.sharePage
@@ -29,9 +26,7 @@ maxconsole.com,hdmekani.com,gezenbilir.com,maxicep.com,australianfrequentflyer.c
 ! ###alt
 720pfilmizletir.com,filmizleplay.com,fullfilmvakti.com,indirmedenizleyin.com###alt
 ! ##.share-buttons
-sukima.me,ran.de,cyclingnews.com,edmdl.com,sat1.de,kabeleins.de,prosieben.de,investopedia.com,chip.de##.share-buttons
 ! ##.dp-share
-isexpro.net,javhdonline.com##.dp-share
 ! ##a[data-share-url]
 lawgazette.co.uk,ibc.org,pcgamesn.com##a[data-share-url]
 ! ##.paylas
@@ -65,7 +60,6 @@ qr.quel.jp###shareoption
 qr.quel.jp##.qr_share
 freeimage.host##.btn-social:not([class*="btn-mail"])
 revuestarlight.com##.st-Footer_Sns
-einfachbacken.de##.social-share-links > a:not(.social-share-links__link--pdf)
 washingtonpost.com###share-tooltip-control
 bookmyshow.com##.bcBRAA
 bookmyshow.com##div[class="df-au df-av df-cq"]
@@ -103,7 +97,6 @@ jiji.com##.MainInner > .ArticleTitle + .SnsBtn
 news-postseven.com##.w-SnsCount
 studopedia.ru##.article-info-share-wrapper > div.icons
 audi-mediacenter.com##div[class^="page-item--"][class$="-feed"]
-daily.co.jp##.ul_socialClip > li > a[href^="javascript:share"]
 bet.com##.article__overlay-share
 bet.com##div[role="button"][aria-label^="Share video on"]
 radiolife.com##.sns-icons
@@ -194,7 +187,6 @@ tbs.co.jp##ul[class^="top-shareblock"]
 info-maimai.sega.jp,monogatari-series.com##.SNS
 heros-ultraman.com##.idx-Social
 viz.com##a[href*="Share()"]
-viz.com##a[href^="http://twitter.com/intent/tweet?"]
 ktonanovenkogo.ru##.podel
 sm.news##.small-slide__social
 suntory.co.jp###suntoryCommonFt_ShareBtn
@@ -393,7 +385,6 @@ mens.tasclap.jp##.p-article-main-bottom-share::before
 ideal.es,elcorreo.com##a[data-voc-social-sharer]
 ideal.es,elcorreo.com##.voc-more-share
 ideal.es,elcorreo.com##.vjs-voc-social-share-wrap
-dq-dai.com,eigahitottobi.com##.share_area
 theblockcrypto.com##.feedCard-social
 canarias7.es,hoy.es,lasprovincias.es##.voc-social-btn[class*="-share"]
 udemycoupons.me##.bctt-click-to-tweet
@@ -402,7 +393,6 @@ minha.exame.com##div[class^="Share__ShareContainer"]
 blog.zoom.us##.f-share-block
 kikubon.jp##.shareSNS_top
 shopee.com.my##div[class] > div.justify-center.items-center > div.flex:first-child
-golem.de##.social-tools
 tass.ru##div[class^="shareList_"]
 skysmart.ru##skysmart-articles-material-share
 ouniversodatv.com##.widget.LinkList + div.widget
@@ -428,7 +418,6 @@ anime-planet.com##.cta.pure-1
 tsargrad.tv##.article__social
 wn.de##.fp-social-media-container
 mon-isha-anime.com##.me_sns
-rtrp.jp##.shareBottom
 rtrp.jp##.shareTop
 poradnikbiznesu.info##.vicky-post-share-container
 poradnikbiznesu.info##.vicky-social-left-container
@@ -496,7 +485,6 @@ nhk.or.jp##.share-fixed
 nhk.or.jp##.nhk-snsbtn
 beskidlive.pl##.bw-social-share
 beskidlive.pl##.mod_fantastic_facebook_sidebar
-canyoublockit.com##body .heateor_sss_sharing_container
 note.com##.o-noteContentHeader__share
 note.com##.a-icon--share
 nazya.com###fav-container > span.rght
@@ -521,7 +509,6 @@ premierleague.com##.socialShareSticky
 digikey.com##div[data-testid="share-popup-trigger"]
 zeolearn.com##.social-fix
 theindianwire.com###text-3
-blog.domclick.ru##div[class^="SocialSharingButton_social-sharing-button"]
 mhealth.ru##.test-result-share
 kp.ru##div[class*="styled__ShareBarWrapper-"]
 news.obozrevatel.com##.reaction_item.--hotFacebook
@@ -566,7 +553,6 @@ gadgets360.com##.reddit-icon
 dallasnews.com##div[class^="app_share-bar_shareBar"]
 sketchup.cgtips.org##.widget_bs-likebox
 miraimedia.asahi.com##.p-single-share
-linuxuprising.com##.share-box
 freepng.ru##.pdt-share
 andreadekker.com##.social-rocket-evernote
 andreadekker.com##.social-rocket-facebook
@@ -582,7 +568,6 @@ culture.ru##.js-card-social-button-show
 newspim.com##.bodysns
 ||square-enix.com/common/templates/images/footer/share_
 perthnow.com.au##div[class*="-StyledSharing "]
-wco.tv##div[class^="addthis_sharing_toolbox_"]
 opencritic.com##.oc-calendar__header + div[class="text-center mt-4"]
 milliyet.com.tr##.horoscope-info__share
 reason.com##.rcom-social-tools
@@ -638,7 +623,6 @@ postype.com##.post-reaction > .action-group
 store.line.me##.MdCMN22Share
 kzn.ru##.socials-sidebar
 happiness.com###share-icon
-gothamist.com##.c-share-tools
 timeout.com##a[class*="social_share__"]
 citaty.net##button[data-quote-share-action]
 freetutorialsus.com##.widget_redwaves_fblikebox_widget
@@ -649,7 +633,6 @@ hojeemdia.com.br##.itens-buttons-social
 scarymommy.com##.sm-share
 embarcadero.com##.saxon-social-share-fixed
 tz.de##.id-Actionbox-items-el--pocket
-tz.de##.id-Actionbox-items-el--whatsapp
 kommersant.ru##.doc_sharing__body > label[for^="sharing_list_"]
 miniwebtool.com##.icon-bar
 thepythoncode.com#?#div[align="center"]:has(> span:contains(/^Sharing is caring/))
@@ -793,7 +776,6 @@ oneindia.com##div[class*="light-share-"]
 ||widget.crowdynews.com/OneIndia_home-horizontal.js$domain=oneindia.com
 kino.1tv.ru##.eump-share-social-items
 netpeaksoftware.com##.social-content-bottom > h3.social__title
-tubularinsights.com##div[class^="single-article-share"]
 newsd.in##.maincontent > div.social
 newsd.in##.followusgoogle
 animationxpress.com##.widget_simple_facebook_page_feed_widget
@@ -802,7 +784,6 @@ maximuzz.ru##.full-track__share
 mel.fm##.share-button__link
 typepad.com##.entry-footer-share
 typepad.com###nimble_fb
-webkul.com##span[class*="wk-bar-share-icon"]
 der-postillon.com##.addthis-wrap
 focus.pl,kobieta.pl,elleman.pl,mojegotowanie.pl,przyslijprzepis.pl,glamour.pl,national-geographic.pl##.article-share-bottom
 beauty321.com##.socialmediapush
@@ -901,7 +882,6 @@ inploid.com###main_question_share_div
 straightedgestyle.com,crossbike.biz###sns-bottoms
 premirea.jp,straightedgestyle.com,kotyanlife.info,daij1n.info,crossbike.biz##.sns-msg
 acefitness.org##.post-full__share
-talasexpresshaber.com##.sharing-container
 ||cashify.in/static/post/svgs/share-*.svg
 shaalaa.com##.share_btn_alt
 crictracker.com##ul[id^="ct_social_share"]
@@ -996,7 +976,6 @@ marvel.com##div.social-links
 vedantu.com###SharePageType
 algemeiner.com##.socialbot
 killscreen.com##.selectionSharer
-m.comic.naver.com##.share_area > .info_share
 manofmany.com##div[data-cmp="share"]
 vgchartz.com###socialMediaIconBox
 terra.com.br##.t360-sharebar
@@ -1031,7 +1010,6 @@ khersondaily.com##a[onclick^="shareEvent("]
 nationalheraldindia.com##div[class^="styles-m__sticky-social-share_"]
 downtoearth.org.in##a[onclick^="social_open("]
 watch.impress.co.jp###amp-floating-area
-segmentfault.com##.sticky-wrap .dropdown > .dropdown-menu > a > button.react-share__ShareButton
 business2community.com,blog.mettl.com##.sharect
 henaojara.com##ul.ListPOpt > li > a[rel="nofollow"][onclick^="window.open"]
 yourhealthinmind.org##.e-inline-share
@@ -1073,7 +1051,6 @@ apnews.com##div[class^="socials"]
 feedly.com##button[title="Save to Twitter"]
 talkingpointsmemo.com##.Sharebar
 gmanetwork.com##.header_social
-bloomberg.com##div[class^="share-article-button__"]
 theatlantic.com##div[class^="ArticleShare_root__"]
 buzzfeed.com##ul[class^="shareBar__"]
 buzzfeed.com##div[aria-label="Share This Article"]
@@ -1132,7 +1109,6 @@ haaretz.com##button[data-test="redditButton"]
 haaretz.com##button[title^="Share in"]
 dizipal.pro,cnbctv18.com,ksl.com##.social
 bulurum.com###socialBox
-queer.pl##a[href^="https://twitter.com/home?"]
 corrieredellosport.it##div[class^="SocialColumn_"]
 sahadan.com,mackolik.com##.widget-article__share-button
 mackolik.com###fancybox-close
@@ -1142,7 +1118,6 @@ kidega.com##.sharerArea
 mk.ru##.article__share-and-comments
 shiseido.co.jp##.sns2019
 javdock.net##.video-share
-juejin.cn##.share-btn:not(.report-btn)
 dailyo.in##.page-socialshare
 dailyo.in##.twoverlay
 yengec.co##.cdb-post-share
@@ -1161,14 +1136,12 @@ yodobashi.com,utaten.com##.snsNav
 techraptor.net##div[id^="block-sharingbuttons-"]
 redhat.com##.block--sharelinks
 livelaw.in##div[data-category="common-social-sticky-share-livelaw"]
-yaro.ua##.social-wrap
 pusatporn18.com##a[href^="https://chat.whatsapp.com/"] > img
 today.line.me##.interactiveShare-item
 gamek.vn##a[onclick*="shareOnFacebook()"]
 ||gamek.mediacdn.vn/Images/btnlike.PNG
 konoe.studio##.blog-post-share
 dedale.ru,cdus.ru,helpexe.ru##.post-meta
-ringon.site##.share_btn
 ringon.site##.share_btn + div.arrow_box
 championat.com##.article-footer__row > div > div.article-footer__title
 rawstory.com##.body-share-wrap
@@ -1233,10 +1206,8 @@ filmindir.be##.show-us-love
 kenko.sawai.co.jp##ul[class^="sns"]
 u-can.co.jp###js-sns-target
 testbook.com##.sharing-wrapper
-estadao.com.br##.share-trigger
 tjournal.ru##.wtf_bc--feed-item--share--list > span:not([data-item-link-share])
 blavity.com##.article-sharing-links
-vg.no##ul[class^="css-"] > li[aria-label="facebook"]
 lihkg.com##.i-share-variant
 tsn.ua###mBtnShare
 infoeda.com##.wpsr-share-icons
@@ -1371,7 +1342,6 @@ silicone-forum.com##div[data-widget-definition="share_page"]
 paquetaesportes.com.br##.whatsapp-contact
 cnnindonesia.com##.share--navigation
 kp.ru##.tell-friends_button--share
-noticiasdatv.uol.com.br##a[class^="addthis_button_"]
 pleno.news##.socials > li > .event-click
 mir24.tv##.social-cell
 todayifoundout.com##a[data-provider="tumblr"]
@@ -1440,7 +1410,6 @@ obj.ca##div[class$="name-sharethis"]
 jaseng.ru##.av-share-box
 radiokp.ru##div[title="Поделиться"]
 note4tech.com###post-social-actions
-note4tech.com##div[data-hook="social-sharing"]
 aufeminin.com##.af-social-btns
 zinzinzibidi.com###social-media-sharing
 delamar.de##.bar-social-hor
@@ -1502,7 +1471,6 @@ schwaebische.de##.socialMediaButton[data-share]
 abi.de##.teile
 prnews.pl##.prne-socials
 getdigital.de##.fbslideout
-oggusto.com##.sharing .sharing-ogs
 timesofindia.indiatimes.com##div[data-bottomsocialshare]
 kurashi-no.jp##.c-shares
 kurashi-no.jp##.p-sns-share-fixed
@@ -1542,14 +1510,12 @@ watchmovie.movie##.video-socialshare-container
 kumo-anime.com,jojo-portal.com,cssreference.io##.footer-share
 dizipal120.com,dizipal121.com,dizipal122.com,dizipal123.com,dizipal124.com,dizipal125.com,dizipal126.com,dizipal127.com,dizipal128.com,dizipal129.com,dizipal130.com,dizipal131.com,dizipal132.com,dizipal133.com,dizipal134.com,dizipal135.com,dizipal136.com,dizipal137.com,dizipal138.com,dizipal139.com,dizipal140.com,dizipal141.com,dizipal142.com,dizipal143.com,dizipal144.com,dizipal145.com,dizipal146.com,dizipal147.com,dizipal148.com,dizipal149.com,dizipal150.com,dizipal151.com,dizipal152.com,dizipal153.com,dizipal154.com,dizipal155.com,dizipal156.com,dizipal157.com,dizipal158.com,dizipal159.com,dizipal160.com##button[onclick^="window.open ('http://www.facebook.com/sharer.php?"]
 dizipal120.com,dizipal121.com,dizipal122.com,dizipal123.com,dizipal124.com,dizipal125.com,dizipal126.com,dizipal127.com,dizipal128.com,dizipal129.com,dizipal130.com,dizipal131.com,dizipal132.com,dizipal133.com,dizipal134.com,dizipal135.com,dizipal136.com,dizipal137.com,dizipal138.com,dizipal139.com,dizipal140.com,dizipal141.com,dizipal142.com,dizipal143.com,dizipal144.com,dizipal145.com,dizipal146.com,dizipal147.com,dizipal148.com,dizipal149.com,dizipal150.com,dizipal151.com,dizipal152.com,dizipal153.com,dizipal154.com,dizipal155.com,dizipal156.com,dizipal157.com,dizipal158.com,dizipal159.com,dizipal160.com##button[onclick^="javascript:window.open('https://twitter.com/intent/tweet?"]
-koravidstream.com##.open-share-toolbar
 crowdin.com##.share-cell
 lybrate.com###shareBtnLeft
 lybrate.com##.share-widget
 apollomaniacs.com###socialbookmark
 ahwaktv.tv##.mico-share
 thedubrovniktimes.com,smart-grids.pl###ampz_inline_bottom
-fitness.wp.pl##.share-links > a:not(.link-comments)
 reuters.com##ul[class^="ShareButtons__container___"]
 hellomagazine.com##.page__share
 yurukuyaru.com##.article-social-btn
@@ -1563,7 +1529,6 @@ ndtv.com##.pst_icn-btn > a.ss-lk
 ndtv.com##.ss > a.ss-lk
 deccanherald.com,acm.org##.share-this-popover
 acm.org##.rlist > li[title="Share"]
-lifehacker.ru##div[class*="footer__share"]
 lifehacker.ru##.article-card-actions__share
 blog.fitwell.com.tr##button[aria-label^="Share on "]
 forklog.com##div[class$="share_blk"]
@@ -1617,7 +1582,6 @@ bradenton.com##.vjs-share-trigger
 ||cdn.bibliatodo.com/assets/img/recursos/compartir/c1.png
 ejjdin.com##.my-plugin-share
 zaytung.com##div[width][align="right"] > a[style^="color:#60B7B5;"]
-theqalead.com,proprivacy.com##.share-it
 stilltasty.com##.social-icons:not(.srchbox)
 medium.com##.dm[aria-label="Share Post"]
 theverge.com##.tab-bar-fixed
@@ -1648,7 +1612,6 @@ radiozet.pl,meloradio.pl,antyradio.pl##.icon-icn_share
 tiscali.it##.tsIcoSocial
 freepik.com##.button--pinterest
 freepik.com##.popover--share
-freepik.com##.button--share
 tozlumagazin.net##.twitter_waller
 tozlumagazin.net##.facebook_waller
 margreiter-shop.de##.details-product-share
@@ -1696,7 +1659,6 @@ mediazona.by##.mz-publish-share
 mediazona.by##.material-footer-share
 bbc.co.uk##.LongArticle-share
 monclick.it##div[data-content="share-dialog"]
-mobilenet.cz##.detailButtons > a.btn--facebook
 sports.ru##.b-social-buttons-new
 scribd.com##.sharing_btn
 superjob.ru##.f-test-button-share
@@ -1721,7 +1683,6 @@ meduza.io##div[data-cy="share_buttons"]
 meduza.io##div[class^="styled__ShareTitle-"]
 lrytas.lt##span[data-tooltip="Dalintis per Facebook"]
 lrytas.lt##span[data-tooltip="Dalintis per Messenger"]
-collider.com##.sharing-btn:not(.btn-comment)
 centruminformacji.tvp.pl##.likeBoxes
 streameast.live##.social-toggle
 ||s-nk.pl/script/nk_widgets/nk_widget_fajne_embed$domain=tvp.pl
@@ -1789,14 +1750,12 @@ kyky.org##.article__social__share
 ||seesaawiki.jp/js/evernote/
 ||seesaawiki.jp/img/usr_second/common/bt_tumblr.gif
 prtimes.jp##.container-share
-wikinews.org###social_bookmarks
 ohtuleht.ee##.share--items
 ohtuleht.ee##.share--label
 hbr.org##a[js-target$="-share"]
 tvp.pl##.vod-page__video-socials
 megaup.net##.socialsider
 pnas.org###shareit
-tvn.pl##a[href^="http://www.facebook.com/sharer.php?"]
 hotline.ua##.instagram-media
 nownews.com##.userBlk > div.titleBlk > div.infoBlk > ul.share
 dailymail.co.uk##.share-comment
@@ -1838,7 +1797,6 @@ eskarock.pl,poradnikzdrowie.pl,eska.pl##.fb__shareBox
 greenlemon.me##div[class="socail_share_area row"]:not([id])
 eldiario.es##.edi-social-buttons
 trashbox.ru##.div_subcaption2_subs
-nzherald.co.nz##.share-bar > a:not([class^="social-link social-link--bookmark"])
 themuse.com###social-marker > a[target="_blank"]
 folha.uol.com.br##.c-modal-drop
 folha.uol.com.br##.f-share__list
@@ -1875,7 +1833,6 @@ e-kitap.site,ekitap.site##.kitap_paylas
 e-kitap.site,ekitap.site##.shareb
 ||player.daznservices.com/player/releases/v*/unfilled/share.chunk.js$domain=goal.com
 the-ans.jp##.side-sns
-lsm.lv##.share-icons
 lsm.lv##.share-caption
 nyafilmer2.com,sadhguru.org,nyafilmer1.com,pagamentidigitali.it,ogsoundfx.com,tittafilmer.com,webfilmer.com,nyafilmer.vip##.a2a_kit
 wellsfargo.com##.sideUtility
@@ -1898,7 +1855,6 @@ zoso.ro###social-share-button
 mojanorwegia.pl##.right-col > .fb
 mojanorwegia.pl##.newshare-wrapper
 paulig.ru##div[id$="_social-sharethis-block"]
-theinventory.com##.js_share-tools
 theinventory.com##.js_share-tools
 nevasport.ru##.sidebar-widget
 cablegratis.online##iframe[src="https://canal.cablegratis.online/aviso/face.php"]
@@ -1954,7 +1910,6 @@ m.europapress.es##.ComparteContainer
 kino-teatr.ru##.block_100_bablo
 bankier.pl##.m-social-bar > div[class^="m-social-bar"]:not(.m-social-bar__comment)
 newscientist.com##.article-body .social__button-container
-einthusan.tv###social-wrapper
 thumbnails.porncore.net##a[href^="//share.naver.com/"]
 jerkoffer.com##.shareinit
 rezkozpatch.xyz##.smart-shares
@@ -1977,7 +1932,6 @@ myfin.by##.custom-share
 ansa.it##.social-menu li.facebook
 ansa.it##.social-menu li.twitter
 ansa.it##.social-menu li.linkedin
-aktuality.sk##a[href^="https://www.facebook.com/sharer.php"]
 dila.ua##.article-share-block
 m-timesofindia-com.cdn.ampproject.org##div.as_heading > .pdTop_2 > div[id^="ss-"]
 m-timesofindia-com.cdn.ampproject.org##.adspacing
@@ -1989,7 +1943,6 @@ mirf.ru##.content_footer_social
 bisnis.com###sticky-share > div.share
 europapress.es###subnavegacionFixed
 guiainfantil.com###share-bottom > li:not(.comments)
-guiainfantil.com##.share-icons > span:not(.comments)
 digiday.com##.article-socials
 foma.ru##.single-block-share
 elitarium.ru###execphp-8
@@ -2085,7 +2038,6 @@ proprofs.com##.share-inner-wrp > .share-click1
 nasa.gov##.chertools_floater
 uzone.id##.button-share-box
 semanticscholar.org##.icon-share-twitter
-semanticscholar.org##.icon-share-facebook
 mel.fm##.article__social-widget
 iguides.ru##.social__subscribe
 eurosport.ru##.ShareIcons__title
@@ -2110,7 +2062,6 @@ lubimiygorod.od.ua##.facebook-widget
 iz.ru##.share_bottom2
 facenews.ua##.gnews
 chudesa.site##ul[id^="menu-menyu-"] > li.menu-facebook
-gala.pl##body .socializer-fb-share
 ibrala.com,haberintakasi.com##a[href^="https://api.whatsapp.com/send"]
 haberintakasi.com##.video-sshare
 nmnby.eu##.publish_share
@@ -2141,7 +2092,6 @@ psicologiaymente.com##.sticky_share-list > li:not(.comments)
 psicologiaymente.com##.article_actions__list > li > .share_dropdown-wrap
 psicologiaymente.com##.article_actions__list > li > button[aria-labelledby^="share"]
 cameralabs.org##.albomsocial > a[rel="nofollow"]
-fandom.com###ShareEntryPoint
 delovoymir.biz##.social_title_top
 delovoymir.biz##div[class^="block-article-social"]
 filmstarts.de##.article-sharing-action
@@ -2173,7 +2123,6 @@ hurhaber.com##.detayy > img[onclick^="window.open("][onclick*="paylas"]
 sueddeutsche.de###sz-video-sidebar-action-mail
 sueddeutsche.de###sz-video-sidebar-action-twitter
 sueddeutsche.de###sz-video-sidebar-action-facebook
-tf1.fr##div[class^="ShareButton_shareButtonContainer_"]
 moneylo.fr##.desktop-share
 moneylo.fr##.mobile-share
 bbs.ruliweb.com##a[href^="javascript:app.sns_share"]
@@ -2185,7 +2134,6 @@ netzwelt.de##.nl-share
 netzwelt.de##ul.mfb--bl
 budzma.org##a[href="https://t.me/budzmaby"]
 moya-planeta.ru##.share-header
-sxyprn.com,cc.com,motor.ru,mapsofworld.com,software.informer.com##.share_btn
 naked-science.ru##.shesht-social-sharing-block
 pleer.ru##div[itemtype] > div#comment + div[class]
 hromadske.ua##.SocialShareBlock
@@ -2193,7 +2141,6 @@ hromadske.ua##.PostPreview-share
 mirf.ru##.head_post_desc_social
 np.pl.ua##.entry-content > p + h6
 gameinformer.com##.gi5-social-share
-thegamer.com,cbr.com,gamerant.com,screenrant.com##.sharing > .sharing-btn:not(.js-show-coments)
 southparkstudios.com##.media-extra > div[role="button"][aria-label^="Share" i]
 tio.ch##.social-toolbar > .litem > .social-share-icon
 dastereo.ru,community.bitwarden.com,forum.hifiguides.com##.quote-sharing
@@ -2248,7 +2195,6 @@ lachainemeteo.com##.socialNetworksBar
 vitebsk.cc##.widget_twitter_feed_widget
 eurosport.fr##[class*="ShareIcons"]
 javhdporn.net,kaplog.com,tvnet.com.tr##.video-share
-focus.ua##.socials-share-toolbar
 tmbukz.ga##.single_social_top
 film.org.pl##.widget-post-share
 indianexpress.com##.lvblg-sharebx
@@ -2267,10 +2213,8 @@ developpez.com##.reseauxSociaux > div[style="width:100%; white-space:nowrap;"] >
 aptoide.com##div[class^="share-button__"]
 cnbcindonesia.com##.share > span
 cnbcindonesia.com##a[class*=" gtm_share_"]
-di.fm##.social-button.share
 forum.militaryparitet.com##.fancy-addthis-post
 onet.pl##.fbShare
-medonet.pl,fakt.pl##.socialButtons
 fakt.pl##div[data-position="mobile"][data-run-module="local/main.social"]
 calculateaspectratio.com##.share > *
 vagalume.com.br###shareLyrics
@@ -2304,8 +2248,6 @@ karspor.com.tr,sismikmarket.com,abakuskitap.com,troyestore.com,edifier.com,idilf
 lookcam.pt,lookcam.it,lookcam.fr,lookcam.de,lookcam.es,lookcam.ru,lookcam.com,lookcam.pl##.livecam_share
 abema.tv##.com-m-media-SNSShare__container
 grafikerler.org##.maxmag_facebook_widget
-wpgurme.com##.post-share .share-handler
-aftonbladet.se##a[href^="https://www.facebook.com/dialog/share?"]
 travelest.ru,zpu.kr.ua##.jllikeproSharesContayner
 teren.in.ua##.widget_weblizar_facebook_likebox
 deccanchronicle.com,boldsky.com##.cnheader-sharing
@@ -2340,7 +2282,6 @@ orion.fm##.penci-social-share-center
 kcra.com##.js-share-container
 teknikturk.com.tr###co-share
 ||livingtraditionally.com/wp-content/cache/min/1/f6d40e07318704badcdcdac0aff1556a.js
-cookpad.com###inline-share-links
 myanimelist.net##.js-sns-icon-container
 protocol.ua###fb-share-button
 protocol.ua###viber_share
@@ -2350,7 +2291,6 @@ weekend.gazeta.pl##.shortSocialBar
 ua.news##.content-socials
 techgame.pl###share-media
 netmeter.eu###shareblock
-afanasy.biz,flsaudio.com,alexzsoft.ru##.single-share
 barstoolsports.com##.sharingLinks__social
 readovka.news##a[href="#tab-main"]
 kresy24.pl###wkomimg
@@ -2380,8 +2320,6 @@ manager-magazin.de##div[data-component="FeatureBar"]
 knowyourmeme.com##.homepage-share
 sportmaster.ru##.sm-goods_main_details_social
 nyafilmer.*##.inlinelike
-pless.pl##.fb-share-button-static
-redpost.com.ua##.fb-share-button-custom
 usdaynews.com,gameost.net##.tt-share
 mycharm.ru##.cell-share
 mycharm.ru##.left-socials
@@ -2422,7 +2360,6 @@ kwantowo.pl##.post-footer-share
 pinkvilla.com##.myBtnShare
 pinkvilla.com##.top_media > ul
 pinkvilla.com##img[onclick*="Sharebutton"]
-thewindowsclub.com###ss-floating-bar
 mp3yukleindir.com##.share-on-socials
 ilmessaggero.it##.share-item-container
 stern.de##.ArticleMeta-sharing
@@ -2501,7 +2438,6 @@ vkurier.info##.heateor_sss_sharing_ul
 waterstones.com##.action-share-container
 gp.by##.yashare-wrap
 ||m.imgur.com/js/share.*.bundle.js
-imgur.com##.Gallery-Share
 gigacourse.com,ruposters.ru##.post-footer
 ruposters.ru##.post-header > div.tb
 news2day.co.kr##.sns_gp
@@ -2526,7 +2462,6 @@ wsu.edu##.spine-share-tab
 cian.ru##div[data-name="SharingButton"]
 focus.ua##.yo-social-panel
 easyspeak.ru##.right_soc_block
-dunya.com##a[data-flip-widget="shareflip"]
 pravda.if.ua,root-nation.com,odnaminyta.com##.tdb_single_post_share
 pravda.if.ua##.tdb_single_post_share + div.td_block_separator
 m.mistrzowie.org##.mmg_facebook_share
@@ -2544,7 +2479,6 @@ trollno.com##.facebook-page
 thinkwithgoogle.com##.detail-header-meta__social
 thinkwithgoogle.com##.article-toolbar-share
 rssatom.com##a[class$="Link"][href="#"][onclick^="(function() {if (!window.open("]
-suffolknews.co.uk,advertiserandtimes.co.uk,northern-scot.co.uk,kentonline.co.uk##.SocialArticleIcons
 bebeautiful.in###stickysocial
 downmienphi.com##footer > div#fanback
 downmienphi.com##.share-module
@@ -2593,7 +2527,6 @@ xakep.ru##.s_so
 myinstants.com,fool.com###share-box
 steelorbis.com,myinstants.com##a[onclick^="share"]
 elle.ua##.page-col-left-social
-ftuforums.com##.widget_redwaves_fblikebox_widget
 expresso.pt##.shareTools
 m.fark.com##.details_share
 realmehelp.com,provideomontaj.ru##.socials-after_post
@@ -2636,7 +2569,6 @@ ogretmenevdesatis.com,pet-room.ru,dogeat.ru##.product-share
 fetchtube.com##.sv-download-ads
 fetchtube.com##.sv-predownload-button > span[style="color:green;text-align:center"]
 fetchtube.com##.sv-predownload-button > span[style="color:green;text-align:center"] + div[style="align:center"]
-stirileprotv.ro,webcg.net,landofgames.ru,lifter.com.ua##.social-btns
 forums.flyer.co.uk##.widget_facebook
 forums.flyer.co.uk##.widget.text-2
 dohomemadeporn.com##.tools__item.social
@@ -2647,7 +2579,6 @@ megasport.center##.elementor-element-populated div.elementor-widget-container > 
 theobserver.ca##.article-actions > .icon-share
 wiez.pl##.quote-socials
 wiez.pl##.post__socials-box
-pravda.com.ua##.post_social
 vashsport.com##.uptl_container-share
 rahim-soft.com##.social_icon > span[data-service]
 m.guancha.cn##.shareMain
@@ -2656,8 +2587,6 @@ lounge.fm##.share > .twitter
 rusplt.ru##.actions-wrapper
 nationalpost.com###breakingnews-social
 bauermedia.co.uk##.c-wrapper > main > article[class*="twitter"][class*="container"]
-wysokieobcasy.pl,wyborcza.pl,wyborcza.biz##.socialBar > ul > .fbShare
-wysokieobcasy.pl,wyborcza.pl,wyborcza.biz##.socialBar > ul > .twitter
 fundalina.com##.share-story-container
 nyafilmer.*##.a2a_default_style
 vp.rambler.ru,media.eagleplatform.com##.eplayer-skin-share
@@ -2670,7 +2599,6 @@ antalyam.com##.zozo_fb_widget
 apnews.com.ua##.post__sticky-social
 omaha.com,diyetextra.com,tdn.com##.share-label
 turbopages.org##.social-panel-root
-businessinsider.com##.share-toggle
 catve.com##div[onclick="window.open('https://www.facebook.com/pg/portalcatve/videos/');"]
 catve.com##svg[width="28"][height="28"][onclick^="window.open("]
 ntv.ru##.sharein
@@ -2724,7 +2652,6 @@ donanimhaber.com##.header-paylasim
 press.pl##.column_left_inner > .share
 press.pl##.article-icons-content > a[href^="http://www.wykop.pl/dodaj?"]
 coingape.com###social-section
-jarock.pl##.post-container .share-buttons
 jarock.pl##.post-container .sidebar .post-fb-box
 jarock.pl##.post-container .sidebar .col-xs-12 > .yt-box
 inmyroom.ru##.b-PostShares
@@ -2734,7 +2661,6 @@ businessinsider.in##.bottom-cmn-share
 haberkibris.com##.sharethis-sticky-share-buttons
 webcartop.jp##.sns-wrapper
 lrytas.lt##.socialMsngr
-wykop.pl##.dropdown > div .social-list > li > .social-share
 lemonde.fr,kotaku.com.au##.meta__social
 tele1.com.tr##.yenisocial > li:not(.google-news-follow)
 mumsnet.com##.social-sharing-icons
@@ -2753,7 +2679,6 @@ themarker.com##button[data-test="whatsappButton"]
 themarker.com##button[data-test="facebookButton"]
 themarker.com##a[data-test="mailButton"]
 happymonday.ua##.share-article__main-links-wrap
-joemonster.org###fb-share
 newsweekjapan.jp###shareToolBtm
 malkaram.com##.detay-sosyal
 juedische-allgemeine.de##.social-icon-wrapper
@@ -2761,12 +2686,10 @@ intexty.com,softhome.ru##.custom-socials
 opom.pl##.blog-tags-social
 adresemama.com,deji.com.tr##.smlIconSet > .shareBtns
 adresemama.com,deji.com.tr##.smlIconSet > .shareTitle
-metacritic.com##.follow_like_module
 tennessean.com##span[data-share-method]
 go.tvn24.pl##.icon-widget > .icon-facebook
 stylecaster.com###single-social-header
 stylecaster.com##.sharecount-social-btns > li.menu-item:not(.sc-icon-comment)
-independent.co.uk##.social-share-wrap > amp-social-share
 mumbailive.com##body .sticky-share
 badisches-tagblatt.de##.StoryShowMetaShare
 tunefind.com##span[class^="Share"]
@@ -2776,7 +2699,6 @@ denofgeek.com##.social-links__items
 denofgeek.com##.social-links__items + span.sep
 goldapple.ru##.pdp__share
 medindia.net,blog.malwarebytes.com##.share-section
-dailymail.co.uk##.article-icon-links .share-link
 be-in.ru##.thing-socials
 gizmodo.com,kotaku.com##.sHsHa
 gizmodo.com,kotaku.com##.js_share-tools
@@ -2813,7 +2735,6 @@ news.ltn.com.tw##.shareline
 androidride.com##.post-share-float
 discoverychannel.com.tr##.widget_bizi_takip_edin
 www-pocket--lint-com.cdn.ampproject.org##.extras > .social
-travelbook.de##.mashsb-container
 travelbook.de##body #mashbar-header
 sinefy.com##a[onclick*="window.open('whatsapp://send"]
 sinefy.com##a[href^="javascript:"][href*="Share"]
@@ -2823,8 +2744,6 @@ yourdictionary.com##aside[role="complementary"] > .yd-share-icons
 toledoblade.com##.pgevoke-contentarea-socialbuttons-wrapper
 expressen.se##.article .social-panel
 coronavirus.mash.ru##.share_a
-embetronicx.com##.ArevicoModal
-embetronicx.com##.ArevicoModal-bg
 showdream.org##.rcol > div.bc.review + center
 sozluk.memurlar.net##.entry-Share
 ||getsocial.io/*/gs_async.js$third-party
@@ -2852,7 +2771,6 @@ dicio.com.br,significados.com.br,dicionariodenomesproprios.com.br##.sg-social
 usnews.com##div[class*="SocialSharing"]
 investing.com###share-btn
 wio.waw.pl##.l-socials__wrapper
-tygodnik.polsatnews.pl##.article__share > .menu--share > ul.menu__list > li.menu__element:not(.menu__element--comments)
 redditery.com##h4 > .social[onclick]:not([onclick*="arguments"])
 j-town.net##.entry-social-btns
 frontend.1worldonline.com##.js-social-btns
@@ -2884,7 +2802,6 @@ kartal24.com##.a-header > .qpr.cf > li[class]:not(.c-open)
 niezalezna.pl###articleBody > center > a[href][onclick^="fbshare"]
 worldofmods.com##.stop-waiting.guest > .repost > .repost-buttons
 xn--80adhccsnv2afbpk.xn--p1ai##.vk-after
-indulgexpress.com,newindianexpress.com##.Share_Icons
 wsj.com###webui-share-tools
 wotexpress.info###right-col > div.group_vk
 radiosaw.de###quicktabs-facebook_twitter_quicktabs
@@ -2892,7 +2809,6 @@ radiosaw.de###block-quicktabs-facebook-twitter-quicktabs
 debaty.sumy.ua##.single_pluso_title
 rebenok.by,1reg.by##.share-float-bottom
 dailymail.co.uk##.sjs-share-container
-dailymail.co.uk##div[class="social top "] > ul
 directg.net##.product-share-container
 breitbart.com##.bnn-social-share
 github.blog##.post__social-share
@@ -2935,7 +2851,6 @@ fxmag.pl##.Social-title
 miped.ru##.article-tags + div.article-social
 schieb.de###avia_fb_likebox-2
 ebaumsworld.com,shop.miele.com.tr,tesbihane.com##.shareBtns
-pixabay.com##.like_buttons > .share_button
 gidasanayim.com##.sosyalmediaicons
 elrellano.com##.widget_heateor_sss_follow
 lesacdechips.com##.social-sharing-bar
@@ -2980,7 +2895,6 @@ sport24.gr##.socialButttons
 sport24.gr##.addthis_sharing_container
 singleclickapps.com##.g-page
 singleclickapps.com##.nav-list > div[style$="border-width:1px;width:300px;height:70px"]
-starsinsider.com##.nm-fb-share
 wallpaperplay.com###adsdimmer a#pin
 wallpaperplay.com###at-image-sharing-tool
 wallpaperplay.com##.bottom_panel > .flexbox > div[style="width: 100%"] > a[href*="assets.pinterest.com"][rel="nofollow"]
@@ -3076,11 +2990,9 @@ essen-und-trinken.de##.mail-button
 news.microsoft.com##.mt-social-links
 sports-ndtv-com.cdn.ampproject.org##.cat-hdr-share
 myfin.by##.news-share > span:first-child
-makeuseof.com,mirfactov.com##.sharing-btn
 kesanpostasi.com##.twp-social-share
 kesanpostasi.com##.twp-toggle-share
 mailonsunday.co.uk,9to5google.com,9to5mac.com,9to5toys.com,dronedj.com,electrek.co##li[class^="share-"]
-msfsaddon.com,arstechnica.com,snopes.com##.share-links
 thebell.io##.share-overlay
 codeburst.io##div[style*="position"][style*="will-change"][style*="transform"] button[class] > svg[width="25"][height="25"]
 stackoverflow.com##.js-social-container
@@ -3122,7 +3034,6 @@ polityczek.pl###likeFB
 grouple.co##.social-panel
 regnum.ru##.article_sharing_buttons
 jbzd.com.pl##.facebook-send
-jbzd.com.pl##.facebook-share
 kp.ua##.sb-subscribe
 2ndvote.com##.herald-single-sticky
 evernote.com##.social-overlay-open
@@ -3131,11 +3042,9 @@ ngs24.ru,e1.ru##div.central-column-container > div[class] > div[class] > div[cla
 sxyprn.net##.sharing_toolbox
 paykasareseller.com##.chatbot a[href*=".whatsapp.com/send?"]
 rotana.net,pladform.ru##.vjs-share-control
-cumberlink.com,journalstar.com##.social-share-links
 gazeta.ru##.column-share
 smart-flash.jp,amp-pcwelt-de.cdn.ampproject.org##.socialButton:not(.feedback)
 autorambler.ru##div.layout > div.grid > div#reviewsList > footer.share
-horoscopes.rambler.ru##.rambler-share
 ||discordapp.com/widget?id=$domain=creatorlabs.net
 smatu.net,usimaru.net,chimolog.co,kurume-it.ac.jp,bita.jp,worldometers.info,softantenna.com##.sharewrap
 gamegaz.com##.snsb > li:not(.comments-balloon-btn)
@@ -3159,7 +3068,6 @@ gazetedamga.com.tr##.social-buttons > a[data-platform-name]:not([data-platform-n
 wowroms.com###col-main .social_title
 terra.com.br##.socialWrapper > li.iconSocial:not(.icon-comment):not(.commentLabel)
 what.cd##.ListPOpt > li > a[rel="nofollow"][onclick^="window.open"][class*="fa-"]
-tehno-rating.ru##.fshare
 fnweb.de##.nfy-sticky-buttons > ul > li[onclick*="mmShare"]
 rheinpfalz.de,pz-news.de##a[class*="nfy-share-"]
 emderzeitung.de##.nfy-detail-content > .nfy-media-group > a:not([onclick]):not([href*="comment"])
@@ -3190,7 +3098,6 @@ bz-berlin.de##.article-sharing-box
 sportbuzzer.de##.dcm-story-new__social-div
 transfermarkt.de##.news-header-social
 sozcu.com.tr##.bottom-toolbar
-zeit.de##.article-sharing
 yoox.com###share-info
 converse.com##.product-actions > .social-container
 sportskeeda.com##.share-text-holder
@@ -3236,7 +3143,6 @@ ddizi1.org,ddizi.co##.tw-color
 gq.com,techcrunch.com,wired.com##.article__social-share
 inyourpocket.com##.header_socials
 komkur.info##.usocial_block
-yenimeram.com.tr##a[onclick^="window.open('https://plus.google.com/share?"]
 minsknews.by##.social-sharing-nk
 mk.co.kr##.sns_right
 leparisien.fr##.article-toolbar > .article-iconbar ~ .article-iconbar
@@ -3252,7 +3158,6 @@ derstandard.*##.js-article-tool-navigatorshare
 timesofindia.com##.vs_share
 sueddeutsche.de##.sz-article__sharing-bar
 m.quotenmeter.de###qm-home > .qm-item + a + div[style^="width:300px; overflow:hidden;"]
-news.crunchbase.com##.ss-inline-share-wrapper
 news.crunchbase.com###ss-sticky-bar
 dramanice.movie##.button_share > a[onclick^="window.open('"]
 ||lasmax.com.tr/images/fa.png
@@ -3277,10 +3182,8 @@ yemeksepeti.com##.order-share-inner
 wgospodarce.pl##.meta__share-list
 yusepjaelani.blogspot.com##div[style*="position: sticky"][style*="dotted silver"]
 disboards.com##div[data-widget-key="shareThisPage"]
-dobreprogramy.pl##a[href^="http://www.facebook.com/share.php"]
 elnuevodia.com##.toolbar-item-share
 atv.com.tr##.share-media
-kazefuri.web.id##.socialshare
 onet.pl##div[class][data-run-module^="embeddedapp/main.sharethis_"][data-gtm-social]
 dirilispostasi.com##.share > span
 gadgetsnow.com##.idsocial.sticky
@@ -3309,7 +3212,6 @@ gotrip.hk##.single-share-bar
 kayserihaber38.com##.haberPaylas
 gundemotuzbes.com##.sctls > ul > li.facebook
 gundemotuzbes.com##.sctls > ul > li.twitter
-gundemotuzbes.com##.socialButtonv1 > ul > li > a[onclick^="ShareOn"]
 embed.radio.co###socialAnchor
 faz.net##.js-sharebuttons[data-services*="twitter"]
 faz.net##.js-layer-sharing-open
@@ -3389,7 +3291,6 @@ vice.com##.article-heading-v2__social-link
 mybrazz.com,mybrazz.club##.social-links-left
 oantagonista.com##.share.visible-desktop
 ru-mi.com##.product_icons_social
-paradergi.com.tr,czasfinansow.pl,attacomsian.com,meme-arsenal.com,merriam-webster.com,embed.ustudio.com,marketwatch.com##.share-icons
 cronista.com##.content-entry-share
 lordiz.com##a[href="javascript:void(0);"][onclick$="_click()"][data-wpel-link="internal"]
 freesoftpdfdownload.blogspot.com###sidebar-two > #HTML2
@@ -3398,7 +3299,6 @@ marketingprzykawie.pl,eltiempo.com###selectionSharerPopover
 eltiempo.com##ul.articulo-guarda-reporta > li.btn_Texto34
 eltiempo.com###shareArticle > ul > li > a[class]:not(.comentar):not(.save-article)
 fakt.pl##.shareWidget
-sanalbasin.com##a[href="javascript:void(0)"][onclick^="popup('https://www.facebook.com/sharer/sharer.php"]
 rmj.ru##.socials_recommend_block
 guiamais.com.br##.socialAdvertiser
 openmedia.io##.single-post-share-icons
@@ -3415,8 +3315,6 @@ jyllands-posten.dk##.artView__shareToolbar
 daemon-hentai.com##.widget_easy_facebook_like_box
 journal.tinkoff.ru##.article-footer__sharer
 fitnavigator.ru,madgeek.io,ironworld.ru,hiji.ru,gorodokboxing.com,asusfone.ru##.entry-footer__share-title
-auto-swiat.pl,komputerswiat.pl##.social-box
-itsfoss.com##.ss-inline-share-wrapper
 torrentrg.org,utofiles.com,torrentbe.net###tweet_notice
 ea.com##.eapl-section-column > ea-social-bar
 arkade.com.br##.share-buttons-post
@@ -3438,7 +3336,6 @@ dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,ec
 dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,echodnia.eu,expressbydgoski.pl,expressilustrowany.pl,gazetakrakowska.pl,gazetalubuska.pl,gazetawroclawska.pl,gk24.pl,gloswielkopolski.pl,gp24.pl,gs24.pl,kurierlubelski.pl,nowiny24.pl,nowosci.com.pl,nto.pl,pomorska.pl,poranny.pl,to.com.pl,wspolczesna.pl,polskatimes.pl,sportowy24.pl,strefaagro.pl,strefabiznesu.pl,stronakobiet.pl,gol24.pl,gra.pl,naszemiasto.pl,miastakobiet.pl,stronazdrowia.pl##div[class*="ArticleFoot"] > div[class*="ArticleFoot"][class*="icons"] > button[title="Udostępnij!"]
 dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,echodnia.eu,expressbydgoski.pl,expressilustrowany.pl,gazetakrakowska.pl,gazetalubuska.pl,gazetawroclawska.pl,gk24.pl,gloswielkopolski.pl,gp24.pl,gs24.pl,kurierlubelski.pl,nowiny24.pl,nowosci.com.pl,nto.pl,pomorska.pl,poranny.pl,to.com.pl,wspolczesna.pl,polskatimes.pl,sportowy24.pl,strefaagro.pl,strefabiznesu.pl,stronakobiet.pl,gol24.pl,gra.pl,naszemiasto.pl,miastakobiet.pl,stronazdrowia.pl##div[class*="ArticleFoot"] > div[class*="ArticleFoot"][class*="icons"] > button[id^="componentsArticleFoot"][id$="Share"]
 dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,echodnia.eu,expressbydgoski.pl,expressilustrowany.pl,gazetakrakowska.pl,gazetalubuska.pl,gazetawroclawska.pl,gk24.pl,gloswielkopolski.pl,gp24.pl,gs24.pl,kurierlubelski.pl,nowiny24.pl,nowosci.com.pl,nto.pl,pomorska.pl,poranny.pl,to.com.pl,wspolczesna.pl,polskatimes.pl,sportowy24.pl,strefaagro.pl,strefabiznesu.pl,stronakobiet.pl,gol24.pl,gra.pl,naszemiasto.pl,miastakobiet.pl,stronazdrowia.pl##div[class*="ArticleFoot"] > div[class*="ArticleFoot"][class*="icons"] > button[id^="componentsArticleFoot"][id$="Share"] ~ button.componentsArticleFoot__icon
-mumbaimirror.indiatimes.com##.topVideoSec > .social-icons.socialVideo
 tsn.ua##.c-share-sticky
 learn.javascript.ru##.frontpage-share
 cosmo.ru##.sharing-new
@@ -3491,15 +3388,12 @@ apkpure.com##.addthis-menu
 samsunsonhaber.com##.payla > div > a[onclick^="payla"]
 1plus1.ua##.article__footer-social
 prokazan.ru##.social-lines
-video.az##.jw-sharing-dock-btn
 hd720pfilmizle.com##.sociaPayLasimt
 gencgazete.net##.content_inner > div.img1_grid > div[class] > div.social
 derstandard.at##.story-tool-socialshare-menu
 elespectador.com##.node-social-networks
-carbuzz.com##.post-share-toolbar
 la7.it###shareholder
 iol.co.za,znak.com,haberkibris.com,marketrealist.com##.sharethis-inline-share-buttons
-gamerant.com##.w-sharing
 ottawamatters.com##.share-title + ul[data-url]
 aamulehti.fi##.article-content > .sc-cmTdod > .sc-ibxdXY > .sc-RefOD
 catalannews.com,scandinaviansoul.com##.element-socialbookmarks
@@ -3517,7 +3411,6 @@ track-trace.com###share-link
 wweek.com##.social-tools-wrapper-bottom
 vitaminler.com##.knw-social-buttons
 bbc.com##.lx-stream-post__footer-share
-tichyseinblick.de##.sharing.bar
 thegamesdb.net##div[data-url^="https://www.facebook.com/sharer/sharer.php"]
 thegamesdb.net##div[data-url^="http://www.stumbleupon.com/submit?url"]
 m.emlakjet.com##.share-bar-wrapper
@@ -3548,12 +3441,10 @@ m.timesofindia.com##div[data-ga*="share-twitter"]
 timesofindia.indiatimes.com##.as_byline > i[data-plugin$="share"]
 haber7.com##.news-share-frame
 thethao247.vn##.the-article-share
-forum.hdblog.it###shareStrip
 svalbardposten.no##.nf-c-artikkel-share
 agrarii-razom.com.ua##.share-social__wrapper
 18000.com.ua##.share-article-text
 18000.com.ua##.has-left-sidebar > .block-facebook
-rivnepost.rv.ua##.sharing-links
 topuniversities.com,rz.com.ua##.block-addtoany
 rz.com.ua##.socials_button > div:not(.pre_name)
 family-style.net##.mvp-post-soc-fb
@@ -3563,7 +3454,6 @@ vinnytsianews.com##.row > aside.widget-area > aside.widget-instagram
 whatsnewinpublishing.com,vinnytsianews.com##.share-btns-main
 cfts.org.ua##.s-shares
 carthrottle.com##.ct-share
-therichest.com##.w-sharing > .sharing-btn:not(.showCommentsButton)
 zive.cz##.ar-society-networks-wrapper > .ar-society-link
 marketmedia.ru##.news-content__social
 elpais.com##.compartir-otros
@@ -3585,7 +3475,6 @@ vivaldimagazin.com,webtekno.com##.content-timeline__detail__social-media
 tv-lida.by,kkphm.com,haohaiyo.cc,51kkp.club##a[href^="https://t.me/"]
 kkphm.com,haohaiyo.cc,51kkp.club###share-square
 rbc.ru##.quiz__result__social
-mperspektiva.ru##.news_share
 philips.ua##.BVRRReviewSocialLinksContainer
 genius.com##[url="$ctrl.annotation.share_url"]
 dev.to###article-actions-tweet-button
@@ -3603,14 +3492,12 @@ babakus.com##.socialbar
 1000projects.org,upscpdf.com###text-4
 gran-turismo.com##.kLGGEq > a[class="_3cOCYi _3FunNS"]
 gran-turismo.com##.kLGGEq > a[class="_3cOCYi gwHPsB"]
-neredekal.com##.share-trigger
 zingat.com##.custom-addthis
 investmentwatchblog.com##.wpsr-buttons
 dachamechty.ru##.c_share-box
 gp.by##.social-block-top
 animeonline.cc,mnogoseriy.ru,rg-mechanics.cc,kinoxa.biz##.yx-share
 cryptocurrencytopnews.com##.dp-social-media-share-wrap
-techbook.de##.mashsb-box
 oyunceviri.net##.widget_jnews_facebook_page
 kino-hd720.club##.polno-share
 gearbest.com##.asideShareFB
@@ -3622,11 +3509,9 @@ torontosun.com##.share-nav-button
 amazon.com##div[data-widgetid="share"]
 svyaznoy.ru##._socials
 svyaznoy.ru##.b-article-activity__socials-wrapper
-eskisehirgundem.com##.ssk-group
 moyatours.com##.omb_login
 vacation-et.work##.sns-group-viral
 turizmgazetesi.com,checkout.com##a[href^="https://linkedin.com/shareArticle"]
-e-psikiyatri.com##.ssk-group
 telecinco.es##li[class^="shareBar__social_"]
 ino.lomo.jp,crystalmark.info##.loop-share-num
 qualitydergisi.com##.post-sharing-tp-1
@@ -3654,7 +3539,6 @@ indiatimes.com##.small-social-icon
 rutube.ru##button#facebook.facebook
 rutube.ru##button#vk.vk
 rutube.ru##button#twitter.twitter
-realnyezarabotki.com##.social-footer
 playua.net##.main-header__info__share
 bizhint.net##.like-artical
 inegolonline.com##a[onclick*="-share-dialog"]
@@ -3672,8 +3556,6 @@ wsj.com##li[class*="WSJTheme__share-tool"]
 muzmo.org##.items > div[class="ajax-item item-song"]:not([id])
 turizmguncel.com##.haberDetay .list-inline.social
 eaomedia.ru##.comment-ss
-naekranie.pl##.social-buttons.floating
-naekranie.pl##.social-buttons > .sharingButton:not(.commentBg)
 moydrygpk.ru##.code-block
 artfulliving.com.tr##.PaylasBtn
 rb.ru##.quiz__subtitle
@@ -3687,7 +3569,6 @@ dolina.ua##.text-description + div[style="float: right; line-height: 39px; margi
 psychologies.ru##.side-block_soc-tabs
 ilkha.com##.entry_content > .full_meta > div[style="float:right"]
 family-style.net,tehnofan.com.ua###mvp-soc-mob-wrap
-comp-profi.com,kitguru.net,formatatmak.com,thefreethoughtproject.com,s0ft4pc.com##.share-post
 glamour.ru##.article-detail-text__photo-socials
 white-windows.ru##.ww-post-share
 userello.ru##.social-on-page
@@ -3736,7 +3617,6 @@ newser.com###divSocialAndCommentsButtonsTop > a:not([id="aShareComments"])
 fishki.net##.content__figure__share__social
 womanadvice.ru###mobile_social
 gazzetta.gr##.field-name-bottom-share-buttons
-bursahayat.com.tr##.share-bar > a
 onlinemschool.com###oms_share_s
 m.bursahayat.com.tr##.general-share
 reporter-24.com##.mh_magazine_facebook_page
@@ -3751,7 +3631,6 @@ dayoga.ru##.footer-social-groups
 technosova.ru,u.today##.share__social
 smachno.ua##.soc_table
 yogajournal.ru##.block_share
-evaveda.com##a[href^="https://vkontakte.ru/share.php"]
 evaveda.com###text-15.widget-container
 evaveda.com###custom_html-2.widget-container
 evaveda.com###text-4.widget-container
@@ -3815,9 +3694,7 @@ videogameschronicle.com##.vgc-socialshare
 infoniac.ru##.sidebar_left .tabs_social
 ktozvonit.com.ua##.tooltip-n > .icon_i
 mustget.ru##.post-share-count
-mustget.ru##.share-toggle
 mustget.ru##.sticky-sidebar .widget_boombox_social
-cinemablend.com##.share-toggle > div.contents
 digi24.ro##.social-link
 autonews.ru,rbc.ru,sportrbc.ru##.article__header__share-block
 rbc.ru##.article__header__counter-block > .article__header__after
@@ -3860,7 +3737,6 @@ d-navi004.com###snsbox
 ogretmensitemiz.com##a[href="javascript:void(0);"][onclick^="shareFacebook"]
 mensxp.com##.article-social > a.track_ga[social-type]:not(.save)
 amarujala.com##.floating-share-iconsDv
-neuepresse.de##.pdb-share-article-container > div[class^="pdb-share-container-item pdb-share-article-container-item pdb-share-container-item_"]
 nsctotal.com.br##.FloatSocialShareContainerWrapper
 shostka.info,sumypost.com##.ni-share
 shostka.info,sumypost.com##.to-telegram
@@ -3871,7 +3747,6 @@ reclameaqui.com.br##.complain-share
 181fm.com##.button-dropdown.share
 repl.it##.share-button-wrapper
 m.lodoshaber.com##.general-share
-gundembursa.com,lodoshaber.com##.share-bar > a[onclick^="RE.share("]
 arte.tv##.avp-button--share2
 patronlardunyasi.com##div[style="width:320px; margin-bottom:20px;"] > a[href][class^="social_"]
 livesport.ws##span.share_title
@@ -3900,7 +3775,6 @@ t3n.de##.c-social.-buttons
 blick.ch##.layout-multi-line--social-sharing
 bigmir.net##.b-article-share
 eksisozluk.com###mobil-sticky-share-topbar
-sportbuzzer.de##div[data-plugin="socialButtons"] > .dcm-story-new__share-facebook
 sportbuzzer.de##div[data-plugin="socialButtons"] > .dcm-story-new__share-facebook + .dcm-story-new__share-text
 sportbuzzer.de##div[data-plugin="socialButtons"] > .dcm-story-new__share-twitter
 sportbuzzer.de##div[data-plugin="socialButtons"] > .dcm-story-new__share-twitter + .dcm-story-new__share-text
@@ -3908,7 +3782,6 @@ tw.news.appledaily.com##.Fbshare
 tw.news.appledaily.com##.Twittershare
 onet.pl##.twitterShare
 foxbaltimore.com,foxchattanooga.com,foxillinois.com,foxlexington.com,foxnebraska.com,foxreno.com,foxrochester.com,foxsanantonio.com,nbcmontana.com,okcfox.com,siouxlandnews.com,wach.com,wchstv.com,wcyb.com,wfxl.com,wgxa.tv,wlos.com,wsbt.com,wsmh.com,wvah.com,cbs2iowa.com,fox4beaumont.com,mycbs4.com,mynews4.com,news4sanantonio.com,abc6onyourside.com,wtov9.com,turnto10.com,fox11online.com,mynbc15.com,nbc16.com,abc22now.com,fox23maine.com,nbc24.com,fox28media.com,myfox28columbus.com,fox42kptm.com,fox45now.com,fox56.com##div[id^="js-Social-Share"]
-bluestacks.com##.share-actions
 rocklandboulders.com,highpointrockers.com##.sn-share-icons
 alexgoldcheidt.com##.entry-content > div[align="center"] > a[href^="//www.alexgoldcheidt.com/go/share-"][target="_blank"]
 fnp.de##.id-Actionbox-items > li:not(.id-Actionbox-items-el--comments)
@@ -3955,7 +3828,6 @@ ilsole24ore.com##.tools > li > .twr
 ilsole24ore.com##.tools > li > .inr
 startandroid.ru###Mod91
 producer.com##.lr_horizontal_share
-medonet.pl,forums.tomshardware.com##.shareButtons
 forums.tomshardware.com##a[data-xf-init="share-tooltip"]
 womanel.com.ua##.orakul-azure-block
 ria.ru##.elem-info__share
@@ -4029,7 +3901,6 @@ etranslator.ro##a[href^="javascript:void(window.open('http://www.etranslator.ro/
 naszemiasto.pl##.componentsArticleTools > .componentsArticleTools__button[title="Udostępnij!"]
 jornaldacidadeonline.com.br##.post__share-bar
 jakbudowac.pl###actionsPanel > .actions-list > button[class^="action share-"]
-n-tv.de##.article__share > a
 the-flow.ru##.social_counters
 openspeedtest.com###ostsharebutton
 plusone8.com,tubezx.com##a[href="#share"]
@@ -4040,7 +3911,6 @@ techjourney.net,manjemedia.com##.cp-floating-social-bar
 olkino.com##.topline_vk
 thequestion.ru##.question__answers-info-share-text
 ltn.com.tw##.share.boxTitle
-formel1.de##.shariff-button
 1cloud.ru##.oc-share
 microsoft.com##.jetpack_widget_social_icons
 microsoft.com##.social-footer-wrap
@@ -4107,16 +3977,12 @@ thebrandage.com##.left > a.tw
 thebrandage.com##.left > a.li
 r7.com##.modal-video-share
 r7.com##.shared-text-social
-dynamo.kiev.ua##.social-likes
 gamer-info.com##.soc
-jvcmusic.co.jp##.lap-list-share > .m-share-site > ul
-jvcmusic.co.jp##.lap-list-share > .m-share-site > span:first-child:not([class])
 thebigdata.co.kr##.snsbar
 gnavi.co.jp##.p-shareButton__cont
 gnavi.co.jp##.gn-share
 forum.rsload.net##.theme__share-dropdown
 ekilog.info,channel-jk.com###sns-group
-bestofclip.com##.show-views > .social_share
 sondakika.com##.socialMediaScope
 dexerto.com##.flex > #sharesCount
 dexerto.com##.flex > #sharesCount + .fwb.ttu
@@ -4145,7 +4011,6 @@ seekingalpha.com##.sa-share-btn-wrapper
 seekingalpha.com###share-btns
 lezizyemeklerim.com##.share > a[data-fbui]
 lezizyemeklerim.com##figure > a[data-pin]
-politica.estadao.com.br##ul[class="share "]
 geminiadvisory.io,chimerarevo.com##.addtoany_shortcode
 inkazan.ru##.share-popups-component
 broncos.com.au##body .share-block__list
@@ -4161,7 +4026,6 @@ m.enbursa.com##.nbSearch[onclick="RE.socialDivShow();"]
 teltarif.de##.sbm
 ||pfm.pl/images/fb.png
 pfm.pl##.single-article-social
-maxedtech.com##.social-buttons
 ngnovoros.ru##div[data-tip="Репост в соцсети"]
 vokrug.tv##.social-group-list
 review-hub.co.uk##.essb-viralpoint
@@ -4336,8 +4200,6 @@ fashion-likes.ru##.soc
 m.dcinside.com,kindou.info##.sp-share
 wiwo.de##.c-socialshare
 handelsblatt.com##.vhb-share-button
-speakingtree.in##.share.verticalC
-speakingtree.in##.top-items > .share-icons
 karapaia.com##.snsshare-ttl
 karapaia.com##.snsshare
 android-smart.com###tb > label[for="scv"]
@@ -4353,7 +4215,6 @@ originalnews.nico##.articleList-subpage-bottom-sns
 tvn24.pl##.shareContainerTop
 tvn24.pl##.shareContainerBottom
 tvn24.pl##.socialShareContainer
-kino.mail.ru,mailblog.mail.ru##.sharelist
 4gamer.net##.socialbookmark
 4gamer.net###SOCIALBOOKMARK_BOTTOM_BAR
 watch.impress.co.jp###social-upper
@@ -4365,13 +4226,9 @@ mskc.pro,idmanxeber.az##.penci-social-buttons > .penci-social-share-text
 mskc.pro,idmanxeber.az##.penci-social-buttons > .penci-social-item:not(.penci-post-like)
 yahoo.co.jp##.yjnSnsBtn
 purepc.pl##.article-options2 > span.soc_fbc
-tvn.pl,dobreprogramy.pl,purepc.pl##a[href^="https://twitter.com/share"]
-purepc.pl##a[href^="https://plus.google.com/share"]
-purepc.pl##a[href^="https://www.facebook.com/sharer/sharer.php"]
 nicovideo.jp##.article-share-footer
 appvs.famitsu.com##.sns--type_article
 asahi.com##.Contents > .UtilityBar
-mobile.reuters.com##.amp-social-container
 s.famitsu.com##.l-sticly-share
 mainichi.jp###area-share
 nikkei.com##li[class^="m-usefulToolsPulldown-"]
@@ -4399,7 +4256,6 @@ freebrowsers.ru##.socialinit
 o2.pl##div[data-st-area^="ST-Article-Social"] > div[class] > div[class] > div[class][title="polubienia"]
 codenet.ru##.np-social-icons
 smhn.info##.share_top
-gofundme.com##.js-share-facebook
 wgrz.com##.sticky-sharing
 plejada.pl,onet.pl###content-share-top > [class*="_share"]
 s.inside-games.jp,gamespark.jp###snsBtn
@@ -4413,7 +4269,6 @@ chrdk.ru##.detail-nav__item_share
 jp.techcrunch.com##body #stcky-footer
 jp.techcrunch.com###social-after-wrapper
 limonmuzik.com,ankaoutdoor.com,kitapaktif.com,soo.cool,akratekstore.com##.productSocial
-seznamzpravy.cz##a[href^="//www.facebook.com/share.php"]
 newsweekjapan.jp###shareTool
 mindhack2ch.com##.hatebu-btn
 news.denfaminicogamer.jp###spFixedContent
@@ -4433,7 +4288,6 @@ togetter.com##.social_lite_button
 togetter.com###social_floating_box
 togetter.com##.feedback_box > [class*="button"]
 togetter.com###fixed_social_footer > .left > .radius_share
-cdn.vuukle.com###app .shares-badge
 cdn.vuukle.com###app .shares-badge + .more-btn
 cdn.vuukle.com##span[class^="ShareCommentAction__"]
 radiotunes.com##div[data-share-region]
@@ -4504,7 +4358,6 @@ daily.co.jp##.ul_socialClip
 voxmedia.com,vox.com##.c-social-buttons > *
 infonet.vn##.social[data-url^="https://infonet.vn/"]
 autogrodno.by##div[id^="jlvkgroup"]
-domain-status.com,pcgamesn.com,thurrott.com##.social-sharing
 nastroy.net##.btn_fb_like
 nastroy.net##.soc_image
 nastroy.net##.soc_kentr
@@ -4513,14 +4366,12 @@ hurriyet.com.tr##li[data-hj-share]
 nzherald.co.nz##.byline-shares-wrapper
 popcorntv.it###shareBtn_lower
 washingtonpost.com##.social-tools-wrapper
-kinopoisk.ru##.ya-share2
 bandwidthplace.com,oo-software.com###share-twitter
 indiegogo.com##share-item[ng-click]
 politeka.net##.meta-title--share
 ont.by##.tagitem
 kinoafisha.ua##.socio
 melos.media###post > .post_sns
-eveningtimes.co.uk##.custom-sharing
 wmaraci.com##.sosyalpaylasim
 nld.com.vn##.sharedmxh
 nld.com.vn##.sharedallmxh
@@ -4536,7 +4387,6 @@ bz-berlin.de##.sharing-bottom
 telebasel.ch##.tb-tile-overlay-share
 baomoi.com##a[data-href*="share"]
 nieuwsblad.be##.social-sticky-wrapper
-livepage.pro##.sharebox
 vnexpress.net###mshare_title > .btn_twitter
 nicovideo.jp##.VideoMenuContainer-areaRight > div[class="Snap Balloon"]
 nicovideo.jp##.Snap.Balloon-arrowWrap
@@ -4551,7 +4401,6 @@ wired.jp##.social-area-syncer
 watch.impress.co.jp###floating-social-buttons
 watch.impress.co.jp###social-under
 smartvsphone.it###post_share_text
-gameranx.com###ctoolbar
 tg24.sky.it##.c-article__sharing
 mp4upload.com##a[href^="javascript:share_"]
 europapress.es##.boton-social
@@ -4592,7 +4441,6 @@ koolinar.ru##a[data-social]
 kievpravda.com##.social-add
 kievpravda.com##.social-blocks
 theoryandpractice.ru##div[data-hypernova-key="SharePanel"]
-biz.liga.net##.social-likes > *
 updatecrazy.com,odnaminyta.com,alexgyver.ru,azstxs-lejyoner-info.cdn.ampproject.org,daftarharga-biz.cdn.ampproject.org,inc42.com,itc.ua##.ss-ic
 elektrikforum.de,bauexpertenforum.de##.social_share_bar
 ostsee-zeitung.de,maz-online.de,kn-online.de,haz.de##.pdb-share-container > div:not([data-js-share-item="font-size"])
@@ -4600,7 +4448,6 @@ courseforfree.net,freecoursesites.com,myenemy.club,wildzz.com,newsteez.com,pchoc
 antalyaekspres.com.tr,wday.ru##.contentShare
 hentaisd.tv###barra
 przegladsportowy.pl##.tw_share
-przegladsportowy.pl,komputerswiat.pl,onet.pl##.fb_share
 tempomag.com.tr##.tags_share-wrapper
 mobileworld.it,smartworld.it,androidworld.it##.bzsocial
 tribalfootball.com##.article-social-wrapper
@@ -4611,7 +4458,6 @@ riafan.ru##.share-pre-block
 gorodrabot.ru##.shareLabel
 kleo.ru###tabs_wrapper
 juraforum.de,wochenblatt.de##.social-media-bar
-canadapolicereport.ca,watergate.tv##.mh-share-buttons
 maedchen.de##.main-header__sharing
 maedchen.de##.article-grid__column--share
 gamebomb.ru##.container-light
@@ -4630,7 +4476,6 @@ obozrevatel.com##.main-grid__subscribe
 obozrevatel.com##.btn-fblikes-counter
 obozrevatel.com##.section-info_part > div.statistics__wrap > :not(a)
 examiner.co.uk##.gig-comment-shareLink
-wday.ru##.share-line
 autocentre.ua##.content-shares
 autocentre.ua##.aside-shares > *
 smak.ua,eurointegration.com.ua##.post__social
@@ -4654,8 +4499,6 @@ instyle.hu###articleAuthorSide > #stickInArticle
 glamour.hu##.wrapSocial
 ellegirl.ru##.page_share
 zonasports.es##.jumbotron .well[style="min-width:1028px"]
-mezohir.hu##.mh-share-buttons > .mh-pinterest
-mezohir.hu##.mh-share-buttons > .mh-googleplus
 magazine.cygames.co.jp,narendramodi.in,theblockcrypto.com,evamagazin.hu##.articleShare
 evamagazin.hu##.articleFacebookShare
 haaretz.co.il##article header > div > div > div > button[font-size="-2"]:not([elementurl])
@@ -4688,7 +4531,6 @@ tayvan-drama.com##.Container33 > .TexAlCenter + .Container100
 coub.com##.sharing__dropdown__item:not([data-clipboard-text])
 buzzfeed.com##.subbuzz__media .action-bar
 pokeristby.ru##.social__networks
-onedio.com##.o-fb-share-btn
 coub.com##.wkly__footer__sharing
 coub.com##.wkly__footer .hbold.box--vertical
 yolculukterapisi.com###sidebar > aside#text-12
@@ -4698,7 +4540,6 @@ pchocasi.com.tr,travelingturks.com##.herald-sticky-share
 patreon.com##.fTSoXD > .iu8a4l-0 > .b0e4o3-0 > .vvigvw-0
 patreon.com##.kwFSoq
 cheezburger.com##.tb-share
-cheezburger.com##.js-share-pinterest
 hide.me##.c-sharebtn
 denfaminicogamer.jp##.entryMeta > .snsPalette.flxBox
 kalptensozler.com##.osd-sms-wrapper
@@ -4723,7 +4564,6 @@ auone.jp##.article__container > .sns--large
 asahi.com##.SnsUtilityArea > .SnsBtn
 asahi.com###Contents > section > .UtilityBar
 airlinehaber.com##.csbwfs-sbutton-post
-telefonguru.hu##a[href^="javascript:share('https://plus.google.com/share?url="]
 telefonguru.hu##a[href^="javascript:share('https://www.facebook.com/sharer/sharer.php?"]
 vokrug.tv##.shared-like-block
 hotcars.com##.art-body-sharing
@@ -4735,7 +4575,6 @@ bilgisayarprogramlari.net##.kfi_post-share
 leiderdorpsweekblad.nl##.tac > .us_twitter
 mlb.com##.byline__share
 businessinsider.com##.share-wrapper-bottom
-opinionstage.com##.os-social-bar
 gateworld.net,intex-press.by,smartbobr.ru##.wc-share-link
 aljazeera.com##.article-readToMe-share-block
 4players.de##a[class^="social-"]
@@ -4764,14 +4603,11 @@ buddhism.ru###sh4
 ladbible.com##.share-controls > div > .share-controls__item:not(.share-controls__item--message):not(.share-controls__item--anchor)
 n4mo.org##.sd-sharing-enabled
 dailymail.co.uk##.article-icon-links > li.facebook
-nationalpost.com##.share-button
 tokyohive.com##body.single .post .social-links > li:not(:first-child)
 tokyohive.com##.overlay-social > .social-links > li:not(:first-child)
 gamme.com.tw##.post > .share_top
 gamme.com.tw##.metas > .shareblock
 gamme.com.tw##.fixedbutton > .linkmore
-gamme.com.tw###wrap > .shareBtn.collapsed
-gamme.com.tw##.post > .share_like_area > .sharebtns > li > [class]:not(.sharebtns_url):not(.sharebtns_msg)
 literaturus.ru##.PlusFollowers
 yahoo.co.jp##.socialBtn
 evrl.to##div[class^="vk_group"]
@@ -4791,7 +4627,6 @@ syl.ru##.share_img
 sovsport.ru##.sharing-row
 replyua.net##.share-blc
 porn300.com,porndroids.com##.video-footer__social .btn-facebook
-porn300.com,porndroids.com##.video-footer__social .btn-twitter
 sophosakademi.org##.theiaStickySidebar > #text-html-widget-2
 seraysever.com##a[title$="a Paylaş"][rel="nofollow"][href^="javascript:void(window.open("]
 nazlim.net###text-53
@@ -4830,26 +4665,20 @@ yeniasir.com.tr##.detail-social > ul > li > a[data-type="googleplus"]
 fikriyat.com##.pageSocial > ul > li:not(.print)
 fikriyat.com##.shareFrame > .item:not(.send):not(.share):not(.embedLink)
 sofra.com.tr##.newShare
-famitsu.com,crackberry.com##.share__list
 gearbest.com##.goodsIntro_share
 dailysabah.com##.navSocial
 coursecouponclub.com,geekhacker.ru,bestcouponhunter.com,ufficiospettacoli.it,phpscripttr.com##.share-link-image
-wired.com##.social-share-sidebar-component
 rossaprimavera.ru,artikeltekno.com##.share_tool
 artikeltekno.com###share-this
 n-tv.de##.social-services
-imore.com##.share__list
-appletoolbox.com##.dpsp-total-share-wrapper
 appletoolbox.com##.dpsp-networks-btns-wrapper > li > .dpsp-pinterest
 repo.hackyouriphone.org##.fb_icon
 repo.hackyouriphone.org##.twitter_icon
-m.cyber.sports.ru,m.sports.ru##.b-social-buttons
 usatoday.com##.persistent-share-button-sticky
 marvel.com##footer > .social-bar-container
 coub.com##.story__sharing-list
 coub.com##.story__sharing-dropdown
 nahnews.org##div[class^="mb-share-"]
-geo.de,comp-profi.com,amp.indiatimes.com,newatlas.com##.social-bar
 hgtv.ca##.socialMediaLinks-container
 m.aksam.com.tr##.interaction-buttons:not(.count-page)
 m.aksam.com.tr##.fixed-interaction-bar
@@ -4873,21 +4702,17 @@ toplanzi.com##img[onclick="fbinvite()"]
 lunar.az##.sende_paylas
 sportnews.to,indir.vip###custom_html-4
 mia.az##.y_icons > a[href^="JavaScript"][href*="/share"]
-mk.ru###vk_groups2
 mk.ru###ok_group_widget
 millixeber.az##.td-footer-wrapper .widget_flb
-webtekno.com##body .content-share-mobile .content-share
 manoramaonline.com##.share_block_sub
 speedtest.net##a[title="More share options"]
 fuck55.net##.bookshare
 onedio.com##.main > div[style="margin:10px 0 10px 0; width:100%; text-align:center;border-bottom:1px solid rgb(234, 234, 234);padding-bottom:20px;"]
 regionxeberleri.com##.fstory > font[color="red"]:not([class]):not([id])
-qafqazxeber.az##.IN-widget
 teknolog.com##.smart-sidebar-item > .xtss-wrap
 teknolog.com##[class^="xtss-"][class$="-post show-for-small"] > .xtss-wrap
 eba.gov.tr##.content-share-area
 faktxeber.com##.ishare
-delo.ua##.sharer
 dijitalguvenlik.org,viatrolebus.com.br,journo.com.tr##.herald-single-sticky
 take.az##.gkFooter > .custom > .custom > h3[style="color: #7D7B7A;"]
 bbc.com##.lx-share-tools
@@ -4899,11 +4724,9 @@ biletix.com###social_media
 speedtest.net##.result-item-share
 msn.com##.sharingtb
 welt.de##.c-social-bar__sharing
-computerbild.de##.socialmedia
 koreanz.tv##a[onclick^="apms_sns"]
 filehorse.com##.share_with_friends
 sputnik.az##.l-wrap > div.l-sidebar > div.b-columnists~div[class="b-block b-tabs "]
-filmweb.pl##.fb-share-button
 show-online.tv##.over_share
 kg-portal.ru##.like_container
 kg-portal.ru###vk_like
@@ -4917,17 +4740,11 @@ pressekompass.net##.custom-share-button
 mp3-audio.download##img[onclick="shareOnFB();"]
 ||mp3-audio.download/img/share-button.jpg
 rojadirectaonlinetv.com,extremotvplay.com##.share-buttons-container
-aktuality.sk,aftonbladet.se,mangarock.com,broadwayworld.com##a[href^="https://twitter.com/intent/tweet?"]
-queer.pl,mangarock.com,broadwayworld.com##a[href^="https://www.facebook.com/sharer/sharer.php"]
 vulture.com##.follow-fb
 chinatimes.com##.new_social_icon
-chinatimes.com##.facebook-page-plugin
-live-nba.stream##.ssk-group
 novator.az##.sidebar-box > .widget_fbw_id
 espinof.com,xataka.com,xatakawindows.com##.article-social-share
 thenewslens.com##.social-btns > ul::before
-thenewslens.com##.social-btns > ul > li:not(.bookmark-btn)
-thenewslens.com##body .member-section .list-container .share-box
 ogsoundfx.com##div[id^="PopupSignupForm"]
 worldlifestyle.com##.fb-mb-share
 mobil.stern.de##.social-sharing-view-wrapper
@@ -4968,7 +4785,6 @@ lifehack.org,newsarama.com##.article-share-bar
 pcgramota.ru##.widget_vkapi
 finanznachrichten.de###footer_twitter
 finanznachrichten.de###artikel-optionen > div[id^="artikel_"]:not(#artikel_bewertung)
-minecraft-forum.net###share-buttons
 cmoney.tw##.fb-btn-out
 cmoney.tw##h3[grp="shareText"]
 cmoney.tw##h3[grp="shareText"] + p[style="text-align:center"] > img
@@ -4993,7 +4809,6 @@ gomel.today##aside.social
 grammarly.com##div[class*="share_panel-"]
 softobase.com###fb_root
 obozrevatel.com##div[class="share show"]
-png.is,nohat.cc,blogkurdu.net##.btn-twitter
 blogkurdu.net##.btn-stumbleupon
 blogkurdu.net##a.btn[onclick^="MyWindow=window.open"][onclick*="share"]
 autoexpress.co.uk##.sharerich-wrapper
@@ -5009,8 +4824,6 @@ duzcepusula.com,denizlidesiyaset.com,gazete365.com,haber1905.net,projemlak.com##
 gmx.net##.content > .topicWrapper.mobile
 muzikmp3indir.com##.sosyal-medya
 muzikmp3indir.com##.indirPaylas
-cracxsoftwares.com##.shareit
-8shit.net,cracxsoftwares.com##.addtoany_share_save_container
 joujizz.com##.share-this-static
 wattpad.com##.highlight-tooltip
 glosbe.com##.fb-stream
@@ -5053,7 +4866,6 @@ periscopeforweb.com##.follow_box
 mobigama.net###shr-header
 mobigama.net##.shr-buttons-wrap
 ternopoliany.te.ua##.itemSocialSharing
-hastac.org,a-o.ninja##.addtoany_list
 howwe.biz##.cf.share--song
 4game.com##.footer-4game__social-section
 latinomegahd.net,filmissimi.net##.rdsocial
@@ -5073,7 +4885,6 @@ today.com##.j-player-social-header
 vizefinalsorupaylasimi.com##.post-cont > div[style*="word-spacing"]:not([id]):not([class]) > center > iframe:not([src])
 100percentfedup.com##.wpdev-share-btns
 gazeta.zp.ua##.article__btns-container
-magesy.be##.ssba
 tipsmake.com,masfrandy.com,sarkisisozlerisozu.com,voipsipclient.blogspot.com,voipsipclient.blogspot.nl##.share-buttons-box
 kocaeligazetesi.com.tr##.block-fan
 10news.com##.layout--share__second
@@ -5102,7 +4913,6 @@ virusler.info.tr##.s-right > .colorbg-grey-social
 gentside.de###sharereceiver
 gentside.de###likeboxreceiver
 webrazzi.com##.mobile-sharing
-bold.dk##.facebook_top
 boredpanda.com##.post-shares-footer > .left > [class*="-share"]
 freesoft.ru###soc_right
 zi.dn.ua##.share_news_block
@@ -5117,7 +4927,6 @@ metabomb.net##.like-and-subscribe
 multiup.eu##a[href^="https://flattr.com"]
 ||html-online.com/like.html
 history.com##.player__info > .c022
-mcpedl.com,purposegames.com,pushsquare.com,purexbox.com,tothenew.com,jewishjournal.com,vg247.com,nintendolife.com,aetv.com,history.com##.share-this
 tothenew.com##.sharethis-text
 chefkoch.de##.recipe-share-btn
 ozon.ru##div[data-widget="sharingButton"]
@@ -5125,7 +4934,6 @@ chita.ru##.article__links-line__share
 bildderfrau.de##a[href^="fb-messenger:"]
 dinamalar.com,dcode.fr##img[alt="Share"]
 asianovel.com##blockquote.alert-warning > div.margin-top-20
-benimhocam.com,markapark.com##body .ProductDetail .product-social-icon-wrapper
 bershka.com##.product-social-container
 lakshmisri.com##.socialTab
 intouch.wunderweib.de##header.sticky > .brand + .metaNavi
@@ -5133,7 +4941,6 @@ forum.miuiturkiye.net##.sidebar > .WidgetFramework_WidgetRenderer_ShareThisPage
 incrussia.ru##.incshare
 defacto.com.tr##.dfShare
 m.brigitte.de##.social-sharing-view-wrapper
-broadwayworld.com,m.brigitte.de##.social-icon
 ozengen.com##.google-widget
 schweizer-illustrierte.ch##.floating_social
 wunderweib.de##.sharingList
@@ -5161,8 +4968,6 @@ foxsportsgo.com##.program-landing-section--share
 nbcsports.com##.IconTwitter
 nbcsports.com##.IconFacebook
 bleacherreport.com##.shareTwitter
-bleacherreport.com##.shareFacebook
-tvnz.co.nz##body .ShareButton
 puls4.com##.media-actions-list > li:not(:nth-child(3)):not(:nth-child(4))
 playnation.de##.e3_refresh_button
 gameofporn.net###fav + .sraz
@@ -5212,10 +5017,8 @@ doctor.ndtv.com##.soclIcnsRsd
 doctor.ndtv.com##.social-widget2
 ndtv.com##div[class^="photogallery_share"]
 diabetes-ratgeber.net##.socialMediaButtonBar
-autobild.de##.socialmedia
 autobild.de##.socialmediabox > .content
 thedenverchannel.com##.layout--share__second
-sabishiidesu.com##.share-box
 phys.org##.google-plus
 formatatmak.com##.theiaStickySidebar > .facebook-widget
 vg.no##.fixed-share-footer
@@ -5257,7 +5060,6 @@ youtube.com##a[href^="http://www.blogger.com/blog-this.g?"]
 youtube.com##.share-panel-services-container > div#share-services-container
 yirmidort.tv##.social > .facebook
 futbolingo.com##a[onlick^="GetUrl('http://twshot.com/share.aspx"]
-futbolingo.com##a[onclick^="GetUrl('http://www.facebook.com/sharer.php"]
 onygo.com###footer_nav > #social > ul > :not(.socialMediaIcons)
 b4bschwaben.de##.nfy-social-media
 123gomovies.info##.social_box
@@ -5341,11 +5143,8 @@ apnews.com##.fbShare.socialIcons
 apnews.com##.tweet.socialIcons
 ucuzabilet.com,programiz.com,viasatsport.se##.social-area
 boldsky.com,deccanchronicle.com##.cnfooter-share
-opinionstage.com##.os-social-bar > div.logo-area > div[class="box toggle-boxes i18n-dir"]
 opinionstage.com##div[data-short_label="Share"]
 oyunindir.club##.sidebar > #text-3
-miamiherald.com##.share-icons > .twitter
-miamiherald.com##.share-icons > .facebook
 wyff4.com##.article-social-branding > .js-share-container
 wyff4.com,wesh.com##.header-inner > .share-content > .share-content--stats
 wesh.com##.share-content--utils > .share-content--utils-action:not(.copy-link)
@@ -5381,7 +5180,6 @@ m.mynet.com##.detail-sticky[i-amphtml-fixedid]
 /pandalocker.$script,domain=lanka.ru
 stylight.de##.Trend-social > .btn
 oyunskor.com##[class="social scrollspy"]
-satcesc.com##.mh-share-buttons > [onclick^="window.open("]
 elcorreo.com,laverdad.es,diariosur.es##.voc-social-btn:not(.voc-bookmarks):not(.voc-more-share):not(.voc-mail-share)
 opportunitydesk.info,thedronegirl.com,mobilecellphonerepairing.com,eckovation.com,inmywordz.com,arquidiocesedeteresina.org.br,androidride.com,gbinsta.com,pajaslocas.com,thewincentral.com,btdunyasi.net,worldfree4ufilm.com,apkmb.com,androidtr.org,usapoliticstoday.com,crackingpatching.com##.widget_facebook_likebox
 infranken.de##.social-share-btn > .btn-list > li > .btn:not(.btn-mail)
@@ -5393,20 +5191,17 @@ m.fnp.de,m.ruesselsheimer-echo.de,m.kreisblatt.de,m.nnp.de,m.taunus-zeitung.de##
 haller-kreisblatt.de###modul-artikel-empfehlen > .headline
 haller-kreisblatt.de###modul-artikel-empfehlen > [class="clearfix"]
 haller-kreisblatt.de##footer > .article-detail-like
-egy.best##.sharer
 ||graph.facebook.com/?ids=*&fields=*share_count
 pelispedia.tv##.botones-soc
 m.volksstimme.de##ul.ph-sb > li.ph-sb-i:not([class="ph-sb-i"])
 bo.de##.share-inner-wrp > li:not(.print)
 duden.de##.contextual-links > a[href="#duden-share"]
 m.brigitte.de##.social-sharing-bottom
-onlinemschool.com##.share_buttons
 microsoft.com###social-bar
 shop.zweirad-stadler.de###social-header
 ||getsocial.io/widget/$third-party
 gscimbom.com###right-area > .follow-us
 platform24.org##.dvNewDetailShare
-sivridilli.com##a[onclick^="window.open('https://www.facebook.com/sharer/sharer.php"]
 akittv.com.tr##.pull-right > .social
 aa.com.tr##body #socialmobilicon
 soccer0010.com###shareBlock
@@ -5445,7 +5240,6 @@ m.ua,magazilla.ru,ek.ua##.soc-buttons-good
 ndtv.com##.article-share__item
 day.az##.like-holder
 promobil.de##div[element-article-sharing]
-thefreedictionary.com##.social-networks > li > a[title^="Share on"]
 computerbild.de##.teaserblock div.specialbutton
 ||cdn.rawgit.com/vaakash/socializer/$domain=my-free-mp3.net
 ||futbolcafetv1.org/like.html
@@ -5457,7 +5251,6 @@ expansion.com,marca.com##.colVideo > .redes
 my.kaspersky.com##.share-socBtns
 my.kaspersky.com##.share-or
 zapak.com##.inlineBlock.tweet
-vedomosti.ru##a[href^="http://telegram.me/share/url?"]
 apkmirror.com##.pushbullet-subscribe-widget
 passfab.ru,cooking.nytimes.com,kapook.com,myvideo.az##.share-group
 myvideo.az###fbShareButton
@@ -5468,7 +5261,6 @@ toptipstricks.net##.WidgetFramework_WidgetRenderer_ShareThisPage
 ultimate-catch.eu##.scsb_twitter
 ultimate-catch.eu##.scsb_facebook
 rtl.be##.w-content-details-sharing
-seriesgato.com##.fb-share
 globalreinsurance.com##a[title^="Share this on"]
 jinekoloji.com##.widget-social
 gidonline.in###socbg
@@ -5484,7 +5276,6 @@ ceptenmp3.net##.google + br
 ||kukudas.com/skin/board/JBoard/img/sns_*.png
 m.hurriyet.com.tr##a[data-share]
 postnauka.ru,handelszeitung.ch##.social-toolbar
-gamestar.de###socialshare
 xpgamesaves.com##.WidgetFramework_WidgetRenderer_ShareThisPage
 noizz.hu,noizz.de##.contentShareButtons
 noizz.hu,noizz.de##.floatingShareButtonContainer
@@ -5495,15 +5286,11 @@ dni.ru##.sotial
 autoblog.com###global-share-right
 luzernerzeitung.ch##.socialszwei > ul > li > a[href="javascript:"]
 luzernerzeitung.ch##.socialszwei > ul > li > [onclick^="fCMSToTwitter"]
-runnersworld.com##.sharebar.vertical > li:not(.comment):not(.print):not(.email)
 mashable.com##.article-shares-stub
-mashable.com##.article-shares-links
 m.azonline.de##.social_media_block
 enisey.tv###js-share-links
 latinohentai.com##.sbox
 colliderporn.com##.social-effect-smartlayers
-chroniclelive.co.uk##.sharebar > ul > .count-shares
-chroniclelive.co.uk##.sharebar > ul > .sharebar-provider
 chroniclelive.co.uk##.up-next--share
 chroniclelive.co.uk###social-follow
 thequestion.ru##.answer__share
@@ -5542,7 +5329,6 @@ azadinform.az##.left.social > noindex > .social-link
 lent.az##.col-xs-2 > a[href="#"] > .tw-inner-news
 radiotimes.com##.social-share-collection
 axar.az##.like-box
-mynet.az##.news_share
 goal.az##.social > .share
 az.bizimxeber.az###right-sidebar > aside[id^="text-"].widget
 britannica.com##.md-list-share
@@ -5555,15 +5341,12 @@ observalgerie.com##.td-ss-main-sidebar > .td_block_template_1.widget:first-child
 uol.com.br##.share > .share-item:not(.after)
 brifinq.com##.article-content > h3 + br + div[style*="width: 100%"]
 welt.de##.c-article-sharer__social-container > .c-article-sharer__icon-wrapper:not(.c-article-sharer__icon-wrapper--is-mailto):not(.c-article-sharer__icon-wrapper--is-print)
-mobil.stern.de##.social-icon-table > .social-icon:not(.social-icon-email)
 ekabu.ru,66.ru##.t-social-buttons
-thefreedictionary.com##.share-block
 a2zcrack.com##.tpcrn-shr-post
 zhidao.baidu.com,gratis.com##.share-area
 azpolitika.info##.lrshare_interfacehorizontal > lr > lrc > [class]:not(.lrshare_email):not(.lrshare_print)
 bilemezsin.com##a[href^="javascript:window.open('http://www.facebook.com/sharer.php"]
 ushilapychvost.ru##.m-item-post-sharing
-cnet.com##.sharebarContainer > .share-button:not(.emailWrapper):not(.comment-count-redesign)
 deskmodder.de##.handschriftzeile > .arteilen_ > .arteilen
 deskmodder.de##.handschriftzeile > .arteilen_ > .arteilen + .pfeil
 stereopoly.de###sidebar > #text-7
@@ -5583,9 +5366,7 @@ cepmuzik.blogspot.com##span[data-target="#share-menu"]
 tubidyac.blogspot.com##.post-footer-line > [class^="share"]
 tz.de##.id-Container-headline > a[href="//www.tz.de/messenger/"]
 tu.tv##ul.compartir
-desmoinesregister.com##.util-bar-module-share
 desmoinesregister.com##.asset-inline-share-tools-bottom
-desmoinesregister.com##.asset-inline-share-tools
 desmoinesregister.com##.story-taboola-related-module
 desmoinesregister.com##.site-nav-social-item
 start33.ru##.news_item__social
@@ -5624,14 +5405,9 @@ mixcloud.com##.social.facebook
 mixcloud.com##.social.pinterest
 berliner-zeitung.de##.dm_article_share
 nhk.or.jp##.social-btn-area
-fullstuff.co##.share-icons > div.entry-comment-count ~ a
-fullstuff.co##.sd-sharing
 spieletest.at##.navArrows > a[href^="javascript:window.open"]
 iz.ru##.share_bottom
 imgskull.com##.btn.red[data-target="modal-share"]
-cumhuriyet.com.tr##.share-this.tu
-aetv.com,fyi.tv,history.com##.share-facebook
-aetv.com,fyi.tv,history.com##.share-twitter
 viceland.com##.video-cta > .js-share
 ||it-like.ru/res/plugins/share42_mob/share42_mob.js
 fotomac.com.tr,aspor.com.tr,anews.com.tr,ahaber.com.tr##.pageTools > ul > li:not(.print):not(.send):not(.mail):not(.resizer):not(.comment)
@@ -5657,7 +5433,6 @@ barstoolsports.com##.iconWrap.facebook
 barstoolsports.com##.articleFooterSocial
 cod33.ru##.social-float
 cod33.ru,tjournal.ru,dtf.ru,vc.ru,rian.com.ua##.social_widgets
-ohmymag.de##body.omm .fshare
 ohmymag.de###likeboxreceiver
 pokemongopocket.com##.fb_like_and_share
 espn.com##.icon-facebook-messenger-solid-before
@@ -5691,23 +5466,18 @@ bemad.es,cuatro.com,divinity.es,eltiempohoy.es,energytv.es,factoriadeficcion.com
 movies07.co##.bw_sharetom
 chowhound.com##.fb_iframe_widget_w
 chowhound.com##.fr_pin_bubble
-javhole.com##.sosyal_buton
 donanimhaber.com##.twitterBTN
 prizyv.ru##.showing-shares
-kitguru.net##.widget_FacebookLikeBox
 shayhowe.com##.toc > .share
 tutsplus.com##.social-share-menu
 ria.ru##.b-sharebar
 softonic.cn,softonic.com,softonic.pl,softonic.nl##.app-list-share
-womenshealthmag.com##.sharebar
 softonic.cn,softonic.com,softonic.pl,softonic.nl##.list-share
 wired.com##.social-icons__list-item--facebook
 wired.com##.social-icons__list-item--twitter
 thegrammarexchange.infopop.cc##.h-share-icon
-sharecuts.cn,wtop.com,thegrammarexchange.infopop.cc,open.online,m.tecmundo.com.br,coffee.digital,redbull.com,coindesk.com,playbuzz.com,huffingtonpost.co.uk,huffingtonpost.com,m.huffpost.com,digital-photography-school.com,tomshardware.com,tomshardware.co.uk##.share-bar
 trickscrunch.com,tricksnation.com,themeslide.com##.mts-cl-overlap-box
 radugaskidok.ru##body > div.content-center[style="position:relative;height:40px;margin-top:10px;margin-bottom:30px;text-align: right;"]
-mediafire.com##.socialContainerWrap
 mobile2.bazonline.ch##.NnSocialMediaContainer
 mobile2.derbund.ch##.NnSocialMediaContainer
 motorsportmanager.com###block-footer-footer-social
@@ -5715,7 +5485,6 @@ livetracklist.com##.onclick-menu.share
 sport1.de##.s1-module-share
 www-sport1-de.cdn.ampproject.org##.s1-module-share
 computerbild.de##.socialIntro
-computerbild.de##.socialmediabar > .content > [class]:not(.mail)
 9monate.de##html.touch .socialbar
 otz.de,thueringer-allgemeine.de,tlz.de##.qp_console_top
 otz.de,thueringer-allgemeine.de,tlz.de##.qp_console_bottom
@@ -5730,7 +5499,6 @@ pcgamer.com##.socialite-widget
 bilan.ch##section.like_block
 shz.de###whatsapp ~ #actions-fwid3
 shz.de##.socialbadge
-m.focus.de###socialbar
 focus.de###article-social > li.tw
 post-gazette.com##.pgevoke-story-socialbuttons > [class^="pgevoke-story-socialbuttons-"]:not(.pgevoke-story-socialbuttons-print):not(.pgevoke-story-socialbuttons-email)
 onlinefanatic.com##.sidebar > #text-17.widget
@@ -5739,7 +5507,6 @@ mic.com##.article-page-share-buttons
 mic.com##.social-actions__button--twitter
 evrensel.net##.fa-pinterest
 juraforum.de##.social-media-bar-fixed
-juraforum.de##.social-media-bar > ul > .social-media-bar-icon:not(.social-media-bar-bewertung):not(.social-media-bar-icon-email)
 clashofclans.com##.BlogDetail-Footer-share > li
 erdbeerlounge.de##.socials-block > [class^="fa-btn-"]:not(.fa-btn-add-comment)
 sitepoint.com##article-sharer
@@ -5752,7 +5519,6 @@ vpnmentor.com##a[id^="sl_share_"]
 cbsnews.com##.right-headline > .box.twitter
 cbsnews.com##.right-headline > .box.facebook
 cbsnews.com##.right-headline > .box.email
-lifewire.com##.pinit-btn
 clashofclansforum.de##.fbLikeCounter
 circa.com##.ShareBar-shareItems > [class^="ShareLink"]:not([data-service="mailto"])
 computerworld.com.au##.art-share > li:not(.print_li):not(.email_li)
@@ -5781,12 +5547,9 @@ europaplus.ru##.footer-social-widgets
 blick.ch##.standingShareBar
 washingtonpost.com##.inline-sharebar
 amp-vox-de.cdn.ampproject.org##.rtli-master-social-share
-gizmodo-com.cdn.ampproject.org##.sharingfooter
 kinomassa.biz###vk_group_kinomassa
 amp.welt.de##.c-social
-dobreprogramy.pl,amp.focus.de,ampproject.org##amp-social-share
 fnp.de,www-op--online-de.cdn.ampproject.org,www-tz-de.cdn.ampproject.org,www-merkur-de.cdn.ampproject.org##.id-Amp-socialShare
-cyberscoop.com##a[href^="https://www.addtoany.com/add_to/"]
 ipleer.fm##.onesongblock-end > i
 porn-monkey.com###fb_video_link
 simpladent.com,hotstar.com,trthaber.com,stereogum.com##.social-holder
@@ -5818,7 +5581,6 @@ esport.aftonbladet.se##.ab-esport-social-share
 esport.aftonbladet.se##.fbLikeBox
 sport.de##.fblikebox
 tf1.fr##.block_socialshare
-autostrada-a2.pl,1prime.ru##.facebook-like-box
 motorpage.ru##.float-right.text-center > a[class$="-share"]
 dunyatv.az##a[href="http://dunyatv.az/esrin-sedasi/"] > .bloktitle:first-child
 pz-news.de##.nfy-sebox-facebook-like
@@ -5841,7 +5603,6 @@ comicbook.com##.social_blk
 narcity.com##body > [class$="-sharer"][id$="-sharer"]
 ucarliyiq.biz##.ui-widget
 ucarliyiq.biz##.widgets-holder > aside[id="zn_text_widget-4"]
-dinamani.com##.Share_Icons
 sonxeber.az##.fbbigshare
 oncunatural.com##.theblogwidgets
 oncunatural.com###fbox-background
@@ -5856,13 +5617,11 @@ mobil.berliner-zeitung.de##aside.recommend-article
 mobil.berliner-zeitung.de##.mfb-component--br
 mirror.co.uk###social-follow
 avtovod.org.ua###fblike
-spiegel.de##.social-bar-wrapper
 m.photos.timesofindia.com##.fblikebtn
 mopo.de##.article-text > .recommend-article
 wetterauer-zeitung.de##ul[data-fcms-method="socialShare"]
 stuttgarter-nachrichten.de##.m-shares
 mobile2.tagesanzeiger.ch##.socialMedia
-pcmag.com###share_container
 rhein-zeitung.de##div.servicebox.html_content[id^="sebox_"]
 cmo.com##.getsocial
 ofigenno.com##.image-rollover-wrap
@@ -5881,7 +5640,6 @@ tchgdns.de##.sharebar-mobile
 trustedreviews.com##.total-share-count
 gentside.com##.fshare+div.counter
 buzzfeed.com##.action-bar--position-floating
-mittelbayerische.de,caseking.de##.share-whatsapp
 esslinger-zeitung.de##.nfy-social-icons
 rufilmtv.org##.social_rufilm
 downace.com##a.uk-button[href="#share_urls"]
@@ -5915,15 +5673,11 @@ novyny.online.ua##.o-btn--share
 novyny.online.ua##.c-sharefixed
 wiesbadener-kurier.de###rightbar > #nativendo-oms-sidebar + .box
 theinvestor.co.kr##a[href^="javascript:snsShare"]
-rbc.ua##div[class^="social-likes-"]
 porneq.com##.share-body
-thesslstore.com##.ampforwp-social-icons
 denizcilikbilgileri.com,metalinjection.net,koinmedya.com,politeka.net,metalinjection.net,unwetteralarm.com,thesslstore.com##.sticky_social
-mobiflip.de##a[onclick^="window.open('https://plus.google.com/share?url="]
 skysports.com##.social-list
 mactechnews.de##.SynFacebookLike
 mactechnews.de##.SynTwitterShare
-menshealth.com##.sharebar > li:not(.email):not(.subscribe)
 radiolino.ch,nebelspalter.ch,news.ch,wetter.ch##.skin_51_fb
 radiolino.ch,nebelspalter.ch,news.ch,wetter.ch##.skin_51_speech
 brigitte.de##.m-sharing-toolbar-vertical
@@ -5945,17 +5699,14 @@ ibb.co###tabbed-content-group .panel-networks
 ibb.co##.header-content-right > a.btn[data-target="modal-share"]
 developer.samsung.com##a[id^="rs_send_"]
 garten.de##h2.pane-title:first-of-type
-sat1.de##.social-wrapper
 androidcentral.com,crackberry.com,imore.com,teslacentral.com,vrheads.com,windowscentral.com##.mn_mbn_share
 donanimhaber.com##.lnk-paylas.google
 metanit.com,gorod48.ru##.socialBlock
-knowyourmeme.com###ctoolbar
 antalyaburada.com###twitterfllowBoxSmall
 antalyaburada.com##.facebookLikeBoxSmall
 paperpaper.ru##.r-likes-wrapper
 uip.me##.post-share > div.show
 gamesofdesire.com###addthis_sharing_toolbox
-mobil.ksta.de##.social_btn
 znaj.ua##.field-name-addtoany
 connect-trojan.net###floating-fblog
 gismeteo.ua,gismeteo.by,gismeteo.kz,gismeteo.pl,gismeteo.com,gismeteo.lt,gismeteo.ru##.article__ctrls
@@ -5977,11 +5728,9 @@ ajans23.com##img[alt="facebook-paylas"]
 line.do##timeline-moment-share
 line.do##share-button
 line.do##share-count
-cmo.com##.getsocial
 techadvisor.com,pcworld.pl,macworld.co.uk,tvn24.pl,techadvisor.co.uk,pcadvisor.co.uk##.shareContainer
 gooool.org##.socialb
 goster.co##body .detay .paylasim.sabit
-sabah.com.tr##.pageTools > ul > .pin
 racurs.ua##.tell_friends
 lostfilm.tv##a.header[href="//vk.com/lostfilmtv_official"]
 hedefhalk.com,pes24.com,esenyurthaberleri.com##div[class^="fix-share-"]
@@ -6010,7 +5759,6 @@ novayagazeta.ru##._3gtsx._1ysoK
 khan.co.kr,nevnov.ru##.share_wrap
 politico.com##.story-share
 yapx.ru##.photoblock-footer-social
-track24.ru##.b-share
 software.informer.com##.wrapper_like
 robtex.com##.soctop
 stranamam.ru##.vkfb
@@ -6022,7 +5770,6 @@ realnoevremya.ru##.colorShareBtn
 realnoevremya.ru##.grayShareBtn
 sueddeutsche.de###article-sidebar-action-facebook
 cosmo.ru##.sharing-div
-spielesite.com##.social-sharing-buttons
 ||spielesite.com/*/share/?ref
 symantec.com##[data-share-config="controller.shareConfig"]
 symantec.com##.action-links
@@ -6031,21 +5778,17 @@ haber2000.com##.sosyal2
 newizv.ru##.share-popups-component
 angrycitizen.ru##.socials-block
 mirror.co.uk##.mod-socialFollow
-mirror.co.uk##.sharebar
 eonline.com##.cs-share
 outlookindia.com##iframe[src="http://www.outlookindia.com/dialog_slides/facebook.php"]
-outlookindia.com##.addthis_button
 mockupworld.co##.checkout-share
 revolvy.com###quiz_share_btns
 revolvy.com###fb_like_pop
 fiat.com.tr##.NoJSSMContainer
-infowars.com##.cresta-share-icon
 fun01.net###win_like_mask
 fun01.net###win_like
 boredpanda.com##.fb-custom-share-mobile
 paratic.com###paraticPostShareButtons
 brax.com,metro.us##.social-share-icons
-xda-developers-forum.blogspot.com##.post-share-buttons
 unvan.az##.fbsmallshare
 turkcell.com.tr##.hero-social
 putlockertv.is##.menu-box > h2:first-of-type
@@ -6226,7 +5969,6 @@ dailylocal.com,delcotimes.com###shareBarWrapper
 apkmirror.com###shareDropdown
 allrecipes.com###shareRecipe
 emarketer.com###shareTxt
-extremetech.com###share_container
 itbox.ua###share_data
 utsports.com###sharebar-wrapper
 down.mdiaload.com,down.fast-down.com,userupload.net,file-upload.com,arabloads.net,file-upload.cc###sharebuttons
@@ -6239,7 +5981,6 @@ muzofon.com###simplemodal-overlay
 focus.de###singlepostSlideInBoxHoch
 digitaltrends.com###sitewide-social
 er.ru###smBlock
-bludv.com###smthemes_share
 megogo.net###snashareLink
 politeka.net###soc-no-header
 ictv.ua###soc_main
@@ -6340,7 +6081,6 @@ idiva.com##.art-social-bar
 newsweek.com##.article--share
 forbes.com##.article-fbs-sharing
 unian.info##.article-selection-shares
-businessinsider.com.pl,fakt.pl,politeka.net,e24.no,indiatimes.com##.article-share
 computerra.ru##.article-soc
 bunshun.jp,sarnovosti.ru,espn.com,newrepublic.com,espncricinfo.com,thedrive.com,viva.ua,youranshare.com,4mama.ua,espn.co.uk,gs.by,mynbc5.com,livedoor.com##.article-social
 tvguide.com##.article-social-section
@@ -6351,7 +6091,6 @@ thenextweb.com##.articleShare-buttons
 dnepr24.com.ua##.article__btns-container
 progorod59.ru##.article__likes-title
 sportsfan.com.au##.article__socialButtons
-therichest.com##.article_share
 ultimate-guitar.com##.article_vote
 chip.com.tr##.as-takip
 focus.ua##.at4-jumboshare
@@ -6387,7 +6126,6 @@ economist.com##.block-ec_social
 icaravan.com.ua##.blockOverlay
 icaravan.com.ua##.blockUI
 microsoft.com##.blog-post-info-bar-share
-travelask.ru##.blog-share-toolbar
 thehill.com##.blogs-social-wrp
 belaruspartisan.by,ramlife.ru##.bookmarks
 m.9gag.com##.bottom-sheet > ul.menu-list > li > a[class="icon"]:not([href])
@@ -6402,7 +6140,6 @@ pugetsystems.com##.btn-social-icon
 si.com##.btn-tw
 bobiler.org##.btnShareFacebook
 filmindirturkcedublaj.com##.butink2 + div[align="center"]
-parasut.com,mailonsunday.co.uk,thisismoney.co.uk,dailymail.co.uk##.button-share-facebook
 valetudo.ru##.buttons > .allbuts > a[rel="nofollow"]
 valetudo.ru##.buttons > .butspre
 katushka.net##.buttons_block
@@ -6622,8 +6359,6 @@ hurriyet.com.tr##.nShare
 mafia-daily.net,mydivision.net##.naked-social-share
 thenational.ae##.nationalsocialshare a[onclick^="popUpWindow"]
 cnnturk.com##.navbar-social > li:not([class="search"])
-thesun.co.uk##.naytev-share-toolbar
-cydiageeks.com,hackintosh.computer##.nc_socialPanel
 filehorse.com##.networking
 bigpara.hurriyet.com.tr##.newSocialBar
 investing.com##.newSocialButtons
@@ -6669,20 +6404,16 @@ lookatme.ru##.post-additions > .hype
 coco01.net,cocomy.net##.post-bottom
 fishki.net,timeallnews.ru##.post-face
 distractify.com##.post-header_sharing-counter
-downphanmem.com,thenextweb.com##.post-share
 engadget.com##.post-share-count
 vviruslove.com,mahluklar.org,yeniulke.net##.post-sharing-bd
 filmihemenizle.com##.post-sharrre
 thedroidguy.com##.post-soc-count
-meleke.com##.post-social-goog
-meleke.com##.post-social-pin
 pravda.com.ua##.post__social-container
 travelask.ru##.post_shares
 chip.com.tr,forum.xda-developers.com##.postbit-social
 sokol.ua##.pp-social-block
 lidyana.com##.product-share-v3
 bizde.com##.product-social-area
-dermokozmetik.com,avva.com.tr##.product-social-icon-wrapper
 walmart.com##.product-social-media
 planeta.ru##.project-activity-twitter
 gamingbolt.com,gqmagazine.fr##.pw-widget
@@ -6719,7 +6450,6 @@ dailysabah.com##.shB > a[onclick*="Share"]
 gamespot.com##.share--column
 nashe.ru##.share-b
 huffingtonpost.com##.share-bar-highlight
-piratecity.net##.share-before
 haberself.com##.share-box-new
 voicetv.co.th##.share-button-group
 ajanskarabuk.com,sanattanyansimalar.com,duzcepusula.com,denizlidesiyaset.com,malatyadan.com,habermarmara.com.tr,larende.com,karamandauyanis.com,iskilipinsesi.com,ankaraport.net##.share-buttons-2
@@ -6739,11 +6469,8 @@ vulture.com##.share-mini
 grammarly.com##.share-more-wrap
 css-tricks.com##.share-on-link
 css-tricks.com##.share-on-title
-dailymail.co.uk##.share-pictures-overlay
 yenisafak.com##.share-single
 pornhub.org,pornhub.com##.share-sites-thumbs
-prestigewebagency.com,indianexpress.com,procreate.art,cielotv.it,wday.ru##.share-social
-mylifetime.com##.share-this > *
 mabidiary.blogspot.com,juejin.cn,crystal-lang.org,aksam.com.tr,ramsaydiagnostics.ru,ottawamatters.com,hurriyet.com.tr##.share-title
 enkiverywell.com,ilsole24ore.com,paginasiete.bo,fanatik.com.tr,posta.com.tr##.share-tool
 nesine.com##.share-video
@@ -6756,7 +6483,6 @@ ng.ru##.shareFix
 ahaber.com.tr##.shareFrame
 osomatsusan.com,sabah.com.tr##.shareList
 pravoved.ru##.shareMoreLink
-rambler.ru##.share__list
 cc.com##.share_cta
 medyatava.com,medyatava.net##.share_icons
 segodnya.ua##.share_icons_big
@@ -6768,10 +6494,8 @@ konkurent.ua##.ico_share
 izlesene.com##.share_vid
 scribd.com,answers.com##.share_wrapper
 cbsnews.com##.sharebar_expanded
-9ketsuki.info,dronedj.com,sadeemapk.com##.sharedaddy
 shopper.life##.sharefull
 sozcu.com.tr##.shareplatform
-aspor.com.tr,ign.com##.sharer
 robbreport.com##.sharethis-buttons
 ndtv.com##.sharetool
 fotovramku.ru##.sharevertical
@@ -6779,7 +6503,6 @@ screenrant.com,therichest.com##.sharing-option
 indiatimes.com##.sharingBox
 therichest.com##.sharingOptions
 giga.de##.sharing_container
-msn.com##.sharingtb
 aksam.com.tr##.sharingwrap
 forum.xda-developers.com##.showthread-social
 stories.bsh-group.com,design-homes.ru,tgcom24.mediaset.it,kamuajans.com,internethaber.com,memurhaber.com##.shr
@@ -6817,7 +6540,6 @@ sobesednik.ru##.social-block-tabs-wrapper
 wday.ru##.social-blocks
 portableapps.com##.social-bottons
 66.ru##.social-button:not(.social-button_blablanator)
-rockpapershotgun.com##.social-buttons
 sovsport.ru##.social-buttons_right-sticky
 onedio.com,onedio.ru##.social-controls
 forbes.com##.social-expand-control
@@ -6834,7 +6556,6 @@ beautyhack.ru,rlsnet.ru,culture.pl,transfermarkt.de,pclab.pl,yeniakit.com.tr,cal
 sovsport.ru##.social-list
 idnes.cz##.social-list-bubble
 imhonet.ru##.social-net
-radiohamburg.de##.social-networks
 playground.ru##.social-plugins-widget
 klerk.ru##.social-popup
 klerk.ru##.social-popup-backdrop
@@ -6846,7 +6567,6 @@ deadline.com##.social-strip
 domik.ua##.social-subscribe-banner
 thestack.com##.social-warfare-container
 tvigle.ru##.social-wide
-kabeleins.de,prosieben.de,sixx.de##.social-wrapper
 dunyavegercekler.com##.social-wrapper > :not([class="font-size"])
 podrobnosti.ua##.social.hide-for-mobile
 pcmag.com##.social300
@@ -6876,7 +6596,6 @@ m.bianet.org,tabnak.ir,hindustantimes.com##.social_icons
 ain.ua,ua.today##.social_like
 jpcert.or.jp,jin115.com,m.timesofindia.com##.social_links
 m.wn.de##.social_media_block
-pcwelt.de##.social_media_buttons
 defendingrussia.ru##.social_popup
 usp-forum.de,win-10-forum.de##.social_share_bar
 resellerratings.com##.social_share_box_wrapper
@@ -6888,7 +6607,6 @@ m.timesofindia.com##.socialcont
 wn.de##.socialmedia_article_linkbox
 unyoo.jp,archive.vanityfair.com,tubefilter.com,101.ru,glavcom.ua,javhdx.tv##.socials
 igate.com.ua,kommersant.ru##.socials-link
-familyhandyman.com##.socialshare
 f1comp.ru##.socikonki
 forbes.ru##.socnet_left_float
 forbes.ru##.socnet_shares_cont
@@ -6897,10 +6615,8 @@ genius.com##.song_header-share_buttons
 cosmopolitanturkiye.com,islahhaber.net##.sosyal
 anadolugazetesi.net##.sosyal > a[onclick][href]
 buguzelsozler.net##.sosyal-yan
-dizibilgi.net,dizibilgi.tv,esekadam.com,kadinextra.com,sempatiklopedi.com##.sosyal_buton
 dha.com.tr##.sosyalmedya
 haberdex.com##.sosyaltakip.spaylas
-firetv-blog.de##.sparkling-social
 fetishshrine.com##.spot-bottom
 ms-devices.com,sharij.net,watchcartoonsonline.eu##.spu-bg
 ms-devices.com,sharij.net,watchcartoonsonline.eu##.spu-box
@@ -6919,7 +6635,6 @@ amazon.com##.swf-sn-share-link
 anlasevgimi.com,ghacks.net##.synved-social-button
 sz-online.de##.szoSocialMediaShare
 мвд.рф##.table-links-layout
-usapoliticstoday.com,k2nblog.com##.td-post-sharing
 rosregistr.ru##.td-social-sharing
 getandroidstuff.com##.td-tags-and-social-wrapper-box
 s4galaxy.ru,tehnot.com##.td_block_social_counter
@@ -6929,7 +6644,6 @@ tarzgo.com,warezturkey.org##.theblogwidgets
 theinquirer.net##.tools-container
 v3.co.uk##.tools-container > li > div.article-tools
 echo.msk.ru##.tooltipster-default
-indiatimes.com##.top-share
 indiatimes.com##.top-share ~ a:nth-child(-n+4)
 southwalesargus.co.uk##.top-sharing
 gundemkibris.com##.top_social
@@ -6960,7 +6674,6 @@ olx.ua##.user-share
 censor.net.ua##.user_activity_like_block
 usatoday.com##.util-bar-btn-share
 usatoday.com##.util-bar-btn-twitter
-usatoday.com##.util-bar-module-share
 wsj.com##.vcrSocial
 weather.com##.ve-player_share-links
 vice.com##.vertical-share-widget
@@ -7020,7 +6733,6 @@ therussiantimes.com##a[href="#fb_widget"]
 otomobil.com.tr##a[href="https://www.facebook.com/otomobilyayincilik"]
 lostfilm.tv##a[href^="//twitter.com/home?status"]
 ~twitter.com##a[href^="//twitter.com/share"]
-~ok.ru##a[href^="//www.odnoklassniki.ru/dk?st.cmd=addShare"]
 sport.ua##a[href^="http://shareit.meta.ua/"]
 medimagazin.com.tr##a[href^="javascript:medipop"]
 tweak.dk##a[href^="javascript:newwindow"] > img
@@ -7043,9 +6755,7 @@ fcore.eu##a[onclick^="share_twitter"]
 nationalreview.com##a[onclick^="sharer"][href="javascript:void(0);"]
 4players.de##a[onclick^="socialShares"]
 lostfilm.tv##a[onclick^="window.open('//connect.mail.ru/share"]
-lostfilm.tv##a[onclick^="window.open('//www.facebook.com/sharer.php"]
 lostfilm.tv,softbuild.ru##a[onclick^="window.open('http://connect.mail.ru/share"]
-softbuild.ru##a[onclick^="window.open('http://vkontakte.ru/share.php"]
 softbuild.ru##a[onclick^="window.open('http://www.liveinternet.ru/journal_post.php"]
 softbuild.ru##a[onclick^="window.open('http://www.livejournal.com/update.bml"]
 sabah.com.tr##a[onclick^="window.open('https://pinterest.com"]
@@ -7078,7 +6788,6 @@ turksinemasi.com##div[class$="bslkzmn2 h300"]
 elitedaily.com##div[class*="article-shar"]
 samara24.ru##div[class*="share-button"]
 myscienceacademy.org##div[class*="sticky-social"]
-tune.com##div[class*="us_share_buttons"]
 temperatur.nu##div[class^="FB-share"]
 yahoo.com##div[class^="article-aft-share-buttons-"]
 focus.ua##div[class^="at-share"]
@@ -7094,7 +6803,6 @@ alkislarlayasiyorum.com##div[class^="socialBtn"]
 mobiltelefon.ru##div[class^="social_like_btns"]
 ndtv.com##div[class^="st_sharebar"]
 handelsblatt.com##div[class^="vhb-share-social"]
-msn.com##div[data-aop="sharingtoolbar_social"]
 kabeleins.de,prosieben.de,sat1.de,sixx.de##div[data-position="share_video_bottom"]
 uol.com.br##div[data-share-buttons]
 thechive.com##div[data-sumome-share]
@@ -7262,7 +6970,6 @@ m.edaily.co.kr##.social-login
 m.g-enews.com##.v_btns_rt
 nta.co.jp,topgate.co.jp,m.gobalnews.com##.sns-list
 m.joseilbo.com##.sns_icon_set
-m.kmib.co.kr##.article_sns
 m.newspim.com##.snslink
 m.ohmynews.com##.app_move_box
 m.pann.nate.com##.social_area
@@ -7345,7 +7052,6 @@ disk.yandex.az,disk.yandex.by,disk.yandex.co.il,disk.yandex.com,disk.yandex.com.
 ! Yandex.Zen
 zen.yandex.by,zen.yandex.com,zen.yandex.kz,zen.yandex.ru,zen.yandex.ua##.article-footer__share-link
 zen.yandex.by,zen.yandex.com,zen.yandex.kz,zen.yandex.ru,zen.yandex.ua##.article-left-block__share-button
-zen.yandex.by,zen.yandex.com,zen.yandex.kz,zen.yandex.ru,zen.yandex.ua##.share-button
 zen.yandex.by,zen.yandex.com,zen.yandex.kz,zen.yandex.ru,zen.yandex.ua##.share-left-block__more
 !
 ! Yandex.Translate
@@ -7355,7 +7061,6 @@ translate.yandex.ru,translate.yandex.ua,translate.yandex.by,translate.yandex.com
 forms.yandex.ru##.quiz-result__share
 !
 ! Yandex.Balaboba
-yandex.ru##.response__share > div.share-icons
 ! END: Yandex
 !
 !
@@ -7376,7 +7081,6 @@ news18.com##div[class*="Footer_newftrshare_"]
 !+ PLATFORM(ios, ext_android_cb, android)
 duniaku.idntimes.com###share-panel
 !+ PLATFORM(ext_ff)
-neowin.net##.article-share
 !+ NOT_OPTIMIZED
 m.sabah.com.tr##.social-fixed
 !+ PLATFORM(ios, ext_android_cb)
@@ -7392,7 +7096,6 @@ meduza.io###DailySubscriber
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 fishki.net##.big-share
 !+ PLATFORM(ios, ext_android_cb)
-setfilmizle.pro##.dt_social_single
 !+ NOT_OPTIMIZED
 medyaloji.net,a24.com.tr##.share_3lu
 !+ NOT_OPTIMIZED
@@ -7401,36 +7104,17 @@ m.gunes.com##.fixed-interaction-bar
 thecode.media##.post-social-links
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 luzernerzeitung.ch##.social > li
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-bludvfilmes.com###smthemes_share
-!+ NOT_PLATFORM(windows,mac,android)
-kinopoisk.ru##.block_social
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-bikeradar.com##.share-buttons
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-seriesgato.net##.fb-share
-!+ PLATFORM(ios, ext_android_cb, ext_safari, mac)
-forbes.com##.social-icon
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-gametimers.it,techmoviles.com,blogthetech.com,gamesandroidhvga.net,gamesandroidhvga.net##.td-post-sharing
 !+ NOT_PLATFORM(windows,mac,android)
 gazeta.ru##.article-share-name
 !+ NOT_PLATFORM(windows,mac,android)
 kakprosto.ru##.content__share
 !+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-gohub.pw##.share-post
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-business-tv.org##.shareit
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
 dir50.com###sharebuttons
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_ublock)
-thetalko.com##.btn-facebook-like
 !+ PLATFORM(ios, android, ext_android_cb)
 barmer.de##.sidebar > .siteactions
 !+ PLATFORM(ios, ext_android_cb)
 bildderfrau.de##.article--sticky
 !+ PLATFORM(ios, android, ext_android_cb)
-9to5google.com,9to5mac.com,9to5toys.com,dronedj.com,electrek.co##.sharedaddy
 ! Not visible on desktop - so should be NOT_OPTIMIZED
 !+ NOT_OPTIMIZED
 betanews.com##.social-links-wrap


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

As a result of #107129, I figured it'd be a good idea to pre-emptively fix social media buttons before people report them. So I took some generic hiding rules from https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SocialShareList.txt with minor adjustments, and am submitting them here.

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/22780683/149937875-6a819ed9-2947-4b4e-843c-c3b2b2e3e266.png)
</details><br/>

* **Expected behaviour**: 

End-users don't see as much need to report social media buttons, because they're hopefully fixed already.

<details><summary>Screenshot:</summary>

N/A
</details><br/>

***Steps to reproduce the problem***:

1) Open https://github.com/AdguardTeam/AdguardFilters/issues?q=is%3Aissue+is%3Aopen+label%3A%22T%3A+Social+Widget%22

***System configuration***

**Filters:**

N/A, as the issue report is exclusively for AdGuard Social Media Filter.

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 11 x64
Operating system version (Android/iOS) | N/A
Browser:                               | Chrome 97.0.4692.71 x64
AdGuard version:                       | uBO 1.40.9b1 + IDCAC 3.3.5
Filters enabled:                       | N/A
AdGuard mode (Android only):           | N/A
Filtering quality (Android only):      | High-quality
HTTPS filtering (Android only):        | On
Simplified filters (iOS only)          | Off
AdGuard DNS:                           | None
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
