### PR TITLE
fix damoh video ads on vip.de

### DIFF
--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -9,6 +9,8 @@
 !------- JS rules ---------------------!
 !--------------------------------------!
 !
+! https://github.com/uBlockOrigin/uAssets/issues/6541#issuecomment-1140420880
+vip.de#%#//scriptlet('prevent-xhr', 'svonm')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/117511
 nachtkritik.de#%#//scriptlet('set-cookie', 'the_cookie10470', 'true')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/108760


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

fixed video ads on `https://www.vip.de/videos/vip-videos/wie-viel-verdient-eigentlich-twenty4tim-6294c0251acd7457990af7b2.html`

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

  - [x] Missed ads or ad leftovers;
  - [ ] Website or app doesn't work properly;
  - [ ] AdGuard gets detected on a website;
  - [ ] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc;
  - [ ] Filters maintenance.

### What issue is being fixed?
##### Enter the issue address:

no issue in the issue tracker

### Add your comment and screenshots
##### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located.

see https://github.com/uBlockOrigin/uAssets/issues/6541#issuecomment-1140420880

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.