### PR TITLE
fix breakage on vip.de

### DIFF
--- a/SpywareFilter/sections/whitelist.txt
+++ b/SpywareFilter/sections/whitelist.txt
@@ -351,7 +351,7 @@ ntp.msn.com#@%#navigator.getBattery = undefined;
 ! http://forum.ru-board.com/topic.cgi?forum=5&topic=50480&start=1420#13
 @@||chat-webim.rsb.ru/l/v/track.php?
 ! https://github.com/AdguardTeam/AdguardFilters/issues/103991
-@@||technical-service.net/api?$domain=n-tv.de
+@@||technical-service.net/api?$domain=n-tv.de|vip.de
 ! https://github.com/AdguardTeam/AdguardFilters/issues/105034
 @@||cdn.clerk.io/clerk.js$domain=batteribyen.dk|batterionline.no|batterionline.se
 ! https://github.com/AdguardTeam/AdguardFilters/issues/106697


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

Video can’t be played `https://www.vip.de/videos/vip-videos/die-katze-zeigt-ihren-nackten-hintern-62946778ae14b0115701e2d2.html`

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

  - [ ] Missed ads or ad leftovers;
  - [x] Website or app doesn't work properly;
  - [ ] AdGuard gets detected on a website;
  - [ ] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc;
  - [ ] Filters maintenance.

### What issue is being fixed?
##### Enter the issue address:

no issue in the issue tracker

### Add your comment and screenshots
##### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located.

same as https://github.com/AdguardTeam/AdguardFilters/issues/103991

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.