### PR TITLE
include cname-trackers Parse.ly to Spyware filter

### DIFF
--- a/SpywareFilter/sections/cname_trackers.txt
+++ b/SpywareFilter/sections/cname_trackers.txt
@@ -74,6 +74,9 @@
 ! Pardot : go.pardot.com disguised trackers
 ! not included
 !
+! Parse.ly : parsely.com disguised trackers
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/trackers/parse_ly.txt
+!
 ! Plausible Analytics : custom.plausible.io disguised trackers
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/trackers/plausible-analytics.txt
 !


### PR DESCRIPTION
https://github.com/AdguardTeam/cname-trackers/issues/33