### PR TITLE
www.bataryapil.com

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -50,7 +50,7 @@
 ||adc.nine.com.au/?token=$redirect=nooptext,important,domain=9now.com.au
 ||googleadservices.com/pagead/conversion_async.js$redirect=noopjs,domain=ffm.to,important
 !
-/analytics.js$domain=bataryapil.com|journey.com.tr|freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|partifabrik.com|newsmax.com|bolgehastanesi.com|ewtc.de
+/analytics.js$domain=freexcafe.com|rusvideos.tv|nakubani.ru|lun.com|songsara.net|newsmax.com|bolgehastanesi.com|ewtc.de
 !
 ||msgrt.gamedistribution.com/collect^
 ||tiktokv.com/web/report?


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/115662

removed domains from `/analytics.js` , that blocked by `cdn.ticimax.com/*/analytics.js`