### PR TITLE
Add more generic filters for revolving adservers

### DIFF
--- a/AnnoyancesFilter/sections/push-notifications.txt
+++ b/AnnoyancesFilter/sections/push-notifications.txt
@@ -247,7 +247,6 @@ abendzeitung-muenchen.de###webpush-app
 ||admessage.support^$third-party
 ||ntvsw.com^$third-party
 ||ichecknotifyfriends.info^$third-party
-/code/native.js?h=
 ||valkirum.com^$third-party
 ||luravius.com^$third-party
 ||amacritus.com^$third-party

--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -112,6 +112,7 @@ porn*.net/bees.js|
 !+ NOT_PLATFORM(ext_safari, ios)
 /tghr.js$script
 !
+/code/native.js?h=
 /aas/r45d/vki/*$script,third-party
 /lv/esnk/*$script,third-party
 /i/npage/*/code.js|$script,third-party

--- a/EnglishFilter/sections/general_url.txt
+++ b/EnglishFilter/sections/general_url.txt
@@ -112,6 +112,12 @@ porn*.net/bees.js|
 !+ NOT_PLATFORM(ext_safari, ios)
 /tghr.js$script
 !
+/aas/r45d/vki/*$script,third-party
+/lv/esnk/*$script,third-party
+/i/npage/*/code.js|$script,third-party
+/bultykh/ipp24/7/bazinga/*$script,third-party
+/pn07uscr/f/tr/zavbn/*$script,third-party
+/sdk/push_web/?zid=$script,third-party
 .pro/v2/a/push/js/$third-party
 /ntfc.php?p=$third-party
 /script/su.js$script,third-party


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

This is update to https://github.com/AdguardTeam/AdguardFilters/pull/111911 , covering more revolving adservers. 99% of them are covered by EL/Base but there certainly are occasional miss.

</details><br/>

* **Expected behaviour**: 

They should be blocked.

</details><br/>

***Steps to reproduce the problem***:

None-trivial, but visit sites on

```
https://publicwww.com/websites/%22%2Faas%2Fr45d%2Fvki%2F%22/
https://publicwww.com/websites/%22%2Flv%2Fesnk%2F%22/
https://publicwww.com/websites/%22%2Fi%2Fnpage%2F%22/
https://publicwww.com/websites/%22%2Fbultykh%2Fipp24%2F7%2Fbazinga%2F%22/
https://publicwww.com/websites/%22%2Fpn07uscr%2Ff%2Ftr%2Fzavbn%2F%22/
https://publicwww.com/websites/%22%2Fsdk%2Fpush_web%2F%3Fzid%3D%22/
```

and you'll see they block many of revolving adservers. The patterns have been stable for months and are not likely to cause breakage, nor I'm aware of any.

***System configuration***

NA

**Filters:**

Base

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | Windows 10
Browser:                               | Brave 1.36.116
AdGuard version:                       | Ext 3.6.17
AdGuard DNS:                           | None


[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
