### PR TITLE
www.heise.de

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -8,7 +8,6 @@
 ! Bad:  $removeparam=utm_id,domain=example.org (for instance, should be in specific.txt)
 !
 !
-$removeparam=wt_mc
 $removeparam=adfrom
 $removeparam=nx_source
 $removeparam=_zucks_suid
@@ -27,6 +26,9 @@ $removeparam=fb_comment_id
 $removeparam=fb_ref
 $removeparam=fb_source
 $removeparam=fbclid
+! URL Campaign Mapper
+! https://documentation.mapp.com/latest/en/url-campaign-mapper-19109338.html
+$removeparam=wt_mc
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100448
 ! https://github.com/AdguardTeam/AdguardFilters/issues/115746
 $removeparam=oprtrack

--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -8,6 +8,7 @@
 ! Bad:  $removeparam=utm_id,domain=example.org (for instance, should be in specific.txt)
 !
 !
+$removeparam=wt_mc
 $removeparam=adfrom
 $removeparam=nx_source
 $removeparam=_zucks_suid


### PR DESCRIPTION
Description: Add rule for `wt_mc` tracking param.

Sample links:

```
https://www.emp.de/?wt_mc=pt.co.img.summerbre

http://obi.de/de/markt-finder/index.html?market=395&wt_mc=seab.google.brand.brand.&wt_cc1=197451019&wt_cc2=obi%20marburg&wt_cc3=e&wt_cc4=

https://www.magenta-musik-360.de/prio-tickets?wt_mc=da_somumuxx_prio-ln-hp-logo

https://www.rainews.it/tgr/veneto/video/2021/09/ven-mobilita-verona-bicicletta-scuola-progetto-mondgreen-0c60df82-473f-4f00-ae97-1e72fa8aee3f.html?wt_mc=2.www.wzp.tgrveneto_ContentItem-0c60df82-473f-4f00-ae97-1e72fa8aee3f.&wt

https://www.magentasport.de/aktion/3liga?wt_mc=da_sospsoxx_2020-sport-sponsoring_3liga-club-10

https://www.tuv.com/thailand/en/automotive-testing.html?wt_mc=Advertising.Print.no-interface.TH22_M04_AUTOPART.TH22_M04_AUTOPART_PT.QR.&cpid=TH22_M04_AUTOPART_PT

https://heimtextil.messefrankfurt.com/frankfurt/en.html?wt_mc=heimtextil.gr.msg.hotelmag_gr_728x90.2022
```
