### PR TITLE
Fix #113990 hertz.com

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -646,7 +646,7 @@ cian.ru##div[data-name="CookiesNotification"]
 2captcha.com##.app-level-notifications
 delfi.ee##div[class^="C-modal"]
 simpl.rent##header + div[class^="NotificationBox__Wrapper-"]
-hertz.it##div[id^="light-box-"]
+hertz.*##div[id^="light-box-"]
 logout.hu###rules_accept
 excellent-hemd.de#$#.modal-backdrop { display: none !important; }
 excellent-hemd.de#$##cookieModal { display: none !important; }


### PR DESCRIPTION
Fix #113990
Page exist for https://www.hertz.com https://www.hertz.de https://www.hertz.it/ https://www.hertz.co.uk and so on.
