### PR TITLE
Fix adserver.bafrahaber.com

### DIFF
--- a/TurkishFilter/sections/adservers_firstparty.txt
+++ b/TurkishFilter/sections/adservers_firstparty.txt
@@ -7,6 +7,7 @@
 ! Bad: ||legitwebsite.com^$third-party (should be in adservers.txt)
 !
 !
+||adserver.bafrahaber.com^
 ||addata.exxen.com^
 ||ads.macsonuclari.mobi^
 ||ads.inegolonline.com^


### PR DESCRIPTION
Website : https://www.bafrahaber.com/
Added
_**adserver.bafrahaber.com**_
for the sake of DNS filter.