### PR TITLE
Comodo Search Removed! (Soon)

### DIFF
--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -208,8 +208,6 @@ org.rambler.ru#@#.ad-serp-item
 3g2upl4pq6kufc4m.onion,duckduckgo.com#@#.highlight_sponsored
 3g2upl4pq6kufc4m.onion,duckduckgo.com#@##ads
 3g2upl4pq6kufc4m.onion,duckduckgo.com#@#.js-results-ads
-! Comodo Search
-@@||search.comodo.com^$elemhide
 ! Ecosia search
 ecosia.org#@#.results-ads
 ecosia.org#@#.card-ad


### PR DESCRIPTION
I asked to Comodo Staff about search.comodo.com . They replied, "We're not supporting the link search.comodo.com anymore and it will be removed soon."
Here is a screenshot of the employee's reply from personal message. > https://i.imgur.com/Y8NCIkm.png
Deleting the dedicated rule early won't harm anyone. For your information.