### PR TITLE
fix anti adblock on francaisfacile.net

### DIFF
--- a/FrenchFilter/sections/antiadblock.txt
+++ b/FrenchFilter/sections/antiadblock.txt
@@ -17,6 +17,8 @@ capital.fr#@#.plainAd
 !
 !
 !
+! https://www.reddit.com/r/uBlockOrigin/comments/v2b6l4/asking_to_unblock_the_adblocker/
+francaisfacile.net#%#//scriptlet("prevent-addEventListener", "DOMContentLoaded", "Adblock")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/118024
 @@||parlons-basket.com/wp-content/*/js/prebid-ads.js
 parlons-basket.com#%#//scriptlet("set-constant", "canRunAds", "true")


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

Adblock get detected `https://francaisfacile.net/`

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

  - [ ] Missed ads or ad leftovers;
  - [ ] Website or app doesn't work properly;
  - [x] AdGuard gets detected on a website;
  - [ ] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc;
  - [ ] Filters maintenance.

### What issue is being fixed?
##### Enter the issue address:

no issue in the issue tracker

### Add your comment and screenshots
##### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located.

<details>
<img width="808" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/171372349-706a84e9-fa01-491e-9142-1e10c2181a6c.PNG">
</details>

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.