### PR TITLE
twitch.tv promoted streams

### DIFF
--- a/EnglishFilter/sections/specific.txt
+++ b/EnglishFilter/sections/specific.txt
@@ -14631,6 +14631,8 @@ twitch.tv##a[href="https://vk.com/bust3rshop"]
 twitch.tv##a[href*="store.asus.com/rog-promo/"]
 twitch.tv##div[data-test-selector="channel_panel_test_selector"] > a[href^="http://bit.ly/"]
 twitch.tv##div[data-test-selector="channel_panel_test_selector"] > a[href^="https://bit.ly/"]
+! twitch.tv - promoted stream tiles
+twitch.tv##div.tw-tower > div:has(div.promoted-card-stat__promotion)
 !
 mail.yahoo.com##div[data-test-id="darla-container"]
 mail.yahoo.com##div[data-test-id="ad-viewability-tracker"]


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***: Removes tiles with a *Promoted* tag.
* **Current behaviour**: twitch.tv obnoxiously displays irrelevant *Promoted* streams

[//]: # (Substitute this line with a description of the problem)

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/81353/158025590-e1c4cfe8-16d5-48ec-a0f9-af918afc09f1.png)

</details><br/>

* **Expected behaviour**: the landing page has no *Promoted* streams

[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)

<details><summary>Screenshot:</summary>

(same as above but without the first "Promoted" tile)

</details><br/>

***Steps to reproduce the problem***:

* Browse to https://twitch.tv, you might want to be logged-in

[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)

***System configuration***

Irrelevant. uBlock Origin.

**Filters:**

[//]: # (Substitute this line with the list of your active filters, separated by commas)

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Browser:                               | irrelevant, Firefox

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
