### PR TITLE
Avira Safe Search Discontinued

### DIFF
--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -12,13 +12,6 @@ bing.com#@#li[class=""][data-bm][style*="margin-bottom"]
 !
 !#safari_cb_affinity(general)
 !
-! Search.Avira.com
-!
-search.avira.com#@#.ad-zone
-@@||google.com/adsense/search/async-ads.js$domain=search.avira.com
-@@||csr.inspsearchapi.com/lib/advertisement.js$domain=search.avira.com
-@@||google.com/afs/ads$domain=search.avira.com
-!
 ! Bing
 !
 bing.com#@#.adsMvC


### PR DESCRIPTION
Please read : https://support.avira.com/hc/en-us/articles/360012814297-Discontinuation-of-the-Avira-Safe-Search