### PR TITLE
afreecatv.com - Logger

### DIFF
--- a/EnglishFilter/sections/foreign.txt
+++ b/EnglishFilter/sections/foreign.txt
@@ -4980,8 +4980,6 @@ hankyung.com##.articlebanner
 ||torrentdia*.com/data/to_list/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76393
 @@||advimg.ad-mapps.com/sdk/js/ver/*/ad_movie_script.js$domain=ichannela.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/75539
-||st.afreecatv.com/api/ad_block_api.php?*&szCheckType=adblock$replace=/&szAdblockUseFlag=y/&szAdblockUseFlag=n/
 !
 ! tistory.com
 ! adblock detect

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -35,6 +35,7 @@
 ! Disabled in DNS filter
 ||telemetry.mozilla.org^
 !
+||delog.afreecatv.com^
 ||ab.blogs.es^
 ||plausible.simplelogin.io^
 ||spade.twitch.tv^


### PR DESCRIPTION
### How to reproduce
1. Visit [afreecatv homepage](https://afreecatv.com/) with AdGuard VPN (Korean IP) and Korean language configuration.
2. Click one of the highlighted live broadcasts.
    <details>
    <summary>Screenshot</summary>

     ![Screenshot from 2022-04-16 15-14-01](https://user-images.githubusercontent.com/98787049/163680416-82abb56c-d7ad-4526-bc06-03c515ad25a1.png)

    </details>
3. Play without any program installation.
    <details>
    <summary>Screenshot</summary>

     ![Screenshot from 2022-04-16 15-15-25](https://user-images.githubusercontent.com/98787049/163680777-09cb3b03-3d85-47a2-86de-cad17afe901d.png)

    </details>

### Screenshot
<details>
<summary>Screenshot</summary>

![Screenshot from 2022-04-16 13-06-27](https://user-images.githubusercontent.com/98787049/163679975-5e730a92-b720-49fa-b8d3-b3e501dc2e03.png)

</details>

### Still cannot reproduce?
Please check the following chat:
 - https://listauthorschat.slack.com/archives/C010N14G4TF/p1650123202007819

### Similarweb Web Traffic Report
https://www.similarweb.com/website/afreecatv.com/#traffic