### PR TITLE
heise.de

### DIFF
--- a/AnnoyancesFilter/sections/cookies_general.txt
+++ b/AnnoyancesFilter/sections/cookies_general.txt
@@ -1518,6 +1518,7 @@
 ||cdn.trustcommander.net/privacy^
 ||static.axept.io/sdk.js
 ||cdn.privacy-mgmt.com^$third-party
+||cdn-*.privacy-mgmt.com^$third-party
 ||cmp.osano.com^
 /javascript/component-CookieConsent
 ||rcsobjects.it/rcs_cpmt/


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
Removes a cookie consent banner on heise.de

* **Current behaviour**: 

[//]: # (Substitute this line with a description of the problem)

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/39418860/153662321-3fd32d2d-1ec0-4f15-9c6c-0720489a30a3.png)

</details><br/>

</details><br/>

* **Expected behaviour**: 

[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/39418860/153662335-e74b25cf-bc63-4cd8-9053-0f8ebc588467.png)
</details><br/>

***Steps to reproduce the problem***:

[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)

Go to heise.de

***System configuration***

**Filters:**

[//]: # (Substitute this line with the list of your active filters, separated by commas)

adguard-annoyance, user-filters, ublock-filters: 30741-27,  ublock-badware, ublock-privacy, ublock-abuse, ublock-unbreak, easylist, easyprivacy, urlhaus-1,  plowe-0

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      |  Arch Linux
Operating system version (Android/iOS) | 10.02.21
Browser:                               |  Firefox 97.0
AdGuard version:                       | UBlock Origin 1.41.2 
Filters enabled:                       | None

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
