### PR TITLE
Fix for copays.org (charity)

### DIFF
--- a/AnnoyancesFilter/sections/subscriptions.txt
+++ b/AnnoyancesFilter/sections/subscriptions.txt
@@ -33,7 +33,7 @@ turkuazgazetesi.net,yenialanya.com,mansetaydin.com,seskocaeli.com,kocaelibarisga
 ||embeds.fanmatics.com^$third-party
 ||cp.unisender.com/*/form-widget-loader.js$third-party
 ##.widget_blog_subscription
-~nothing.tech,~mega-debrid.eu,~curvegames.com,~news.un.org,~norwichzen.org.uk,~dereferer.me###mc_embed_signup
+~copays.org,~nothing.tech,~mega-debrid.eu,~curvegames.com,~news.un.org,~norwichzen.org.uk,~dereferer.me###mc_embed_signup
 !
 cybernews.com##.subscribe__modal
 lnews.jp##.sp-btn-mail-magazine


### PR DESCRIPTION
Fixes https://copays.org/stay-connected/
(this is a charity that helps people get life saving meds)
