### PR TITLE
add tracking params rules for theregister.com

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -653,4 +653,6 @@ $removeparam=dclid
 ||v.youku.com^$removeparam=ptag
 ||v.youku.com^$removeparam=scm
 ||v.youku.com^$removeparam=spm
+! The Register
+||theregister.com^$removeparam=td
 !


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
add tracking params rules for theregister.com

* **Current behaviour**: 

````
https://www.theregister.com/2022/04/27/microsoft-linux-vulnerability/?td=rt-3a
````

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>

![image](%screenshot_url%)
</details><br/>

* **Expected behaviour**: 

````
https://www.theregister.com/2022/04/27/microsoft-linux-vulnerability/
````

<details><summary>Screenshot:</summary>

![image](%url_of_screenshot%)
</details><br/>

***Steps to reproduce the problem***:

[//]: # (Substitute this line with a step-by-step instruction how to reproduce the issue)

***System configuration***

**Filters:**

[//]: # (Substitute this line with the list of your active filters, separated by commas)

[//]: # (Please enter the correct values for your case to the table below)

Information                            | Value
---                                    | ---
Operating system:                      | ?
Operating system version (Android/iOS) | ?
Browser:                               | ?
AdGuard version:                       | ?
Filters enabled:                       | ?
AdGuard mode (Android only):           | VPN / Proxy (manual/auto)
Filtering quality (Android only):      | High-quality / High-speed / Simplified
HTTPS filtering (Android only):        | On (Default/Blacklist mode) / Off
Simplified filters (iOS only)          | On / Off
AdGuard DNS:                           | None / Default / Family Protection
Stealth mode options (Windows only)    | ?
Helpdesk ID (if exists):               | ?

[//]: # (This template is meant for missed ad/false positive reports, for other type of reports edit it accordingly)
[//]: # (If this is a crash report, include the crashlog with https://gist.github.com/)
