### PR TITLE
www.tf1info.fr

### DIFF
--- a/FrenchFilter/sections/antiadblock.txt
+++ b/FrenchFilter/sections/antiadblock.txt
@@ -104,9 +104,6 @@ cookomix.com#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_
 @@||cookomix.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/66771
 @@||debridup.com/*.js$~third-party
-! https://github.com/AdguardTeam/AdguardFilters/issues/77931
-!+ NOT_PLATFORM(windows, mac, android, ext_ff)
-@@||static.adsafeprotected.com/favicon.ico$domain=tf1.fr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64033
 cliqueduplateau.com##.oadb-popup-container
 @@||cliqueduplateau.com/wordpress/wp-content/plugins/oboxmedia-ads/assets/ads.js
@@ -326,19 +323,40 @@ ultimate-catch.eu#%#//scriptlet("abort-current-inline-script", "document.getElem
 @@||static.criteo.net/js/px.js^$domain=ultimate-catch.eu
 !+ PLATFORM(ios, ext_android_cb)
 @@||cas.criteo.com/delivery/ajs.php^$domain=ultimate-catch.eu
-! https://github.com/AdguardTeam/AdguardFilters/issues/77931
-www.tf1.fr#%#//scriptlet('set-constant', '__TF1_CONFIG__.adblock.serverRequest', 'false')
 !
-tf1.fr#$#.ads.ad.adsbox.ad-placement.carbon-ads { display: block!important; }
+! [TF1]
+! https://github.com/AdguardTeam/AdguardFilters/issues/77931 (TF1)
+! https://github.com/AdguardTeam/AdguardFilters/issues/108132 (TF1 INFO)
+! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
+!
+! (1/2) "DOM" AAB CHECK
+!
+tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.display', { value: false, writable: false });
+tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.enable', { value: false, writable: false });
+!
+! Part below required for TF1 galaxy websites (iframe) + for products without scriptlets support
+tf1.fr,tf1info.fr#$#.ads.ad.adsbox.ad-placement.carbon-ads { display: block!important; }
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
-prod-player.tf1.fr,tf1.fr#@#.ads
-prod-player.tf1.fr,tf1.fr#@#.ad
-prod-player.tf1.fr,tf1.fr#@#.ad-placement
-prod-player.tf1.fr,tf1.fr#@#.carbon-ads
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ads
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad-placement
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.carbon-ads
 ! not working in Safari because of a bug
 ! https://github.com/AdguardTeam/AdguardForiOS/issues/1253
 @@||tf1.fr^$generichide
+@@||tf1info.fr^$generichide
 !#endif
+!
+! (2/2) "NETWORK REQUEST" AAB CHECK
+!
+tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.serverRequest', { value: false, writable: false });
+tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.serverRequest', { value: false, writable: false });
+!
+! Whitelisted mainly for "adguard_app_ios" and "adguard_ext_android_cb" (fallback solution for others)
+@@||static.adsafeprotected.com/favicon.ico$domain=tf1.fr|tf1info.fr
+@@||ads.stickyadstv.com^|$xmlhttprequest,domain=tf1.fr|tf1info.fr
+! [/TF1]
+!
 ! https://forum.adguard.com/index.php?threads/chat-nrj-fr.28809/
 @@||chat.nrj.fr/Scripts/Lib/adsbygoogle.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15246


### PR DESCRIPTION
Hello, :wave:
&nbsp;

![tf1info](https://user-images.githubusercontent.com/4764956/151021723-1d3adeb8-a9aa-41eb-bbb1-f578186c7d62.png)

:arrow_right_hook: See the result [before](https://user-images.githubusercontent.com/4764956/151023028-43377180-96b3-47ab-88d2-33f5c4b86d30.png) / [after](https://user-images.githubusercontent.com/4764956/151023042-f79e38c5-e85a-4f0e-b530-23bf7a2147bb.png) on **`tf1info.fr`**.
###### :bulb: About the ["next" name](https://user-images.githubusercontent.com/4764956/151054326-d6a5ee23-67e1-4aea-b4d7-40b5fd730b0a.png).
&nbsp;

And just for info, _current_ values on **`tf1.fr`** without using AdGuard:

![tf1](https://user-images.githubusercontent.com/4764956/151038776-a3246034-7fe5-4dd2-a45f-629a1f275ebe.png)

&nbsp;

### By the way, a bit of redesign in the process. :thumbsup:

<details>
<summary><em>:mag: Some informative stuff (click to reveal) …</em></summary>

- I removed `www.` for `tf1.fr` (both to be consistent with the rest + because of [this](https://github.com/AdguardTeam/AdguardForiOS/issues/1897) temporary bug on iOS);

- On `tf1info.fr`, `.adblock.display` was named by them `.adBlock.enable` instead (still, it's "DOM" AAB check only despite its "global" property name and != `.adBlock.serverRequest`) — see screenshot [TF1](https://user-images.githubusercontent.com/4764956/151006504-26765c1e-031f-498a-bdb9-b3604aad6307.png) / screenshot [TF1 INFO](https://user-images.githubusercontent.com/4764956/151006519-d79686b5-c942-42f6-ad1d-d3462198de43.png);

- Just for information, about `favicon.ico` which was set as `NOT_PLATFORM(windows, mac, android, ext_ff)`: it's because of [this](https://github.com/AdguardTeam/AdguardFilters/pull/78494/files#r604834686) (`$replace` related) but was not updated accordingly once [switched to scriptlet](https://github.com/AdguardTeam/AdguardFilters/issues/77931#issuecomment-822360802);

- I left `prod-player.tf1.fr,tf1.fr` as it was. Although _technically_ `tf1.fr` would suffice (probably done in an effort to be more explicit);

- Regarding `ads.stickyadstv.com` but also `static.adsafeprotected.com/favicon.ico` (which I finally chose after reflection not to limit to `adguard_app_ios || adguard_ext_android_cb` to be more future-proof -> if the adequate scriptlet becomes invalid one day + because request not done anyway when the adequate scriptlet is in use):
  - ↳ the only problem is the combo "scriptlets not supported + AdGuard DNS Filter in use" (and if scriptlets are not supported, no support for `$redirect` either, so no solution for this _specific_ situation). By chance, for many users on iOS, it's not anymore a problem thanks to the recent support of scriptlets (Premium feature though), so the request will be prevented there too in this case.
&nbsp;

##### :bulb: About: [https://tf1-et-vous.tf1.fr/tf1-info-la-nouvelle-offre-digitale-de-linformation-du-groupe-tf1](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https%3A%2F%2Ftf1-et-vous.tf1.fr%2Ftf1-info-la-nouvelle-offre-digitale-de-linformation-du-groupe-tf1) [translation [here](https://tf1--et--vous-tf1-fr.translate.goog/tf1-info-la-nouvelle-offre-digitale-de-linformation-du-groupe-tf1?_x_tr_sl=fr&_x_tr_tl=en&_x_tr_hl=en)] (LCI -> TF1 INFO)
</details>


&nbsp;
&nbsp;
&nbsp;
___
Fixes #108132