### PR TITLE
warthunder.com cookie notice (Annoyance)

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -452,6 +452,7 @@ fotostrana.ru##.footer-cookie-agreement
 pokemonmasters-game.com##.c-agree-cookie
 tiktok.com##div[class*="DivCookieBannerContainer"]
 /_js/consent_check.php$domain=sporx.com|superfb.com
+warthunder.com##.wt-cb
 warthunder.ru##.wt-cb
 ||citroen-club.it/forum/java/cookie.js
 capture.dropbox.com##.dig-Snackbar[role="alert"]

--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -452,8 +452,7 @@ fotostrana.ru##.footer-cookie-agreement
 pokemonmasters-game.com##.c-agree-cookie
 tiktok.com##div[class*="DivCookieBannerContainer"]
 /_js/consent_check.php$domain=sporx.com|superfb.com
-warthunder.com##.wt-cb
-warthunder.ru##.wt-cb
+warthunder.com,warthunder.ru##.wt-cb
 ||citroen-club.it/forum/java/cookie.js
 capture.dropbox.com##.dig-Snackbar[role="alert"]
 shakeshack.com###block-privacymessageblock


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 
Cookie Notice

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](
![image](https://user-images.githubusercontent.com/29574622/155408912-15c5be59-04f2-44f1-95f3-b4e28ccad7e8.png)
)
</details><br/>

* **Expected behaviour**: 
No cookie notice

***Steps to reproduce the problem***:

Visit: `https://warthunder.com/en`

***System configuration***

**Filters:**

Base, Tracking, Annoyance, Social
