### PR TITLE
skroutza.skroutz.gr analytics updated url

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1151,6 +1151,7 @@ reddit.com##a[href="#pixel"]
 ||heyhelga.net/analytics.js
 ||analytics-cms.whitebeard.me/js/
 ||skroutz.gr/analytics/srecord/
+||skroutza.skroutz.gr/skroutza.min.js
 ||bol.com/tracking/*.gif
 ||voonik.com/analytics.min.js
 ||topshop.com/wcsstore/ConsumerDirectStorefrontAssetStore/images/trans_pixel.gif


### PR DESCRIPTION
Skroutz.gr Analytics update

Updated as per the following link
https://developer.skroutz.gr/analytics/#step-1-integrate-the-analytics-tracking-script

Screenshot of script in action
![image](https://user-images.githubusercontent.com/100943059/156774190-b095caba-c08d-4f5a-a58d-a84e28cf0370.png)
