### PR TITLE
Fix search.naver.com

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -52,7 +52,9 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com|bolgehastanesi.com|ewtc.de
 !
+!#if ( !adguard_app_windows )
 ||search.naver.com/p/crd/rd
+!#endif
 ||tpucdn.com/js/ga-*.js
 ||techpowerup.com/_log
 ||purr.nytimes.com/*/purr-cache

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -52,9 +52,6 @@
 !
 /analytics.js$domain=bataryapil.com|journey.com.tr|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com|bolgehastanesi.com|ewtc.de
 !
-!#if ( !adguard_app_windows )
-||search.naver.com/p/crd/rd
-!#endif
 ||tpucdn.com/js/ga-*.js
 ||techpowerup.com/_log
 ||purr.nytimes.com/*/purr-cache

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -6,6 +6,14 @@
 ! Bad: ||example.org^$xmlhttprequest,redirect=noopvast-3.0 (for instance, should be in specific.txt)
 !
 !
+||search.naver.com/p/crd/rd$removeparam=i
+||search.naver.com/p/crd/rd$removeparam=px
+||search.naver.com/p/crd/rd$removeparam=py
+||search.naver.com/p/crd/rd$removeparam=sx
+||search.naver.com/p/crd/rd$removeparam=sy
+||search.naver.com/p/crd/rd$removeparam=p
+||search.naver.com/p/crd/rd$removeparam=s
+||search.naver.com/p/crd/rd$removeparam=time
 ! https://github.com/AdguardTeam/AdguardFilters/issues/110942
 ||buzzfeednews.com^$removeparam=ref
 ! https://github.com/AdguardTeam/AdguardFilters/issues/110758

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -6,6 +6,7 @@
 ! Bad: ||example.org^$xmlhttprequest,redirect=noopvast-3.0 (for instance, should be in specific.txt)
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/pull/112096
 ||search.naver.com/p/crd/rd$removeparam=i
 ||search.naver.com/p/crd/rd$removeparam=px
 ||search.naver.com/p/crd/rd$removeparam=py


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/112077
https://github.com/AdguardTeam/AdguardFilters/issues/112089

### How to reproduce
1. Visit [here](https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=ad) with AdGuard for Windows.
2. Click the highlighted element.
    <details>
    <summary>Screenshot</summary>

   ![Screenshot1](https://user-images.githubusercontent.com/98787049/156926972-e6a18aae-3720-4759-8840-6307228e9854.png)
 
    </details>