### PR TITLE
Sorting domain-specific rules

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -90,7 +90,7 @@ filmifullizle.club##a[href="/filmifullizle.php"]
 /sex*.png$domain=filmoneriler.com|fullsexfilmleri.com
 /suv.js$domain=sinemafilmizle.net|filmmoduu.com
 /popup.js$domain=buzfilmizle1.com|bayfilmizle1.com
-/ads/$domain=setfilmizle.cc|mp3indirdur.mobi|forum.donanimhaber.com
+/ads/*$domain=setfilmizle.*|mp3indirdur.mobi|forum.donanimhaber.com
 ||hdmixfilim.com/vast2.js
 filmizlemetv.com##div[id^="spnsr5"]
 filmizlemetv.com##.rsm-ykr-trf

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -84,6 +84,13 @@ filmifullizle.club##a[href="/filmifullizle.php"]
 /i/*.mp4$domain=webteizle1.com|sezonlukdizi*.com
 /binanceps.jpg$domain=filmmakinesi.*|turkcealtyazi.org
 /files/uploads/advert/*$domain=larende.com|anamurekspres.com|kemergozcu.com
+/wp-content/uploads/*/video*.gif$domain=hulali.net|nikecr7.com
+/wp-content/uploads/*.gif$domain=cdn.diziyou.com|hdfilmcehennemi2.*|geyvemedya.com
+/wp-content/uploads/*.mp4$domain=siyahfilmizle.*|kalitelifilmizle.net
+/sex*.png$domain=filmoneriler.com|fullsexfilmleri.com
+/suv.js$domain=sinemafilmizle.net|filmmoduu.com
+/popup.js$domain=buzfilmizle1.com|bayfilmizle1.com
+/ads/$domain=setfilmizle.cc|mp3indirdur.mobi|forum.donanimhaber.com
 ||hdmixfilim.com/vast2.js
 filmizlemetv.com##div[id^="spnsr5"]
 filmizlemetv.com##.rsm-ykr-trf
@@ -99,7 +106,6 @@ haberlobi.com,haber46.com.tr,kamudanhaber.net##.widget-advert
 ||easymp3mix.com/js/re-ads-*.js
 ||filmizlehub.com/rok.js
 altporno.xyz,hulali.net,nikecr7.com##div[class*="-icerikten-"]
-/wp-content/uploads/*/video*.gif$domain=hulali.net|nikecr7.com
 kariyer.net##.banner-wrapper 
 flvconverter.org,youtube-mp3-music.com,flvconverter.org##div[v-if]
 mp3kedi.com,mp3medya.com##a[href^="https://kingredirect.com/"]
@@ -178,7 +184,6 @@ trivago.com.tr##div[class^="Ad_leaderboard-"]
 abcgundem.com##div[style*="height:262px;"][align="center"]
 emlakjet.com##div[class^="styles_listingDfpBanner__"]
 letgo.com##div[class*="FeedOtoPlusGridItemstyles"]
-||cdn.diziyou.com/wp-content/uploads/*.gif
 diziyou.com##a[href^="https://rebrand.ly/"]
 ||cdn.diziyou.com/player/assets/videojs.ads.min.js
 ||cdn.diziyou.com/player/assets/videojs-preroll.min.js
@@ -219,9 +224,7 @@ altyazilifilm.cc###vs
 randomovie.co##a[href^="https://media.tebanner1.com/"]
 ||play.dizigom1.com/oreklam.png
 hderotikfilmizle.net##.happy-under-player
-||filmoneriler.com/sex*.png
 ||erotizmfilmleri.net/rek*.png
-||fullsexfilmleri.com/sex*.png
 ||hderotikfilmizle.net/wp-content/themes/retrotube/assets/img/banners/
 sporx.com##a[href^="https://iddaa.sporx.com/"]
 sporx.com##.hk_bar
@@ -236,7 +239,6 @@ brickfanatics.com###secondary
 brickfanatics.com###home-banner-dt
 sinepal.*###reki
 sinepal.*##body .ads-skin
-||sinemafilmizle.net/suv.js
 ||filmmoduu.com/wp-content/uploads/*/*/supertotobet.gif
 ||morethanpost.com/wp-content/uploads/2022/01/mrtryl.mp4$media,redirect=noopmp3-0.1s
 ||filmmom.pro/popm/
@@ -248,10 +250,8 @@ kamubulten.com##header > div[style="height: 300px;"]
 buyurindir.org##center a[onclick^="window.open("]
 ||adownload9.online//style.css
 ||fullhd720pizle.live/f7/f7.php
-||buzfilmizle1.com/popup.js
 ||fullhdabifilm.com/maintabs13.js
 ||filmkuzusu1.com/pops5.js
-||bayfilmizle1.com/popup.js
 ensonhaber.com##a[href^="https://ensonhaber.me/r"][target="_blank"][rel="sponsored"]
 mynet.com##.ad-home-masthead-wrapper
 paratic.com##.p-bnr
@@ -285,7 +285,6 @@ zamaninvarken.com###custom_html-6
 becer.net,kredi.biz.tr###custom_html-4
 milliyet.com.tr##p > a[href*="&utm_medium="][href*="&utm_campaign="][target="_blank"] > img
 ||i2.milimaj.com/i/milliyet/75/770x0/61efcb5686b24a11e046229a.jpg$domain=milliyet.com.tr
-||filese.me/pop.php
 webteizle.vip###freebie
 seyredelim.com###home-content > div[style^="background: rgb(14,33,84)"]
 ||prestashopturkiye.com/ucretsiz-sanal-pos.jpg
@@ -304,14 +303,13 @@ yetkinreport.com###el-4ed034a2 p > a > img
 fenerbahce.org##.qrcode-banner
 fenerbahce.org##.sticky-banner
 siyahfilmizle.*##.sticky-footer-banner
-||siyahfilmizle.*/wp-content/uploads/*.mp4
 ensonhaber.com##.owl-stage > .owl-item > .c-slider__item > a[href^="https://bit.ly/"]
 mail.com.tr###mail_ad
 mail.com.tr##.banner_text_bottom
 mail.com.tr##div[id^="main-billboard"]
 yenierzurumhaber.com##.reklamside
 /ad-zones.js$domain=yenidonem.com.tr|bursahakimiyet.com.tr|bursahayat.com.tr|gundembursa.com
-istikbalgazetesi.com##div[align="center"] > a[target="_blank"] > img
+kriptoteknikhaber.com,istikbalgazetesi.com##div[align="center"] > a[target="_blank"] > img
 istikbalgazetesi.com##.side-banner
 altinpiyasa.com###lyr_ads_top2
 fotomac.com.tr##.head-banner
@@ -367,7 +365,7 @@ sozcu.com.tr##.news-item > a[href^="https://bit.ly/"]
 ||izleorg2.org/pop3.js
 beyazgazete.com##div[id^="ads-div-"]
 mp3semti.com##div[bvm-banner-id]
-webtekno.com##.wt-masthead__horizontal
+sanalyer.com,webtekno.com##.wt-masthead__horizontal
 fivemsociety.com##.yordi-banner-reklam
 fivemturk.com##.p-body-inner > div[style="width: 100%; display: flex;"] > a[target="_blank"]
 ||cdn.discordapp.com/attachments/*.gif$domain=fivemturk.com
@@ -380,7 +378,6 @@ dizilab8.*##div[data-tur^="ads"]
 ||bestdizi.net/sport*.js
 sikayetvar.com##.mastheadcontainer
 ||dizikorea.com/5.js
-||setfilmizle.cc/ads/
 ||setfilmizle.cc/yurt.js
 setfilmizle.*##.pageskin-top
 setfilmizle.*##.set-pageskin
@@ -646,7 +643,6 @@ teknoblog.com##.wpb_wrapper > div.banneralani1.td-pb-border-top
 hdfilmcehennemi.*##.play-that-video a[target="_blank"]
 ||hellcdn.xyz/uploads/*.mp4
 ||hdfilmcehennemi2.*/bist.html
-||hdfilmcehennemi2.*/wp-content/uploads/*.gif
 ||hdfilmcehennemi2.*/wp-content/uploads/*/bg*$image
 hdfilmcehennemi2.*##.bireklam
 medyapress.net##a[title^="pubg"][target="_blank"]
@@ -921,7 +917,6 @@ ekonomist.com.tr##div[class$="-ad-area"]
 turkce-brosurler.com##div.banner-outer
 ufukgazetesi.net,uyan32.com,imzagazetesi.com.tr,theanatoliapost.com,izmirsondakika.com,sakaryamedyaajans.com,sakarya360.com,trendoa.com,sonsaat.com.tr##.rk
 log.com.tr##.custom-html-widget > div[style^="clear:both;margin:10px auto;"]
-log.com.tr###masthead-wrapper
 bilgicik.com##a[href^="https://www.acilkitap.com/"] > img
 zirvedehaber.com##.header-ainfo
 ||zirvedehaber.com/wp-content/uploads/*/posof.png
@@ -943,7 +938,6 @@ haberturk.com##.photo-page-ads
 kriptoarena.com##.geniseleman
 ||babafullfilmizleme.com/ft*.js
 kriptoteknikhaber.com##.code-block > a[target="_blank"] > img
-kriptoteknikhaber.com##div[align="center"] > a[target="_blank"] > img
 fullfilmcidayim.com,720p-fullhdizleme.com,babafullfilmizleme.com###filmcidayidesktop
 /(dikey|horay)\.jpg/$domain=pusuhaber.net
 goster.co##div.reklam
@@ -1032,7 +1026,6 @@ sekilliharfler.com###adsense-size
 ||guzel.net.tr/banner/$third-party
 yesilekonomi.com##.header-banner-area
 yesilekonomi.com##.yesilekonomiwidget > a[href][data-bid] > img
-||ceviz.pw/pop.php
 yabancidizi.*##*:not(.poster) > a[href][target="_blank"] > img
 yabancidizi.*##a[href^="https://accounts.binance.com/tr/register"]
 ||bbnhaber.com.tr/assets/img/Reklam2.jpg
@@ -1162,7 +1155,6 @@ dunyasozluk.com##a[href="https://kafasozluk.com"][target="_blank"] > img
 ||dunyasozluk.com/images/ks/kafasozluk_d.png
 ||satoshiturk.com/binance1.gif
 /frmtr\.com\/images\/\w{0,2}\d?.gif/$domain=frmtr.com
-||filmmoduu.com/suv.js
 airturkhaber.com##.avia-image-container
 ensonhaber.com##.masthead_detail
 warezturkey.org###news-partner
@@ -1947,7 +1939,6 @@ oggusto.com###advertisement
 egonomik.com###sidebar > aside.widget_custom_html
 egonomik.com###sidebar > aside.widget_text
 engelliler.biz##.above_body > div.navigationWrapper + div[class] > div[align] > a[target="_blank"] > img
-||refdomain1.xyz/popup.js
 tafdi.net##.vidusttext
 tafdi.net##.vidalttext
 fullhdfilmcehennemi.pw###content > div.sidYan
@@ -2220,7 +2211,6 @@ bodrumhaberpostasi.com##.header > div.surmansetu
 bodrumhaberpostasi.com##.kutu
 ||yatvitrini.com/images/*banner
 ||yatvitrini.com/images/XY2.gif
-sanalyer.com##.wt-masthead__horizontal
 ||sanalyer.com/resimler/radkod_freelance_ekibi.png
 ||tarsusakdeniz.com/Depo/Banner/
 geredeyenigun.com##div[class^="sol_reklam_"]
@@ -2448,7 +2438,6 @@ tafdi.net##body > a[href][rel="nofollow"][id^="bg"]
 ||airkule.com/banner/
 ||asyafanatiklerim.com/wp-content/uploads/*/*banner*.gif
 ||asyafanatiklerim.com/wp-content/uploads/*/*bannner*.gif
-||kalitelifilmizle.net/wp-content/uploads/*.mp4
 dizired1.com###footer-kayan
 dizired1.com###cboxOverlay
 dizired1.com###colorbox
@@ -2610,7 +2599,6 @@ sabah.com.tr##.ifBanner300x250
 geyvemedya.com##div[class^="ads"]
 fethiyehaber.com###pageFull > .wrap950u.mTop10
 geyvemedya.com##a[target="_new"] > img:not([src*="whatsapp"]):not([facebook])
-||geyvemedya.com/wp-content/uploads/*.gif
 pchocasi.com.tr##.herald-sidebar > div.widget_custom_html
 ||kimintelefonu.com/*_reklam
 kimintelefonu.com##div[style="clear:both;height:30px"]
@@ -2657,8 +2645,6 @@ memurlar.net##iframe[src="//sgkrehberi.com/haberbandi/memurlar"]
 ||mp3indirco.info/resimler/music.gif
 erzurumsonhaber.com,banazguncelhaber.com##a[target="_blank"] > img
 ||guncelprojebilgileri.com/files/banners/$domain=emlaktasondakika.com
-||refdomain3.xyz/popup.js
-||refdomain4.xyz/popup.js
 ||i.imgsafe.org^$domain=sinebol.com|filmionlineizle.pw
 sinebol.com###sidebar > a[href][target="_blank"] > img
 sinebol.com##a[href^="https://www.baysansli13.com/click.php"]
@@ -2903,7 +2889,6 @@ koreanturk.com##p > a[href][target="_blank"]:not([href^="http://www.koreanturk.c
 cnnturk.com##.sponsor-container
 ||streamloaded.com/assets/public^$domain=hdfilmcehennemi.*,media
 paratic.com##.dt_banner
-||uzakdogu.tv/popup.js
 uzakdogu.tv##.sbox > a[target="_blank"][rel*="noopener"] > img
 ||filmifullizle*.com/250x250.html
 ||filmifullizle*.com/728x180.html
@@ -2930,7 +2915,6 @@ maksatbilgi.com###stream-item-widget-15
 maksatbilgi.com##.stream-item-below-post-content
 webrazzi.com###wrapper > .above-header
 ||casinoportali*.com/wp-content/html-tables/$third-party
-||filmseyretfilmizle.com/pop.php
 haberinadresi.com##a[href^="http://www.haberinadresi.com/banner.php?id="]
 haberinadresi.com###second-slider .swiper-slide > img[src*="/ozel_esentepe_hastanesi_"]
 haberinadresi.com###second-slider .swiper-slide > a[href^="http://www.haberinadresi.com/ozel-esentepe-hastanesi-"]
@@ -3343,7 +3327,6 @@ ilacrehberi.com###kt_2
 ||1631757767.rsc.cdn77.org/po.min.js^
 ||teklinkfilmindir.org/fullfilm/Resim/yeni/viprek.gif
 ||teklinkfilmindir.org/fullfilm/Resim/yeni/300250reklam.png
-||mp3indirdur.mobi/ads/
 isakoc.com###minty_ad-2
 185.85.75.229##.sidebar > ul > li[id^="text-"]
 gidahatti.com##a[href^="https://tr.hach.com"]
@@ -3588,7 +3571,6 @@ hdfilmizlebe1.net,fullhdfilmcehennemi2.org###sidebar > .sidebarborder:first-chil
 edirnehaber.org##div[style="width:300px; height:250px; margin:;"]
 ||tiparus.com/img/720.gif
 t24.com.tr##.tise-banner
-||forum.donanimhaber.com/ads/
 ||intercdn.xyz/cdn/*/675x90.html
 ||images.ranini.tv/banner/
 ||superhaber.biz/logoustu
@@ -3633,7 +3615,7 @@ qadinlar.co##object[data^="http://qadinla.com/frame"]
 intersinema.com##[href*=".hit.gemius.pl"]
 ||hdodenfilm.com/ODENREKLAM/
 onedio.com##.o-sponsored-article
-onedio.com##.sponsored
+eksisozluk.com,onedio.com##.sponsored
 onedio.com##[class="common-box common-box-300px featured"]
 sondakika.com##div[id^="300x250_Kutu"]
 sondakika.com##.news-row > .news-item[style="width: 300px; height: 250px;"]
@@ -3664,7 +3646,6 @@ trthaber.com##a[onclick*="Reklamı Kapat"]
 ||bultenler.klscdn.com/bulten/*.mp4
 ozhandonder.net###text-5.widget_text
 ingilizcenotlar.com##div[id^="ads"]
-||erotikhikayeoku.net/pop.php
 ||rsc.cdn77.org/matbet/yeni/1000x60.gif
 ||s3.eu-west-2.amazonaws.com/affb/25766/w1000-h50/1000x50.html
 trthaber.com##div[id^="div-gpt-ad-"]
@@ -3817,7 +3798,7 @@ kibrispostasi.com###main_right > div > a > [style*="308px;"][style*="border"]
 haberler.com###marcamarca
 haber10.com###masthead-control
 yeniakit.com.tr###masthead-outer
-star.com.tr,aksam.com.tr###masthead-wrapper
+log.com.tr,star.com.tr,aksam.com.tr###masthead-wrapper
 tgrthaber.com.tr###masthead_div
 haberler.com,sondakika.com###mustheadAdd
 doviz.com###ngVirgul_660x250
@@ -4029,7 +4010,6 @@ sarkisozlerihd.com##.single-lyric-ads
 kanal42haber.com,hayat.ro,yurtspor.com,tasova.net,kemergozcu.com,brshabermedya.com##.site_onu
 arabadergisi.com##.slider-reklam
 turkrus.com##.sol_reklamlar
-eksisozluk.com##.sponsored
 andante.com.tr##.switching-banner-group
 r10.net##.tablosifir a[rel="nofollow"] > img
 webmasto.com##.td-banner-wrap-full


### PR DESCRIPTION
/wp-content/uploads/*.gif
/wp-content/uploads/*.mp4
##.sponsored
/sex*.png
/suv.js
/popup.js (refdomain1.xyz, refdomain3.xyz, refdomain4.xyz, uzakdogu.tv DOESN'T work, that's why I didn't add)
/pop.php (all domains doesn't work, that's why I didn't add)
###masthead-wrapper
##div[align="center"] > a[target="_blank"] > img
##.wt-masthead__horizontal
/ads/