### PR TITLE
Dead domains (1)

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -8,9 +8,9 @@
 !
 ! Images hosting. Used for advertising on many sites
 !+ NOT_OPTIMIZED
-://i.hizliresim.com^$domain=filmsezonu.com|bestdizi.net|bifilmizlesene.net|tekparthd.net|ajans32.com|limitsizfilmizle.net|haber32.com.tr|buyuktorbali.com|technopat.net|ertehaber.com|duzcetv.com|unyenethaber.com|medyayenigun.net|haberant.com|dizilost.com|medya32.com|balfilmizlet.com|malatyamegahaber.com|filmjr1.com|zerotikk.com|jokerfilmizle.com
+://i.hizliresim.com^$domain=filmsezonu.com|bestdizi.net|tekparthd.net|ajans32.com|haber32.com.tr|buyuktorbali.com|technopat.net|ertehaber.com|duzcetv.com|unyenethaber.com|medyayenigun.net|haberant.com|dizilost.com|medya32.com|balfilmizlet.com|malatyamegahaber.com|filmjr1.com|zerotikk.com|jokerfilmizle.com
 !+ NOT_OPTIMIZED
-://i.resimyukle.xyz^$domain=rexfilmizle.com|unyenethaber.com
+://i.resimyukle.xyz^$domain=unyenethaber.com
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/5969
 /images/banner/*$domain=haberinadresi.com|yalovagazetesi.com|diyarinsesi.org|46haber.com|haber46.com.tr|cukurovaexpres.com|ciddigazete.com|karamangundem.com|tercihiniyap.net|alanyapostasi.com.tr|pratikhaber.com|sonhaber.eu
@@ -39,7 +39,7 @@ lawanda.info###details > p[style^="background-color:"][style*="font-weight: bold
 ! ##.advert
 kanal42haber.com,larende.com,kemergozcu.com,otohaber.com.tr,lha.com.tr,aktifbulten.com.tr,antalyasonhaber.com,haberetanik.com,tevhidgundemi.com,hakimiyet.com,gaziantep27.net,sektorankara.com,olay53.com,olayrize.com,akcaabatinsesi.com,haberzamani.net,avazturk.com,ereglimetro.com.tr,aydinhedef.com.tr,lojiport.com,ngazete.com,marastanhaber.com.tr,sosyalmanset.com,nutuk.com.tr,yenikapihaber.com,ilgazetesi.com.tr,hakkariobjektifhaber.com,tasova.net,hakkarihabertv.com,karamanhabercisi.com,marasgundem.com.tr,sivasbulteni.com,detaykibris.com,wanhaber.com,elazighaber.com,virahaber.com,61trabzonhaber.com,karsmanset.com,mepanews.com,golbasisongaste.com,yuksekovahaber.com.tr,memleket.com.tr,gazeteguncel.com,dokuzsutun.com.tr,enerjigunlugu.net,buyukkocaeli.com.tr,magazinkolik.com,sakaryahaber.com,ekrangazetesi.com,kamuhabermerkezi.com,isilanlarikariyer.com,haberine.com,konyaninsesi.com.tr,siyasetcafe.com,denizhaber.net,optimushaber.com,gunboyugazetesi.com.tr,agazete.com.tr,aktuelpsikoloji.com,banazguncelhaber.com,kibris724.com,takvim.com.tr,aydin24haber.com,agrisoz.com,diyarinsesi.org,turkiyeegitim.com,liderhaber.org,nazillihavadis.com,koylerim.com,yeniasir.com.tr,medyatrabzon.com,ahaber.com.tr,risalehaber.com,bilecikhaber.com.tr,sanalkurs.net,pusulahaber.com.tr,bolgegundem.com,mymemur.com.tr,olay.com.tr,saglikaktuel.com,afyonanahaber.com.tr,merhabahaber.com,sariyermanset.com,haberartiturk.com,yeniduzen.com,analizmerkezi.com,bafra55.net,atv.com.tr,ajans32.com,aspor.com.tr,dengegazetesi.com.tr,haberay.com.tr,istanbulhaber.com.tr,kargohaber.com,malatyaguncel.com,medyaege.com.tr,memurpostasi.com,ozgurkocaeli.com.tr,pazar53.com,sabah.com.tr,teknolojic.com,ulkucumedya.com,ulusalpost.com,yenicaggazetesi.com.tr,ajansbesiktas.com##.advert
 ! ##body .banner
-bilecikhaber.com.tr,bursahakimiyet.com.tr,igfhaber.com,yenidonem.com.tr,insaatderyasi.com,borsatek.com,dizilab8.*,yeniduzen.com,abcgazetesi.com,memleket.com.tr,anadoludabugun.com.tr,egelife.com,halktv.com.tr,karar.com,haberciniz.biz,cevapla.tv,yurtgazetesi.com.tr,malatyaguncel.com,tozlumagazin.net,konyaninsesi.com.tr,bbnhaber.com.tr,bolgegundem.com,otuzbeslik.com,favorifilm.com,nefisyemektarifleri.com,bnhaber.com.tr,sektorankara.com,mansethaber.com,kibrispostasi.com,akcaabatinsesi.com,gununyalanlari.com,sosyalhalisaha.com,labmedya.com,lojiport.com,ertehaber.com,vandahaber.com,beyazgazete.com,sacintarzin.com,yesiligdir.com,perakende.org,hdfilmizle3.com,hakkariobjektifhaber.com,hakkarihabertv.com,karamanhabercisi.com,yarimadagazetesi.com,marasgundem.com.tr,sinematuru.com,enerjigunlugu.net,ulastirmadunyasi.com,fotospor.com,wanhaber.com,virahaber.com,61trabzonhaber.com,buyukkocaeli.com.tr,fullhdfilmdeposu.com,filmifullizle.tv,fanatik.com.tr,erasmusu.com,bolugundem.com,coin-turk.com,expsex.com,ozgurkocaeli.com.tr,polatbuyukarslan.com,aofsoru.com,kocaeligazetesi.com.tr,antalyaburada.com,bafra55.net,airporthaber.com,magazinkolik.com,netgazete.com,oyungemisi.com,pudra.com,sabah.com.tr,televole.com,tgrthaber.com.tr,yeniakit.com.tr,neoldu.com##body .banner
+bilecikhaber.com.tr,bursahakimiyet.com.tr,igfhaber.com,yenidonem.com.tr,insaatderyasi.com,borsatek.com,dizilab8.*,yeniduzen.com,abcgazetesi.com,memleket.com.tr,anadoludabugun.com.tr,egelife.com,halktv.com.tr,karar.com,haberciniz.biz,cevapla.tv,yurtgazetesi.com.tr,malatyaguncel.com,tozlumagazin.net,konyaninsesi.com.tr,bbnhaber.com.tr,bolgegundem.com,otuzbeslik.com,nefisyemektarifleri.com,bnhaber.com.tr,sektorankara.com,mansethaber.com,kibrispostasi.com,akcaabatinsesi.com,gununyalanlari.com,sosyalhalisaha.com,labmedya.com,lojiport.com,ertehaber.com,vandahaber.com,beyazgazete.com,sacintarzin.com,yesiligdir.com,perakende.org,hakkariobjektifhaber.com,hakkarihabertv.com,karamanhabercisi.com,yarimadagazetesi.com,marasgundem.com.tr,sinematuru.com,enerjigunlugu.net,ulastirmadunyasi.com,fotospor.com,wanhaber.com,virahaber.com,61trabzonhaber.com,buyukkocaeli.com.tr,fullhdfilmdeposu.com,filmifullizle.tv,fanatik.com.tr,erasmusu.com,bolugundem.com,coin-turk.com,expsex.com,ozgurkocaeli.com.tr,polatbuyukarslan.com,aofsoru.com,kocaeligazetesi.com.tr,antalyaburada.com,bafra55.net,airporthaber.com,magazinkolik.com,netgazete.com,oyungemisi.com,pudra.com,sabah.com.tr,televole.com,tgrthaber.com.tr,yeniakit.com.tr,neoldu.com##body .banner
 ! ##div[class^="banner_"]
 havaturkiye.com,mersinhaber.com,siirtpress.com,merhabahaber.com##div[class^="banner_"]
 ! ##div[class^="advert_"]
@@ -47,9 +47,9 @@ larende.com,sonses.tv,anamurekspres.com,avrupabulten.com,sakinca.com,gazetebanka
 ! ##.ads
 diyarbakirgazete.com,konupara.com,cumrapostasi.com,yeniakit.com.tr,sinemafilmizle.net,degisimgazetesi.com.tr,esporlab.com,havadurumu15gunluk.org,voleybolmagazin.com,londragazete.com,bursahayat.com.tr,trt1.com.tr,noktabursa.com.tr,anlikaltinfiyatlari.com,imzagazetesi.com.tr,pasada.com.tr,guzelankaram.com,theanatoliapost.com,biricerik.com,memoryhackers.org,haberank.net,yenidonem.com.tr,kediportal.com,slideplayer.biz.tr,sakarya360.com,yeniakit.com.tr,bigunhaber.com,trendoa.com,son32.com,emlaknews.com.tr,cagingazetesi.com.tr,sabahhaberi.com,sonsaat.com.tr,medyaankara.com,erotikfilmtube.com,anadolugunluk.com,kentgazetesi.com,kesinkarar.com,davetmedya.com,fatsaduruhaber.com,bursverenkurumlar.com,mengen.gen.tr,bodrummuhabiri.com,belekomahaber.com,capital.com.tr,canlimobeseizle.com,kadinhalleri.com,nallihanhaber.com,muhabir26.com,gundembursa.com,pgnhaber.com,genmedya.com,uyan32.com,selcukhaber.com,webhakim.com,ibrala.com,hatayzafer.com.tr,ulakci.com,haberyum.com,yozgatses.com,turkulus.com,forumotomobil.com,bodrumolay.com,akvaryum.com,zobakit.com,uyumhaber.com,kmarashaber.com,yenimeram.com.tr,vivaldimagazin.com,tafdi.net,gzt.com,thebrandage.com,gamer.com.tr,direkizleyin.com,medyafaresi.com,indir.com,bjk.com.tr,bursadabugun.com,emlakeki.com,gercekgundem.com,haber7.com,internethaber.com,memurhaber.com,webtekno.com##.ads
 ! ##.footer-sticky
-1080pfilmizle.me,xxfilmizle.com,filmgezegeni.org,fullhdizle.*,vipfilmlerizleme.*,sportsregg.com,altyazilifilm.*,filmihdizlet.com,rexfilmizle.com,sineturk1.com,fullizlefilmizle.com,fullhizlifilmizlesen.com,hdcehennem.com,cilekfilm.com##.footer-sticky
+1080pfilmizle.me,xxfilmizle.com,filmgezegeni.org,fullhdizle.*,vipfilmlerizleme.*,sportsregg.com,altyazilifilm.*,sineturk1.com,fullhizlifilmizlesen.com##.footer-sticky
 ! ##.rek
-kadikoygazetesi.com,oyunrota.com,imzagazetesi.com.tr,davahaber.com,sabahhaberi.com,canlihaber.com,milligazete.com.tr,hotstream.club,bidunyahaber.net,kocaeliseffaf.com,kadikoygazetesi.com,kartalgazetesi.com,kirkbir.com,wfilmizle.net,cagdaskocaeli.com.tr,kocaelihaberdunyasi.com##.rek
+kadikoygazetesi.com,oyunrota.com,imzagazetesi.com.tr,davahaber.com,sabahhaberi.com,canlihaber.com,milligazete.com.tr,hotstream.club,bidunyahaber.net,kocaeliseffaf.com,kadikoygazetesi.com,kartalgazetesi.com,kirkbir.com,cagdaskocaeli.com.tr,kocaelihaberdunyasi.com##.rek
 ! ##.rkm
 ozgunkocaeli.com.tr,karamandan.com,olaymedya.com,kocaelifikir.com,dirilispostasi.com,kocaelidenge.com,kocaelibarisgazetesi.com,nevsehirkenthaber.com,gazianteptime.com.tr,canlihaber.com,rhaajans.com,nazillipost.com,spor264.com.tr,geyvelim.com,hbrcaldiran.com,nnchaber.com,turkiyehaberi.com,habertakvimi.com,yesilgiresun.com.tr,ozgurkocaeli.com.tr,buyukkocaeli.com.tr,vanhavadis.com,kpsscafe.com.tr,forapost.com,okuhaber.com,akyazi.net,cagdaskocaeli.com.tr,haberlerankara.com,seskocaeli.com,kocaelizirve.com,yenialanya.com,t54.com.tr,haber266.com,safihaber.com,nazilliadalet.com,bizimyaka.com,akdeniztelgraf.com,ispartamhaber.com,haberhurriyeti.com,mercekhabergazetesi.com,gaziantepinhabercisi.com,gurbettekierzurum.com.tr,haberaydin.com,lidergazetesi.com,haberso.com,aydingazetesi.com,aydinyenihaber.com,haber28.com,netgaste.com,sakaryadanhaber.com,erzurumhaber.com.tr,yenidevir.com.tr,golcukgundem.com,elbistanolay.com,cthaber.com,mihraphaber.com,pamukovahalk.com,medyabar.com,bgazete.com.tr,kartepegazetesi.com.tr,istekocaeli.com,mansetaydin.com,sesgazetesi.com.tr,bugunkocaeli.com.tr,kocaeligazetesi.com.tr,milligazete.com.tr,hbrma.com,tanisgazetesi.com.tr,elbistankaynarca.com,guncelkocaeli.com,enkocaeli.com##.rkm
 ! ##.ad
@@ -80,13 +80,13 @@ filmifullizle.club##a[href="/filmifullizle.php"]
 /video_ob*.js$domain=realfilmizleme.com|babafullfilmizleme.com|720p-fullhdizleme.com
 /ft*.js$domain=realfilmizleme.com|babafullfilmizleme.com|720p-fullhdizleme.com
 /js/minipop.js$domain=webteizle1.com|sezonlukdizi*.com
-/speed/like-ajax.php$domain=filmizlemetv.com|filmkusu.org
+/speed/like-ajax.php$domain=filmizlemetv.com
 /i/*.mp4$domain=webteizle1.com|sezonlukdizi*.com
 /binanceps.jpg$domain=filmmakinesi.*|turkcealtyazi.org
 /files/uploads/advert/*$domain=larende.com|anamurekspres.com|kemergozcu.com
 /wp-content/uploads/*/video*.gif$domain=hulali.net|nikecr7.com
 /wp-content/uploads/*.gif$domain=cdn.diziyou.com|hdfilmcehennemi2.*|geyvemedya.com
-/wp-content/uploads/*.mp4$domain=siyahfilmizle.*|kalitelifilmizle.net
+/wp-content/uploads/*.mp4$domain=siyahfilmizle.*
 /sex*.png$domain=filmoneriler.com|fullsexfilmleri.com
 /suv.js$domain=sinemafilmizle.net|filmmoduu.com
 /popup.js$domain=buzfilmizle1.com|bayfilmizle1.com
@@ -326,12 +326,8 @@ vipfilmlerizleme.*###iframe-reklam
 canlialtinfiyatlari.com##div[style="display:block;margin:10px 0;height:280px;"]
 tlkur.com##div[style="display:block;height:290px;margin:10px 0;"]
 pifilmizle.com##.ustrek
-filmkusu.org##div[class^="spnsr"]
-filmkusu.org##div[id^="spnsr"]
-filmkusu.org##.spnsr-text
-filmkovasi.org,filmkusu.org###likexajax
+filmkovasi.org###likexajax
 ||filmkovasi.org/integration/like-ajax.php
-||filmkusu.org/wp-content/uploads/betwoon.mp4
 filmzal.*,dizimax.net##.mst_ad
 ||dizimax.net/adservice/
 ||dizimax.net/wp-content/*/js/popr.js
@@ -473,12 +469,9 @@ insaatnoktasi.com##.ads-full-banner
 bamfilmizle.com###fixedban
 inploid.com##div[class="gadbox wboxed"]:not([id])
 bedavapdfkitap.com##center > div > a[rel="nofollow"]
-||ifilmizle.org/asd.js
 kayserihaber38.com###reklamHD
 ||puffytr.com/js/popup-
 yenibiris.com##div[class^="text-center list-ban-"]
-||dafflix.com/olley.mp4
-||dafflix.com/daffpop4.js
 arabalar.com.tr###sag-reklam
 bantmag.com###MenuAlti
 sozcu.com.tr##.adInitRemove
@@ -492,7 +485,7 @@ nedemekla.com##.reklam-336x300
 ||i.ibb.co/FnmQPJG/standard.gif
 darkcrew.org##div[style="text-align:right"] > center > a > img
 iyihisset.com##.top_banner
-1080pfilmizle.me,dafflix.com,hdfilmcehennemi2.*##.player-ustu-metin > a[rel="nofollow"]
+1080pfilmizle.me,hdfilmcehennemi2.*##.player-ustu-metin > a[rel="nofollow"]
 hdfilmcehennemi2.*##.player-alti-metin > a[rel="nofollow"]
 formsante.com.tr###td-outer-wrap > div[class^="mob-"]
 memoryhackers.org##.ads-header
@@ -632,7 +625,6 @@ warezturkey.org##center > a[target] > img
 gittigidiyor.com##div[id^="div-ad-"]
 emlaklobisi.com###regular-header > div.container> div.widget-header
 indirin.co##a[href^="https://www.linkonclick.com/jump/next.php"]
-||hdfilmcehenemi.net/dolmus.js
 hurriyetdailynews.com,hurriyet.com.tr##.advMasthead
 hdfilmcehennemi.*##.card-money
 hdfilmcehennemi.*##.money-text
@@ -745,7 +737,6 @@ spyhackerz.org##.p-body > .p-body-inner > div[style="text-align: center"] > a.li
 ||i.ibb.co/*/kitap-banner.gif$domain=spyhackerz.org
 kriptokoin.com##.widget_viewedimages ~ div.widget
 kriptokoin.com##a[href^="https://www.bitci.com/"]
-filmoyunindir.com##img[width="530"][height="245"]
 yenicaggazetesi.com.tr##.sidebar > div[class="space-3 flex center margin-bottom-md"]
 yenicaggazetesi.com.tr##.container > div[class="space-2 flex center margin-bottom-md"]
 ||yenicaggazetesi.com.tr/d/other/cnt.jpg
@@ -964,7 +955,6 @@ sozcu.com.tr##.bitci-bar
 fontyukle.net##div[class^="sag-ust"]
 turizmhaberleri.com##img[width="820"][height="120"]
 turizmhaberleri.com##img[width="300"][height="250"]
-||betlox.com^$domain=favorifilm.com
 yumurtaliekmek.com##._pubserver_div
 forum.sordum.net,lezizci.com,bilgidem.com##div[data-zone]
 /files/images/banner-*.jpg$domain=bilgidem.com|lezizci.com
@@ -985,7 +975,7 @@ lojistikhatti.com##img[alt="Banner"]
 ||lojistikhatti.com/images/WCA-Digital-Banner.jpg
 bakimlikadin.net##.extra-posts
 ||indirmedenfilmizle.vip/pop06.js
-erotik123.com,erotikizlefilm.com,yetiskinfilmizle.net,erotikfilms.net,erotizmfilmleri.net,erotik-film.org,yetiskinfilmler.org,erotiksexfilmizle.com,hdsexfilmizle.com##div[id] a[href^="https://www.google.com/url"]
+erotik123.com,erotikizlefilm.com,yetiskinfilmizle.net,erotizmfilmleri.net,erotik-film.org,yetiskinfilmler.org,hdsexfilmizle.com##div[id] a[href^="https://www.google.com/url"]
 shiftdelete.net##.nokta-display-ad
 ||zakcdn.com/rk/ara.gif$domain=edarm.com
 ||akhisarpress.com/reklam/
@@ -996,8 +986,8 @@ gaziantephaber.com,bartinolay.com##div[class*="_greklam "]
 nefisyemektarifleri.com##div[style="height:265px; text-align: center;"]
 hayvansitesi.com##div[style^="float:left;"][style*="width:300px;"]
 ilan365.net##div[style^="min-height:300px;margin-top:"]
-filmsokagi.org,filmizlemetv.com###Oncvideo
-filmkusu.org,filmizlemetv.com##.abcdarkadas
+filmizlemetv.com###Oncvideo
+filmizlemetv.com##.abcdarkadas
 ilacprospektusu.com##.rrReklam
 ilacprospektusu.com##.altReklam
 rasthaber.com##div[style="min-height: 120px;"]
@@ -1479,7 +1469,6 @@ iddaakulubu.com##div[style="width: 1290px; "] > a[href][rel="external"][target="
 ||filmlane.com/wp-content/uploads/*/933x90_tb.gif
 somaaktuel.com##.reklammenualti
 gorunumgazetesi.com.tr##div[style^="width:990px; height:90px;"]
-||full1080pfilmizle.com/wp-content/uploads/*/*x*-akbet.gif
 r10.net##.text-center.dblck
 fullhdfilmsitesi.live##.yanbar
 ||fullhdfilmsitesi.live/cloudflare/loader/
@@ -1659,10 +1648,6 @@ tunceliemek.com.tr##.reklam-body-left1
 tunceliemek.com.tr##.container > .intitation > div[style^="background-image:"]
 kandiragundem.com##div.hbrad
 1080hdfilmizle.com##div[align="center"] > a[href][target="_blank"] > img
-dafflix.com##body > div[data-type="pgskin"]
-dafflix.com##.right.floated > div[data-gets] > a[href][target="_blank"] > img
-||dafflix.com/akk.gif
-||dafflix.com/2rek.webp
 ||canli-betboo-pw.cdn.ampproject.org/i/s/canli.betboo.pw/rek/
 tekirdagodak.com##.last-sidebar-right > img[alt="Reklam"]
 tekirdagodak.com##.last-sidebar-right > img[width="100%"][height="70%"]
@@ -1798,7 +1783,6 @@ filmbil.com##.video-content > center > p[style^="background-color:"]
 haberglobal.com.tr##.related-news-container
 casinokazan.net##.ustbar
 casinokazan.net##.onerilenler
-dafflix.com##.rek-wrap > *:not(b)
 r10.net##li[id^="sponsorReklam"]
 kirkbir.com##div[id="sol_rek"]
 kirkbir.com##div[id="sag_rek"]
@@ -1826,7 +1810,6 @@ gazeteyenigun.com.tr###header-advertise
 yesiligdir.com##.asd
 ||ekoyapidergisi.org/banner/
 magazin.com.tr##div[class^="googlead_"]
-wfilmizle.net##.videoust > .player-ustu-metin
 ||mersinhaber.com/depo/banner/
 ||memurlar.net/common/widget-image/yayla/*x*/index.html
 hibya.com##iframe[src="https://hibya.com/banner.htm"]
@@ -1836,7 +1819,6 @@ filmindirhd.org##.fstory-content > div.clearfix + br + div
 filmindirhd.org##.swal-overlay
 fullhdfilmmodu.org##.sidebarreklam
 ||fullhdfilmmodu.org/*/redwin-youtube.mp4
-favorifilm.com##body > p[align="center"] > a[target="_blank"] > img
 upslut.com##center > a[rel="nofollow"] > img
 ||medimagazin.com.tr/templates/default/banners/tk_da/medimagazinreklam_hype_generated_script.js
 ||perakende.org/storage/banners/
@@ -1879,7 +1861,6 @@ kimkimdir.net.tr##.single-kablonet
 derszamani.net,hemhalkegitim.com##.singleBlock
 ||realizle.site/betmatik2.mp4
 netfilmtvizle.com##center > a[href][target="_blank"] > img[alt="poker oyna"]
-dafflix.com##.rek-0
 sirketlerligi.com##.bannerzone
 ||hdfilmcehennem.com/reklams/
 8gunhaber.com##img[width="336"][height="196"]
@@ -1914,7 +1895,6 @@ r10.net##.container > .rPanel > a[href][rel="nofollow"] > img
 r10.net###inlinemodform > .announcements + div[class] > span > a[href][target="_blank"] > img
 r10.net##footer > .container > .iconArea ~ div[class] > div[class] > a[href][rel="nofollow"] > img
 r10.net##footer > .container > .iconArea ~ div[class] > div[class] > a[href][target="_blank"] > img
-||hdfilmizle3.com/banner/
 kenttv.net##a[href^="https://kenttv.net/reklam/"]
 ||sondakika.com/widget/backup/backup_*.aspx
 ||liderhaber.org/kredih/kredihaber.html
@@ -1994,7 +1974,7 @@ aydinlatma.org##.dikreklamsag
 aydinlatma.org##.a-single
 aydinlatma.org##div[style^="width:970px; height:"]
 aydinlatma.org##div[style="width:640px; height:320px;"]
-dayifullfilmizle.com,full1080pfilmizle.com,vipfilmlerizle.com##div[data-nopop]
+dayifullfilmizle.com,vipfilmlerizle.com##div[data-nopop]
 elektriktesisatportali.com##.banner-alani
 akvaryum.com##.adflashsag
 akvaryum.com##.banners-index
@@ -2140,7 +2120,6 @@ animex.club##iframe[src="https://www.animex.club/reklamEngine.php"]
 dizitube.net,netfilmtvizle.com###popup-reklam a[href]
 oyuncukuru.org##.theiaStickySidebar > aside#text-4
 messletters.com###addTop
-full1080pfilmizle.com##a[href^="https://www.jull.com.tr"] > img
 karadenizgazete.com.tr##.adversAreaa
 haberglobal.com.tr##.masthead-banner
 tafdi.net##.vidalt-ads
@@ -2810,7 +2789,7 @@ emlaktagundem.com###leftTable > h1[style="font-weight:bold; font-family: 'Verdan
 sahibinden.com##.header-banners
 ||sakaryarehberim.com/pictures/hbdreklam/
 ||sakaryarehberim.com/pictures/srreklam/
-filmfiz.net,full1080pfilmizle.com,dizitube.net,netfilmtvizle.com,hdfilmdeposu.tv###videoreklam
+filmfiz.net,dizitube.net,netfilmtvizle.com,hdfilmdeposu.tv###videoreklam
 ||petroturk.com/wp-content/uploads/*/tora-banner-*.gif
 ||ilkfullfilmizle*.com/rklm/*.html
 ceptenmp3.net##a[href^="https://www.onclickmega.com/"]
@@ -3307,9 +3286,8 @@ radyodinle.com###adds
 showradyo.com.tr##.wrapper_right
 showradyo.com.tr##.wrapper_left
 ||imgim.com/451m9h.jpg
-full1080pfilmizle.com,filmizlex.com,acunn.com,canliradyodinle.web.tr##.banner2
+filmizlex.com,acunn.com,canliradyodinle.web.tr##.banner2
 canliradyodinle.web.tr##.container.header970
-bifilmizlesene.net##.KODDOSTU-FIX
 autoshow.com.tr###text-39
 autoshow.com.tr###text-49
 autoshow.com.tr###text-35


### PR DESCRIPTION
bifilmizlesene.net
limitsizfilmizle.net
rexfilmizle.com
favorifilm.com
hdfilmizle3.com
filmihdizlet.com
fullizlefilmizle.com
hdcehennem.com
cilekfilm.com
wfilmizle.net
filmkusu.org (redirects to filmizlemetv.com which has active rules in filter; so rules related to this domain are useless)
kalitelifilmizle.net (site content are different, maybe site view changed)
ifilmizle.org
dafflix.com
hdfilmcehenemi.net
filmoyunindir.com
erotikfilms.net (this domain redirects to erotikfilmizle1.com, so rules related to this domain are useless)
erotiksexfilmizle.com
filmsokagi.org
full1080pfilmizle.com