### PR TITLE
Update #90885 - move rules for revolving adservers

### DIFF
--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -33,8 +33,6 @@ abendzeitung-muenchen.de###webpush-app
 ||karuna4u.com^$third-party
 ||pushofferpro.com^$third-party
 ! uCoz
-.pro/v2/a/push/js/$third-party
-/ntfc.php?p=$third-party
 ||leechiza.net^$third-party
 ! `window.wpnConfig`
 ! https://vinuser5.biz/?pu=ha3gemtcg45ha3ddf4ytanju

--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -112,6 +112,8 @@ porn*.net/bees.js|
 !+ NOT_PLATFORM(ext_safari, ios)
 /tghr.js$script
 !
+.pro/v2/a/push/js/$third-party
+/ntfc.php?p=$third-party
 /script/su.js$script,third-party
 /javascript/fropo.js
 /pub/js_min.js|


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

I don't understand why they're in Annoyances, and it seems my comment in #90885
> /ntfc.php?$script in Base

was wrong, maybe was confusing with uBlock filters. For `.pro/v2/a/push/js/$third-party`, visit [NSFW] `h2porn.com` and you'll see `http://ca.clcknads.pro/v2/a/push/js/37050`. For `https://publicwww.com/websites/%22ntfc.php%22/` and you see a lot e.g. `youtubemp3.to` calls `https://pusherism.com/ntfc.php?p=1733642` blocked by EL.

</details><br/>

* **Expected behaviour**: 

They should be in base to block revolving adservers.

</details><br/>

***Steps to reproduce the problem***:

Visit the site and see requests.

***System configuration***

NA

**Filters:**

NA

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | ?
Operating system version (Android/iOS) | ?
Browser:                               | ?
AdGuard version:                       | ?
Filters enabled:                       | ?
AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
Filtering quality (Android only):      | High-quality / High-speed / Simplified
HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
Simplified filters (iOS only)          | On / Off
AdGuard DNS:                           | None / Default / Family Protection
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
