### PR TITLE
Duplicate mobile rules deleted

### DIFF
--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -831,7 +831,6 @@
 ||mads.bz^
 ||mainadv.com^
 ||manage.com^
-||marketplace-ios-*.hyprmx.com^
 ||maudau.com^
 ||mbn.com.ua^
 ||mdotm.com^

--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -821,7 +821,6 @@
 ||lgse.com^
 ||liftdna.com^
 ||ligatus.com^
-||live.hyprmx.com^
 ||loopme.me^
 ||luxadv.com^
 ||luxup.ru^

--- a/MobileFilter/sections/css_extended.txt
+++ b/MobileFilter/sections/css_extended.txt
@@ -134,7 +134,6 @@ noticias.uol.com.br#?#body .tm-ads
 news18.com#?#.article_main > div[class^="jsx-"][style*="min-height:"] > .OUTBRAIN:upward(1)
 pcgames.de#?#.disrupter-Color-OrangeReview > a:has(> .textFrame > .articleInfo > .autorName:contains(Anzeige))
 pcgames.de#?#.articleTicker > .item:has(> .textFrame > .articleInfo > .at_sponsored)
-grapee.jp#?#aside > div[class^="mod-ads-area"]:upward(1)
 2chan.net#?#.ui-li > iframe[src^="//dec.2chan.net/bin/"]:upward(1)
 news.tv-asahi.co.jp#?##common-header > #adbanner_spheader:upward(1)
 qiita.com#?#.p-items_main > div > div > div > div > div#dfp-slot-article-after-body-for-mobile:upward(4)

--- a/MobileFilter/sections/general_extensions.txt
+++ b/MobileFilter/sections/general_extensions.txt
@@ -91,8 +91,6 @@ m.tnaflix.com#%#//scriptlet("set-constant", "exoUrl", "undefined")
 m.tnaflix.com#%#//scriptlet("set-constant", "organicPop", "undefined")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/47217
 m.drtuber.com#%#//scriptlet("abort-on-property-read", "mobileAdvPop")
-! https://github.com/AdguardTeam/AdguardFilters/issues/45869
-m.nuvid.*#%#//scriptlet("abort-on-property-read", "mobileAdvPop")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44470
 m.spankbang.com#%#document.cookie = "bbm_pp_mobile=1; path=/";
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42640
@@ -102,7 +100,6 @@ pornhd.com#%#//scriptlet("abort-on-property-read", "popUnderUrl")
 tube8.com#%#AG_onLoad(function() { if(window.location.href.indexOf("/interstitial/") != -1){ var el = document.querySelector('a[href].continue-to-video');if(el){el.click();} } });
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30369
 m.hd21.com#%#document.cookie = "adv_show=3";
-m.hd21.com#%#//scriptlet("abort-on-property-read", "mobileAdvPop")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22801
 iqiyi.com#%#document.cookie = "i18nGuideApp=true";
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24463

--- a/MobileFilter/sections/general_url.txt
+++ b/MobileFilter/sections/general_url.txt
@@ -45,9 +45,6 @@
 ||runnergamesch.com/*/BasCount/adAll
 ||sinst.fwdcdn.com/_uploaded_files/ads/
 ||smart.tinyhoneybee.com/log/
-||startappexchange.com/*/getadsmetadata
-||startappexchange.com/*/gethtmlad
-||startappexchange.com/tracking/adClick?d=
 ||tb.beeline.ru/Scripts/App/AnchorCompiled.min.js
 ||youtube.com/api/stats/ads
 ! Facebook Ad Choices

--- a/MobileFilter/sections/general_url.txt
+++ b/MobileFilter/sections/general_url.txt
@@ -48,8 +48,6 @@
 ||startappexchange.com/*/getadsmetadata
 ||startappexchange.com/*/gethtmlad
 ||startappexchange.com/tracking/adClick?d=
-||startappservice.com/*/gethtmlad
-||startappservice.com/InApp/
 ||tb.beeline.ru/Scripts/App/AnchorCompiled.min.js
 ||youtube.com/api/stats/ads
 ! Facebook Ad Choices

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -263,7 +263,6 @@
 ||graph.facebook.com^$app=com.hyperionics.avar
 ||graph.facebook.com^$app=ace.jun.shortcuts
 ||graph.facebook.com^$app=com.chess
-||graph.facebook.com^$app=com.idea.backup.smscontacts
 ||graph.facebook.com^$app=com.altshift.notnot
 ||graph.facebook.com^$app=free.vpn.unblock.proxy.vpn.master.pro
 ||graph.facebook.com^$app=com.avira.android
@@ -315,7 +314,6 @@
 ||graph.facebook.com^$app=es.rafalense.themes
 ||graph.facebook.com^$app=com.xoopsoft.apps.bundesliga.free
 ||graph.facebook.com^$app=com.trungpt.video.download
-||graph.facebook.com^$app=com.devexpert.weather
 ||graph.facebook.com^$app=com.eterno
 ||graph.facebook.com^$app=com.hornet.android
 ||graph.facebook.com^$app=com.jrtstudio.AnotherMusicPlayer

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -609,7 +609,6 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ||mobimagic.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21087
 ||adywind.com^
-||cdn-adn.rayjump.com/cdn-adn/*/offersync^
 ||hasmobi.net^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24182
 @@||imasdk.googleapis.com^|$app=com.nextmediatw

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -758,8 +758,6 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ||wpsconfig4svr.elasticbeanstalk.com/config/android/list?
 ||minfo.wps.cn/minfo/infos.ads?
 ||cloudservice14.kingsoft-office-service.com/onlineParam
-! https://forum.adguard.com/index.php?threads/hd-videobox.20645/
-||startappservice.com/*/getadsmetadata?
 ! https://github.com/AdguardTeam/AdguardFilters/issues/4644
 ||api.hh.ru/banners_targeting
 ! https://github.com/AdguardTeam/AdguardFilters/issues/4572
@@ -803,7 +801,6 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ||gumtree.com/partner/bing?*&adUnitId=
 ||gumtree.com/partner/bingimpression?
 ! AfreecaTV
-||ad.daum.net/imp
 ||afreeca-tag.ad-mapps.com^
 ||mtag.mman.kr^
 ! Zigbang (analytics)

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1387,7 +1387,6 @@ beritasatu.com##.flying_carpet-box
 everyeye.it##header > div.adv-top
 everyeye.it##.banner_destra_mobile
 zeenews.india.com##.outbrain-bg
-m.investing.com##.adDrawer
 nv.ua##.content-wrapper > div#async__head_opinions:empty
 gadgets-ndtv-com.cdn.ampproject.org##amp-iframe[src^="https://apis.kostprice.com/"]
 gadgets-ndtv-com.cdn.ampproject.org##.kpframe
@@ -1998,7 +1997,6 @@ bankier.pl##html[amp-version] .content-center.gray-bg
 mgsm.pl###plus-top-mobile
 ||mgsm.pl/js/get*AdsMobile.xhtml
 m.timesofindia.com##.hzroot
-m.timesofindia.com##iframe#di_iframe
 m.timesofindia.com##.toi-amazon
 m.timesofindia.com##div[data-primead]
 m.ariva.de###siteTeaserLayer

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -2532,7 +2532,6 @@ m.nihaogood.com##.Adinfo
 ||twrailpolice.appspot.com/full_ad_priority.txt
 ||twrailpolice.appspot.com/campaign.xml
 ||54.169.80.245/ad^
-||tw.api.vpon.com/api/webviewAdReq
 m.cna.com.tw##.fancybox-wrap
 m.cna.com.tw##.fancybox-wrap + .fancybox-overlay
 m.cda.pl###reklama_layout_top

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1049,7 +1049,6 @@ mail.ru##.ads-bottom__fixed
 buzzap.jp##.sp_inarticle
 last.fm##.recs-feed-item--ad
 wyniki.sport.pl##.bookmakerContainer
-telegraphindia.com##.adbox310
 telegraphindia.com##.adbox626
 telegraphindia.com###ub-sticky-ad-container
 hensachiterrace.com##.footer_overlay
@@ -1537,7 +1536,6 @@ dcard.tw##div[style="height: 250px; width: auto;"]
 dcard.tw##div[style="height:250px;width:auto"]
 yan.vn##.AdsAppend
 yan.vn##.sticky_bottom
-unian.net##.tabs-with-flex > div#tab1
 unian.net##.tabs-with-flex > div#tabpanel1
 m.mobile01.com##.u-ad-image
 pornone.com##.banner-wrapper
@@ -2459,7 +2457,6 @@ m.accuweather.com##.outer > div[id="top"][class="top lowered"]
 silenceisconsent.net##.z-ad-display
 themercury.com.au##.widget-area-main-content > .tgc-footer-fixed
 m.winfuture.de###main > .mb25.mr5
-m.winfuture.de###main > div[align="center"]
 ||m.fantasti.cc/rb^
 gsp.ro##.banner-branding
 fukuishimbun.co.jp##div[id^="uz-"][id*="fukuishimbun_sp-"]


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Example: 

### Add your comment and screenshots

```
||graph.facebook.com^$app=com.devexpert.weather has been made redundant by ||graph.facebook.com^$app=com.devexpert.weather

||graph.facebook.com^$app=com.idea.backup.smscontacts has been made redundant by ||graph.facebook.com^$app=com.idea.backup.smscontacts

telegraphindia.com##.adbox310 has been made redundant by telegraphindia.com##.adbox310

unian.net##.tabs-with-flex > div#tab1 has been made redundant by unian.net##.tabs-with-flex > div#tab1

m.winfuture.de###main > div[align="center"] has been made redundant by m.winfuture.de###main > div[align="center"]

m.hd21.com#%#//scriptlet("abort-on-property-read", "mobileAdvPop") has been made redundant by m.hd21.com#%#//scriptlet("abort-on-property-read", "mobileAdvPop")

m.nuvid.*#%#//scriptlet("abort-on-property-read", "mobileAdvPop") has been made redundant by m.nuvid.*#%#//scriptlet("abort-on-property-read", "mobileAdvPop")

grapee.jp#?#aside > div[class^="mod-ads-area"]:upward(1) has been made redundant by grapee.jp#?#aside > div[class^="mod-ads-area"]:upward(1)

||live.hyprmx.com^ has been made redundant by ||live.hyprmx.com^

m.timesofindia.com##iframe#di_iframe has been made redundant by m.timesofindia.com###di_iframe

m.investing.com##.adDrawer has been made redundant by investing.com##.adDrawer

||marketplace-ios-*.hyprmx.com^ has been made redundant by ||marketplace-*.hyprmx.com^

||tw.api.vpon.com/api/webviewAdReq has been made redundant by ||tw.api.vpon.com^

||startappservice.com/*/gethtmlad has been made redundant by ||startappservice.com^
||startappservice.com/InApp/ has been made redundant by ||startappservice.com^
||startappservice.com/*/getadsmetadata? has been made redundant by ||startappservice.com^

||ad.daum.net/imp has been made redundant by ||ad.daum.net^

||startappexchange.com/*/getadsmetadata has been made redundant by ||startappexchange.com^
||startappexchange.com/*/gethtmlad has been made redundant by ||startappexchange.com^
||startappexchange.com/tracking/adClick?d= has been made redundant by ||startappexchange.com^

```



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
