### PR TITLE
Added Video Ad Network

### DIFF
--- a/EnglishFilter/sections/adservers_firstparty.txt
+++ b/EnglishFilter/sections/adservers_firstparty.txt
@@ -7,6 +7,7 @@
 ! Bad: ||legitwebsite.com^$third-party (should be in adservers.txt)
 !
 !
+||ad.vidverto.io^
 ||ads.vidoomy.com^
 ||veih8bee.xhcdn.com^
 ||qontent.pomvideo.cc^


### PR DESCRIPTION
Their homepage: https://vidverto.io/

I saw the _**ad.vidverto.io**_ in NextDNS logs.

You can see the entry in other blocklists.
https://blocklist-tools.developerdan.com/entries/search?q=ad.vidverto.io