### PR TITLE
Fix #110217 (Comment #1039404424) google.com

### DIFF
--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -73,6 +73,7 @@ google.*#@?#div[jscontroller][jsaction] > div[jsname][jscontroller][data-record-
 @@://www.google.*/aclk$urlblock
 google.*#@##search div[jscontroller][jsaction] > div[class] > div[jscontroller] div[jscontroller] > div[jscontroller] > div[jsname][jscontroller][jsaction][data-record-click-time][class]
 google.*#@#div[data-attrid="kc:/local:promotions"]
+google.*#@#kp-wp-tab-overview > div.TzHB6b.cLjAic:nth-child(2) > div > div.sATSHe > div > div.LuVEUc.B03h3d.P6OZi.V14nKc.i8qq8b.ptcLIOszQJu__wholepage-card.wp-ms > div.UDZeY.mf8UVb.OTFaAf > div.wDYxhc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/107444
 google.*#@#.commercial-unit-mobile-top
 google.*#@#.commercial-unit-mobile-top > div[data-pla="1"]


### PR DESCRIPTION
Rule created and modified with Browser-Assistent. Checked with several search tries and also another, e.g. "Pokemon Arceus". Also in different Browsers. Ad was filtered fine.
