### PR TITLE
www.dashlane.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -124,6 +124,7 @@ rapidonline.com#$#.cookie-policy-wrap { display: none !important; }
 rapidonline.com#$#body { overflow: auto !important; }
 eurogarden.eu###bcmsCookieInfoWrapper
 myunidays.com##.c-cookie-banner-container
+dashlane.com##div[data-testid="privacy-consent-content"]
 apothekerkammer.at#$##gdcc-wrapper { display: none !important; }
 apothekerkammer.at#$#.modal-backdrop { display: none !important; }
 apothekerkammer.at#$#body { overflow-y: auto !important; padding-right: 0 !important; }


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/108721

In issue system configuration indicated that user has AdGuard desktop application, and it means that the cosmetic rules will not work on this website (website in https exclusion list). On my mind rule for this website might be helpful
in AdGuard browser extension.

<details><summary>Screenshot:</summary>

![Снимок экрана 2022-02-14 в 16 50 55](https://user-images.githubusercontent.com/91964807/153876585-d1101204-afdc-43f5-9a16-f56dedf1faa9.png)

</details><br/>

