### PR TITLE
fix rasppishop.de blocked scroll

### DIFF
--- a/AnnoyancesFilter/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/sections/cookies_specific.txt
@@ -120,6 +120,7 @@ techadvisor.co.uk,forum.notebookreview.com,computerworld.com,skysports.com#$#bod
 !
 !
 !
+rasppishop.de#$#body { overflow: auto !important; position: static !important; }
 lass-dich-nieder.de###id-cookie-layer
 ttoday.it#$#.cli-barmodal-open { overflow: auto !important; }
 ttoday.it#$##cookie-law-info-bar { display: none !important; }


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

Unbreak the site `https://www.rasppishop.de/rpi4-bundle-offiz-teile_8` (cookie banner blocked but unable to scroll)

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please contact our tech support: `support@adguard.com`

  - [ ] Missed ads or ad leftovers;
  - [x] Website or app doesn't work properly;
  - [ ] AdGuard gets detected on a website;
  - [ ] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc.

### What issue is being fixed?
##### Enter the issue address:

No one

### Add your comment and screenshots

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.