### PR TITLE
fix wetter.com cookie banner issue

### DIFF
--- a/AnnoyancesFilter/sections/cookies_whitelist.txt
+++ b/AnnoyancesFilter/sections/cookies_whitelist.txt
@@ -1823,6 +1823,7 @@ marmaray.gov.tr#@##cookie-law-info-bar
 @@||api.usercentrics.eu/settings/*/latest/*.json$domain=wetter.com|joyn.de|stromseite.de
 @@||api.usercentrics.eu/consent-templates/*$domain=wetter.com
 @@||api.usercentrics.eu/tcf2/*.json$domain=wetter.com
+@@||graphql.usercentrics.eu/graphql$xmlhttprequest,domain=wetter.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/56704
 airfrance.com.tr,airfrance.am,airfrance.be,airfrance.bf,airfrance.bg,airfrance.bj,airfrance.ca,airfrance.cd,airfrance.cg,airfrance.ch,airfrance.cl,airfrance.co.ao,airfrance.co.il,airfrance.co.jp,airfrance.co.kr,airfrance.co.th,airfrance.co.uk,airfrance.com,airfrance.com.br,airfrance.com.cn,airfrance.com.co,airfrance.com.eg,airfrance.com.hk,airfrance.com.kh,airfrance.com.lb,airfrance.com.mx,airfrance.com.tw,airfrance.com.uy,airfrance.cz,airfrance.de,airfrance.es,airfrance.fr,airfrance.gf,airfrance.gp,airfrance.ht,airfrance.hu,airfrance.id,airfrance.it,airfrance.mq,airfrance.mu,airfrance.my,airfrance.nc,airfrance.ne,airfrance.pa,airfrance.pe,airfrance.pf,airfrance.pl,airfrance.pt,airfrance.re,airfrance.ro,airfrance.ru,airfrance.sa,airfrance.sg,airfrance.si,airfrance.tg,airfrance.ua,airfrance.us,airfrance.vn#@#.gdpr-container
 ! https://github.com/AdguardTeam/AdguardFilters/issues/56714


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

The cookie banner can be accepted but it appears every time again after a new site got opened. Fixed it
`https://www.wetter.com/`

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

  - [ ] Missed ads or ad leftovers;
  - [x] Website or app doesn't work properly;
  - [ ] AdGuard gets detected on a website;
  - [ ] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc;
  - [ ] Filters maintenance.

### What issue is being fixed?
##### Enter the issue address:

no issue in the issue tracker

### Add your comment and screenshots
##### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located.

<details>

<img width="568" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/172058784-dceebbbe-2662-48a2-ba0c-1bacf71386e2.PNG">

</details>

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.