### PR TITLE
biletall.com

### DIFF
--- a/AnnoyancesFilter/sections/mobile-app.txt
+++ b/AnnoyancesFilter/sections/mobile-app.txt
@@ -23,6 +23,7 @@
 ##head[prefix~="medium-com:"] ~ body .js-postActionsBarContent > .js-readNextInteractions
 !
 wondershare.com##.d-lg-none
+biletall.com###mobile-applications
 gunosy.com##div[class*="_app"]
 gunosy.com##.download_link
 gunosy.com##.airplain


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/113749

I don't think that we should block `biletall.com/event` from the issue

<details><summary>Screenshot:</summary>

<img width="1157" alt="Снимок экрана 2022-04-04 в 17 09 29" src="https://user-images.githubusercontent.com/91964807/161562136-a647c604-20cb-4012-83cd-ddb88b4e8586.png">

</details><br/>