### PR TITLE
milirepo.sabatech.jp

### DIFF
--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -2996,7 +2996,6 @@ feedspot.com##.share_mod_ul
 football24.ua##.share-soc-icons
 ttf.org.tr##.face-box
 contra.gr##.Article__social
-lotte.co.jp,9ketsuki.info##.social-top
 sexvideos-hd.com,pornohirsch.net###fb_video_link
 sexvideos-hd.com,pornohirsch.net###sh_video_link
 abczdrowie.pl,money.pl,o2.pl,wp.pl,dobreprogramy.pl##.wp-player .social
@@ -5570,7 +5569,8 @@ newyorker.com##li[data-source="facebook"]
 aol.com##.shared-services-w
 m.patronlardunyasi.com##body > div[style*="height:50px; background-color:#fff; z-index:1000; position:fixed; bottom:0; border-top:1px solid #ccc;"]
 yenisafak.com##.share > a[title]
-bitdays.jp,am-our.com,bazurecipe.com,lotte.co.jp,9ketsuki.info,hurriyetdailynews.com##.social-bottom
+sabatech.jp,lotte.co.jp,9ketsuki.info##.social-top
+sabatech.jp,bitdays.jp,am-our.com,bazurecipe.com,lotte.co.jp,9ketsuki.info,hurriyetdailynews.com##.social-bottom
 hurriyetdailynews.com##.content-info > .social-links
 neuhandeln.de##.mh-social-bottom
 invitro.ru,t-online.de##.messenger


### PR DESCRIPTION
Fix #114038 

I removed `milirepo.` because sabatech.jp have same elements.
For example #114040