### PR TITLE
Fix reveddit.com's error message popup

### DIFF
--- a/AnnoyancesFilter/sections/popups.txt
+++ b/AnnoyancesFilter/sections/popups.txt
@@ -1167,7 +1167,7 @@ askiitians.com###juniorHackerCodingMaster
 fourminutebooks.com##.rm-toaster
 richards.com.br###newsModal
 mizuno.com.br###newUserPopUp
-reveddit.com#$#.ReactModalPortal { display: none !important; }
+reveddit.com#$#.ReactModalPortal:if-not(p:contains(Error)) { display: none !important; }
 reveddit.com#$#body[class*="open"] { overflow: auto !important; }
 skillcrush.com#$##lead-popup { display: none!important; }
 skillcrush.com#$#html { position: static!important; }


### PR DESCRIPTION
reveddit.com shows an error message with a helpful description on
how to fix it when it's unable to connect to reddit.

This change unblocks those popup messages by excluding popups 
that contain "Error".

<details>
<summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/70697865/174856811-1a0586a6-908a-43d4-a2b1-b4447a35386b.png)

</details>