### PR TITLE
fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,23 @@ body:
       placeholder: ex. https://example.com/
     validations:
       required: true
+
+  - type: dropdown
+    id: what-happened
+    attributes:
+      label: What type of problem have you encountered?
+      description: If the problem does not fall under any category that is listed here, please contact our tech support - support@adguard.com
+      multiple: true
+      options:
+        - Missed ads or ad leftovers
+        - Website or app doesn't work properly
+        - AdGuard gets detected on a website
+        - Social media buttons — share, like, tweet, etc.
+        - Annoyances — pop-ups, cookie warnings, etc.
+        - Missed analytics or tracker
+        - Dangerous site
+    validations:
+      required: true
       
   - type: checkboxes
     attributes:
@@ -53,23 +70,6 @@ body:
       label: AdGuard version
       description: What version of our software are you running?
       placeholder: for example, 7.7.2, 2.6.1.1060 nightly, 3.6.14 beta
-    validations:
-      required: true
-
-  - type: dropdown
-    id: what-happened
-    attributes:
-      label: What type of problem have you encountered?
-      description: If the problem does not fall under any category that is listed here, please contact our tech support - support@adguard.com
-      multiple: true
-      options:
-        - Missed ads or ad leftovers
-        - Website or app doesn't work properly
-        - AdGuard gets detected on a website
-        - Social media buttons — share, like, tweet, etc.
-        - Annoyances — pop-ups, cookie warnings, etc.
-        - Missed analytics or tracker
-        - Dangerous site
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,15 @@ description: Report an issue with filters
 labels: ["Unsorted"]
 # labels: ["A: Bug", "A: By Design", "A: Cannot reproduce", "A: Closed", "A: In progress", "A: Invalid", "A: Problematic", "A: Rejected", "A: Resolved", "A: Won't fix", "Extra", "Extra (zmc)", "Infrastructure", "N: AdGuard Browser Extension", "N: AdGuard Content Blocker", "N: AdGuard DNS", "N: AdGuard for Android", "N: AdGuard for iOS", "N: AdGuard for Mac", "N: AdGuard for Safari", "N: AdGuard for Windows", "N: Other", "NSFW", "P1: Critical", "P2: High", "P3: Medium", "P4: Low", "T: Ads", "T: Annoyance", "T: Anti Adblock Script", "T: Incorrect Blocking", "T: Popups", "T: Social Widget", "T: Stealth Mode issue", "T: Tracker"]
 body:
+  - type: input
+    id: url
+    attributes:
+      label: Where is the problem encountered?
+      description: Enter the web address or affected application link.
+      placeholder: ex. https://example.com/
+    validations:
+      required: true
+      
   - type: checkboxes
     attributes:
       label: Prerequisites
@@ -89,15 +98,6 @@ body:
       options:
         - Desktop
         - Mobile
-    validations:
-      required: true
-
-  - type: input
-    id: url
-    attributes:
-      label: Where is the problem encountered?
-      description: Enter the web address or affected application link.
-      placeholder: ex. https://example.com/
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report_NSFW.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_NSFW.yml
@@ -3,6 +3,15 @@ description: Report an issue with filters (NSFW)
 labels: ["Unsorted", "NSFW"]
 # labels: ["A: Bug", "A: By Design", "A: Cannot reproduce", "A: Closed", "A: In progress", "A: Invalid", "A: Problematic", "A: Rejected", "A: Resolved", "A: Won't fix", "Extra", "Extra (zmc)", "Infrastructure", "N: AdGuard Browser Extension", "N: AdGuard Content Blocker", "N: AdGuard DNS", "N: AdGuard for Android", "N: AdGuard for iOS", "N: AdGuard for Mac", "N: AdGuard for Safari", "N: AdGuard for Windows", "N: Other", "NSFW", "P1: Critical", "P2: High", "P3: Medium", "P4: Low", "T: Ads", "T: Annoyance", "T: Anti Adblock Script", "T: Incorrect Blocking", "T: Popups", "T: Social Widget", "T: Stealth Mode issue", "T: Tracker"]
 body:
+  - type: input
+    id: url
+    attributes:
+      label: Where is the problem encountered?
+      description: Enter the web address or affected application link.
+      placeholder: ex. https://example.com/
+    validations:
+      required: true
+      
   - type: checkboxes
     attributes:
       label: Prerequisites
@@ -87,15 +96,6 @@ body:
       options:
         - Desktop
         - Mobile
-    validations:
-      required: true
-
-  - type: input
-    id: url
-    attributes:
-      label: Where is the problem encountered?
-      description: Enter the web address or affected application link.
-      placeholder: ex. https://example.com/
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report_NSFW.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_NSFW.yml
@@ -11,6 +11,23 @@ body:
       placeholder: ex. https://example.com/
     validations:
       required: true
+
+  - type: dropdown
+    id: what-happened
+    attributes:
+      label: What type of problem have you encountered?
+      description: If the problem does not fall under any category that is listed here, please contact our tech support - support@adguard.com
+      multiple: true
+      options:
+        - Missed ads or ad leftovers
+        - Website or app doesn't work properly
+        - AdGuard gets detected on a website
+        - Social media buttons — share, like, tweet, etc.
+        - Annoyances — pop-ups, cookie warnings, etc.
+        - Missed analytics or tracker
+        - Dangerous site
+    validations:
+      required: true
       
   - type: checkboxes
     attributes:
@@ -51,23 +68,6 @@ body:
       label: AdGuard version
       description: What version of our software are you running?
       placeholder: for example, 7.7.2, 2.6.1.1060 nightly, 3.6.14 beta
-    validations:
-      required: true
-
-  - type: dropdown
-    id: what-happened
-    attributes:
-      label: What type of problem have you encountered?
-      description: If the problem does not fall under any category that is listed here, please contact our tech support - support@adguard.com
-      multiple: true
-      options:
-        - Missed ads or ad leftovers
-        - Website or app doesn't work properly
-        - AdGuard gets detected on a website
-        - Social media buttons — share, like, tweet, etc.
-        - Annoyances — pop-ups, cookie warnings, etc.
-        - Missed analytics or tracker
-        - Dangerous site
     validations:
       required: true
 


### PR DESCRIPTION
How about moving the issue URL in the template up so that it is visible in the popover when hovering over the issue number? That would be handy.
