### PR TITLE
tarnkappe.info tracker

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -1040,6 +1040,7 @@
 ||m.trb.com^
 ||ma.news.naver.com^
 ||ma.tarnkappe.info^
+||posthog.tarnkappe.info^
 ||ma.zoho.eu^
 ||magnetrack.klangoo.com^
 ||mamka.aviasales.ru^


### PR DESCRIPTION
### Please include a summary of the change and which issue is fixed.

Tracking from `posthog.tarnkappe.info` on `https://tarnkappe.info/test/vpn-vergleich-2022-ovpn-vs-hide-me-vs-perfect-privacy-als-app-243192.html`

---


### Prerequisites
##### To avoid invalid pull requests, please check and confirm following checkboxes:


  - [x] This is not an ad/bug report;
  - [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
  - [x] I have performed a self-review of my own changes;
  - [x] My changes do not break web sites, apps and files structure.

### What problem does the pull request fix?
##### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

  - [ ] Missed ads or ad leftovers;
  - [ ] Website or app doesn't work properly;
  - [ ] AdGuard gets detected on a website;
  - [x] Missed analytics or tracker;
  - [ ] Social media buttons — share, like, tweet, etc;
  - [ ] Annoyances — pop-ups, cookie warnings, etc;
  - [ ] Filters maintenance.

### What issue is being fixed?
##### Enter the issue address:

no issue in the issue tracker

### Add your comment and screenshots
##### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located.

There is tracking again, now coming from `posthog.tarnkappe.info` (self hosted from `posthog.com`)

### Terms

  - [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met.
