### PR TITLE
Drop helpscout rule, fixes #107957

### DIFF
--- a/AnnoyancesFilter/sections/widgets.txt
+++ b/AnnoyancesFilter/sections/widgets.txt
@@ -232,7 +232,6 @@ sks-auto.ru##.fw-container__step__form__design-btn__body
 ||callkeeper.ru^$third-party
 liquidweb.com##footer + div[class^="FixedButton_"]
 aimersoft.com###aimersoft-chat-robot
-||helpscout.net^$third-party
 ||widget-v*.tidiochat.com^$third-party
 ||salesiq.zoho.in^$third-party
 ||widget.getgist.com^$third-party


### PR DESCRIPTION
Not a "useless widget" in any sense of the phrase, it's a legitimate bona fide support contact form and/or support chat widget. Not a feedback/ratings tool, not an "assistant". Possibly the only support contact method that some websites have.

See #107957 for template