### PR TITLE
gooday.nikkei.co.jp

### DIFF
--- a/AnnoyancesFilter/sections/subscriptions.txt
+++ b/AnnoyancesFilter/sections/subscriptions.txt
@@ -36,6 +36,7 @@ turkuazgazetesi.net,yenialanya.com,mansetaydin.com,seskocaeli.com,kocaelibarisga
 ~copays.org,~nothing.tech,~mega-debrid.eu,~curvegames.com,~news.un.org,~norwichzen.org.uk,~dereferer.me###mc_embed_signup
 !
 webcg.net##.mailmagazine-widget
+gooday.nikkei.co.jp##.gdy-side-sns
 onliner.by#?#.news-text > p[style]:has(> strong:contains(/Наш канал в|Падпісвайцеся/))
 time.com##.roadblock
 free-ebooks.net##.register-box


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/115432

I think that we shouldn't block banners from screenshot in the issue, because they leads on internal pages

<details><summary>Screenshot:</summary>

<img width="453" alt="Снимок экрана 2022-04-13 в 19 32 00" src="https://user-images.githubusercontent.com/91964807/163227689-f1fc8355-abd4-4b4f-a302-4d2b1e953069.png">

</details><br/>