### PR TITLE
do not include logly.co.jp disguised trackers

### DIFF
--- a/SpywareFilter/sections/cname_trackers.txt
+++ b/SpywareFilter/sections/cname_trackers.txt
@@ -65,6 +65,9 @@
 ! Lead Forensics : ghochv3eng.trafficmanager.net disguised trackers
 ! not included
 !
+! Logly : logly.co.jp disguised trackers
+! not included
+!
 ! NameSilo : ab1n.net disguised trackers
 ! included to EnglishFilter/sections/cname_adservers.txt
 !


### PR DESCRIPTION
https://github.com/AdguardTeam/cname-trackers/issues/35