### PR TITLE
Fix #110217 (Comment #1039404424) google.com

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -294,6 +294,7 @@ linkjust.com,updatesmarugujarat.in,mexashare.com,links4u.me,linku.us,skips.link,
 !
 !
 !
+google.*###kp-wp-tab-overview > div.TzHB6b.cLjAic:nth-child(2) > div > div.sATSHe > div > div.LuVEUc.B03h3d.P6OZi.V14nKc.i8qq8b.ptcLIOszQJu__wholepage-card.wp-ms > div.UDZeY.mf8UVb.OTFaAf > div.wDYxhc
 pubhtml5.com##.ph5---banner---container
 ||viewsb.com/js/jquery/*/jquery-*.min.js?v=
 manga-raw.club##div[style="height: 200px;"]


### PR DESCRIPTION
Rule created and modified with Browser-Assistent. Checked with several search tries and also another, e.g. "Pokemon Arceus". Also in different Browsers. Ad was filtered fine.
