### PR TITLE
www.canalplus.com

### DIFF
--- a/FrenchFilter/sections/antiadblock.txt
+++ b/FrenchFilter/sections/antiadblock.txt
@@ -57,11 +57,6 @@ chat.babel.com#%#//scriptlet('prevent-setTimeout', 'ShowAdvertising')
 @@||googletagmanager.com/gtag/js$domain=chat.babel.com
 @@||adv.123multimedia.com/AdConfig.aspx$domain=chat.babel.com
 !#endif
-! https://github.com/AdguardTeam/AdguardFilters/issues/102748
-qub.ca#$#.adsbox.ad-banner:not([style="height: 5px; width: 5px; position: absolute; top: 0;"]):not(.blocker-tester + .ad-banner) { display: block !important; }
-qub.ca#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }
-!+ PLATFORM(ios, ext_android_cb)
-@@||qub.ca^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/101696
 @@||abcbourse.com/scripts2/prebid.js
 abcbourse.com#$##mywraptest { height: 1px !important; }
@@ -161,10 +156,6 @@ jardiner-malin.fr#%#//scriptlet("set-constant", "wIsAdBlocked", "false")
 @@||cdn-a.yieldlove.com/yieldlove-bidder.js$domain=jardiner-malin.fr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54079
 bleachmx.fr#%#//scriptlet("abort-on-property-read", "mdpDeBlocker")
-! https://github.com/AdguardTeam/AdguardFilters/issues/53934
-@@||proxy.ads.canalplus-bo.net/web/*/advert/?adInfo=$domain=canalplus.com
-@@||v.fwmrm.net/ad/g/1?*&resp=vmap$domain=canalplus.com
-@@||proxy.ads.canalplus-bo.net/web/*/adserver/info/?adInfo=$domain=canalplus.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53875
 @@||leakgaming.fr/js/*/Adsplex-shu.js
 leakgaming.fr#%#//scriptlet("abort-current-inline-script", "$", "!document.getElementById(btoa")
@@ -275,9 +266,6 @@ sante.journaldesfemmes.fr,linternaute.com#$#.AdBox.Ligatus.pub_300x250.pub_300x2
 @@||kweb.r66net.com/getlink|$domain=linternaute.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=linternaute.com
 !#endif
-! https://forum.adguard.com/index.php?threads/15884/
-@@||static.canal-plus.net/resources/adframe.html?adName=$domain=canalplus.com
-@@||proxy.ads.canalplus-bo.net/web/*/adserver/info/?asset=$domain=canalplus.com
 ! https://forum.adguard.com/index.php?threads/m-rtl-be-adguard-mobile.31398/
 @@||service.videoplaza.tv/proxy/bwtest.jpg$domain=rtl.be
 @@||service.videoplaza.tv/proxy/pulse-sdk-html5^$domain=rtl.be
@@ -318,8 +306,6 @@ illicoporno.com#%#window.is_adblocked = false;
 ! https://forum.adguard.com/index.php?threads/www-culture-generale-fr.30064/
 culture-generale.fr#@#.an-advert-banner
 culture-generale.fr#@#.an-sponsored
-! https://forum.adguard.com/index.php?threads/www-rtlplay-be-tvi-humour-rtl-tvi.29736
-@@||be-rtl.videoplaza.tv/proxy/distributor/$domain=rtlplay.be
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25494
 ledauphine.com###adBlockDetect
 ! https://github.com/AdguardTeam/AdguardFilters/issues/22988
@@ -330,15 +316,6 @@ ledauphine.com###adBlockDetect
 @@||vandenbrink.fr^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21648
 @@||reevown.com/vendor/publicite_blog.js^
-! https://github.com/AdguardTeam/AdguardFilters/issues/85384
-! https://github.com/AdguardTeam/AdguardFilters/issues/37231
-@@||ads.stickyadstv.com/auto-user-sync$domain=6play.fr
-@@||ads.stickyadstv.com/www/delivery/swfIndex.php?reqType=$domain=6play.fr
-@@||v.fwmrm.net/ad/g/1$domain=6play.fr
-@@||cdn.stickyadstv.com/www/images/*.mp4$xmlhttprequest,domain=6play.fr
-@@||imasdk.googleapis.com/js/sdkloader/vpaid_adapter.js$domain=6play.fr
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=6play.fr
-||cdn.stickyadstv.com/www/images/*.mp4$media,redirect=noopmp3-0.1s,domain=6play.fr
 ! https://forum.adguard.com/index.php?threads/nordpresse-be.29210/
 nordpresse.be#@#.an-advert-banner
 nordpresse.be#@#.an-sponsored
@@ -357,40 +334,6 @@ ultimate-catch.eu#%#//scriptlet("abort-current-inline-script", "document.getElem
 @@||static.criteo.net/js/px.js^$domain=ultimate-catch.eu
 !+ PLATFORM(ios, ext_android_cb)
 @@||cas.criteo.com/delivery/ajs.php^$domain=ultimate-catch.eu
-!
-! [TF1]
-! https://github.com/AdguardTeam/AdguardFilters/issues/77931 (TF1)
-! https://github.com/AdguardTeam/AdguardFilters/issues/108132 (TF1 INFO)
-! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
-!
-! (1/2) "DOM" AAB CHECK
-!
-tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.display', { value: false, writable: false });
-tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.enable', { value: false, writable: false });
-!
-! Part below required for TF1 galaxy websites (iframe) + for products without scriptlets support
-tf1.fr,tf1info.fr#$#.ads.ad.adsbox.ad-placement.carbon-ads { display: block!important; }
-!#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
-prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ads
-prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad
-prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad-placement
-prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.carbon-ads
-! not working in Safari because of a bug
-! https://github.com/AdguardTeam/AdguardForiOS/issues/1253
-@@||tf1.fr^$generichide
-@@||tf1info.fr^$generichide
-!#endif
-!
-! (2/2) "NETWORK REQUEST" AAB CHECK
-!
-tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.serverRequest', { value: false, writable: false });
-tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.serverRequest', { value: false, writable: false });
-!
-! Whitelisted mainly for "adguard_app_ios" and "adguard_ext_android_cb" (fallback solution for others)
-@@||static.adsafeprotected.com/favicon.ico$domain=tf1.fr|tf1info.fr
-@@||ads.stickyadstv.com^|$xmlhttprequest,domain=tf1.fr|tf1info.fr
-! [/TF1]
-!
 ! https://forum.adguard.com/index.php?threads/chat-nrj-fr.28809/
 @@||chat.nrj.fr/Scripts/Lib/adsbygoogle.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15246
@@ -523,3 +466,72 @@ retinaboys.com###screen_block
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7980
 smarthomearea.de#@#.an-sponsored
 smarthomearea.de#@#.an-advert-banner
+!
+!
+! French-language official catch-up TV web apps
+!
+!
+! [MISCELLANEOUS]
+! https://github.com/AdguardTeam/AdguardFilters/issues/102748
+qub.ca#$#.adsbox.ad-banner:not([style="height: 5px; width: 5px; position: absolute; top: 0;"]):not(.blocker-tester + .ad-banner) { display: block !important; }
+qub.ca#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }
+!+ PLATFORM(ios, ext_android_cb)
+@@||qub.ca^$generichide
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/53934
+@@||proxy.ads.canalplus-bo.net/web/*/advert/?adInfo=$domain=canalplus.com
+@@||v.fwmrm.net/ad/g/1?*&resp=vmap$domain=canalplus.com
+@@||proxy.ads.canalplus-bo.net/web/*/adserver/info/?adInfo=$domain=canalplus.com
+! https://github.com/AdguardTeam/AdguardFilters/issues/123526
+canalplus.com#%#//scriptlet('json-prune', 'ads.enableAntiAdBlocking')
+! https://forum.adguard.com/index.php?threads/15884/
+@@||static.canal-plus.net/resources/adframe.html?adName=$domain=canalplus.com
+@@||proxy.ads.canalplus-bo.net/web/*/adserver/info/?asset=$domain=canalplus.com
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/85384
+! https://github.com/AdguardTeam/AdguardFilters/issues/37231
+@@||ads.stickyadstv.com/auto-user-sync$domain=6play.fr
+@@||ads.stickyadstv.com/www/delivery/swfIndex.php?reqType=$domain=6play.fr
+@@||v.fwmrm.net/ad/g/1$domain=6play.fr
+@@||cdn.stickyadstv.com/www/images/*.mp4$xmlhttprequest,domain=6play.fr
+@@||imasdk.googleapis.com/js/sdkloader/vpaid_adapter.js$domain=6play.fr
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=6play.fr
+||cdn.stickyadstv.com/www/images/*.mp4$media,redirect=noopmp3-0.1s,domain=6play.fr
+!
+! https://forum.adguard.com/index.php?threads/www-rtlplay-be-tvi-humour-rtl-tvi.29736
+@@||be-rtl.videoplaza.tv/proxy/distributor/$domain=rtlplay.be
+! [/MISCELLANEOUS]
+!
+! [TF1]
+! https://github.com/AdguardTeam/AdguardFilters/issues/77931 (TF1)
+! https://github.com/AdguardTeam/AdguardFilters/issues/108132 (TF1 INFO)
+! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
+!
+! (1/2) "DOM" AAB CHECK
+!
+tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.display', { value: false, writable: false });
+tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.enable', { value: false, writable: false });
+!
+! Part below required for TF1 galaxy websites (iframe) + for products without scriptlets support
+tf1.fr,tf1info.fr#$#.ads.ad.adsbox.ad-placement.carbon-ads { display: block!important; }
+!#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ads
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.ad-placement
+prod-player.tf1.fr,tf1.fr,tf1info.fr#@#.carbon-ads
+! not working in Safari because of a bug
+! https://github.com/AdguardTeam/AdguardForiOS/issues/1253
+@@||tf1.fr^$generichide
+@@||tf1info.fr^$generichide
+!#endif
+!
+! (2/2) "NETWORK REQUEST" AAB CHECK
+!
+tf1.fr#%#AG_defineProperty('__TF1_CONFIG__.adblock.serverRequest', { value: false, writable: false });
+tf1info.fr#%#AG_defineProperty('__NEXT_DATA__.runtimeConfig.adBlock.serverRequest', { value: false, writable: false });
+!
+! Whitelisted mainly for "adguard_app_ios" and "adguard_ext_android_cb" (fallback solution for others)
+@@||static.adsafeprotected.com/favicon.ico$domain=tf1.fr|tf1info.fr
+@@||ads.stickyadstv.com^|$xmlhttprequest,domain=tf1.fr|tf1info.fr
+! [/TF1]
+!

--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -9,8 +9,6 @@
 !------- JS rules ---------------------!
 !--------------------------------------!
 !
-! French-language catch-up TV web apps
-!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/119411
 voici.fr,programme-tv.net,gala.fr,capital.fr#%#AG_onLoad(function(){if(window.pmsCoreAds&&Array.isArray(pmsCoreAds)){window.pmsCoreAds=new Proxy(pmsCoreAds,{set:(a,b,c,d)=>{if("function"==typeof c)try{let a=!1;const b=b=>{var c=document.querySelector(".ads-core-video");c&&a?clearInterval(d):(b(),a=!0)},d=setInterval(b,1e3,c)}catch(a){}return Reflect.set(a,b,c,d)}})}});
 ! allocine.fr - fixing delay in the video player
@@ -24,20 +22,6 @@ purepeople.com#%#(function(){var a={cmd:[],public:{getVideoAdUrl:function(){},cr
 seriepourvous.com#%#//scriptlet("remove-attr", "href", "a[href]#clickfakeplayer")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/104938
 scan-manga.com#%#//scriptlet("abort-current-inline-script", "document.getElementById", "window.open")
-! https://github.com/AdguardTeam/AdguardFilters/issues/83543
-canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
-! https://github.com/AdguardTeam/AdguardFilters/issues/103930
-6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled applaunch.data.player.features.ad.dai.enabled', 'appName')
-! https://github.com/AdguardTeam/AdguardFilters/issues/100525
-! https://gist.github.com/ameshkov/265f353a816110e8b9d5fc37ad66c31a
-prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
-! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
-tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
-!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/105459
 mapcustomizer.com#%#//scriptlet('remove-class', 'with-ad', 'div')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100793
@@ -75,6 +59,24 @@ actu17.fr#%#//scriptlet("abort-on-property-write", "td_ad_background_click_link"
 jacquieetmicheltv.net#%#var _st = window.setTimeout; window.setTimeout = function(a, b) { if(!/target_url/.test(a)){ _st(a,b);}};
 ! http://forum.adguard.com/showthread.php?6907
 generation-nt.com#%#Object.defineProperty(window, 'AdvertBay', { get: function() { return []; } });
+!
+! French-language official catch-up TV web apps
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/83543
+canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
+! https://github.com/AdguardTeam/AdguardFilters/issues/123526
+canalplus.com#%#//scriptlet('json-prune', 'ads.*.default ads.*.url')
+! https://github.com/AdguardTeam/AdguardFilters/issues/103930
+6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled applaunch.data.player.features.ad.dai.enabled', 'appName')
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+! https://gist.github.com/ameshkov/265f353a816110e8b9d5fc37ad66c31a
+prod-player.tf1.fr#%#(function(){let callCounter=0;const nativeJSONParse=JSON.parse;const handler={apply(){callCounter++;const obj=Reflect.apply(...arguments);if(callCounter<=10){if(obj.hasOwnProperty('env')&&obj.env.hasOwnProperty('origin')){if(!obj.hasOwnProperty('ads')){obj.ads={};}obj.ads.enable=false;obj.ads._prerolls=false;obj.ads._midrolls=false;}}else{JSON.parse=nativeJSONParse;}return obj;}};JSON.parse=new Proxy(JSON.parse,handler);})();
+! TODO: Change AG_defineProperty to scriptlet when this issue will be fixed - https://github.com/AdguardTeam/Scriptlets/issues/65
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithForm', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithImage', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithScript', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.pingURLWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
+tf1.fr#%#AG_defineProperty('tv.freewheel.SDK.Util.sendAdRequestWithXMLHTTPRequest', { get: function() { return function() {return true;}; } });
 !
 !--------------------------------------!
 !------- CSS fixes --------------------!

--- a/FrenchFilter/sections/general_extensions.txt
+++ b/FrenchFilter/sections/general_extensions.txt
@@ -65,7 +65,7 @@ generation-nt.com#%#Object.defineProperty(window, 'AdvertBay', { get: function()
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83543
 canalplus.com#%#//scriptlet('set-constant', '__data.application.settings.featPlayerAds', 'false')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/123526
-canalplus.com#%#//scriptlet('json-prune', 'ads.*.default ads.*.url')
+canalplus.com#%#//scriptlet('json-prune', 'ads.*.default ads.*.url ads.enableMidrolls', 'ads')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/103930
 6play.fr,rtlplay.be#%#//scriptlet('json-prune', 'applaunch.data.player.features.ad.enabled applaunch.data.player.features.ad.dai.enabled', 'appName')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100525

--- a/FrenchFilter/sections/replace.txt
+++ b/FrenchFilter/sections/replace.txt
@@ -5,15 +5,18 @@
 ! Bad:  ||example.org/video-links (should be in specific.txt)
 !
 !
-! French-language catch-up TV web apps
+! https://github.com/AdguardTeam/AdguardFilters/issues/43218
+||v.fwmrm.net/ad/g/1?$replace=/(tv\.freewheel\.SDK\._instanceQueue\['Context_[\s\S]*?'\][\s\S]*?\.requestComplete\(\{)[\s\S]*\}\);/\$1\}\);/,important,domain=01net.com
+!
+! French-language official catch-up TV web apps
 !
 ! https://forum.adguard.com/index.php?threads/7957/page-2#post-90715
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i
 ||amazonaws.com/www.w9.fr/config.json$replace=/"enabled": true\,/"enabled": false\,/i,important
+! https://github.com/AdguardTeam/AdguardFilters/issues/123526
+||canalplus.com^$document,replace=/"featPlayerAds":true/"featPlayerAds":false/
 ! https://forum.adguard.com/index.php?threads/www-rtlplay-be-tvi-humour-rtl-tvi.29736
 ||be-rtl.videoplaza.tv/proxy/distributor/$replace=/(\,"vast":\{)[\s\S]*(\}\}\])/\$1\$2/,important,domain=rtlplay.be
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100525
 ||prod-player.tf1.fr/*/Player/Player.js$script,xmlhttprequest,other,replace=/_prerolls:!(0|1)\,_midrolls:!(0|1)/enable:!1\,_prerolls:!1\,_midrolls:!1/
 !
-! https://github.com/AdguardTeam/AdguardFilters/issues/43218
-||v.fwmrm.net/ad/g/1?$replace=/(tv\.freewheel\.SDK\._instanceQueue\['Context_[\s\S]*?'\][\s\S]*?\.requestComplete\(\{)[\s\S]*\}\);/\$1\}\);/,important,domain=01net.com

--- a/MobileFilter/sections/specific_app.txt
+++ b/MobileFilter/sections/specific_app.txt
@@ -5,16 +5,6 @@
 ! Bad:  ||graph.facebook.com^$third-party (should be in adservers.txt)
 !
 !
-! French-language catch-up TV mobile apps
-!
-! https://github.com/AdguardTeam/AdguardFilters/issues/103930
-||smartclip.net^$app=fr.m6.m6replay
-! https://github.com/AdguardTeam/AdguardFilters/issues/100525
-||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
-||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1
-!
 ! ru.yandex.metro
 ||extmaps-api.yandex.net/promo/api/
 ! ua.slando - fixing adverts
@@ -913,3 +903,14 @@ c0server.jags.co.jp/jss/img/banners/$app=jp.co.jags.android.Bokumaka
 ! https://github.com/AdguardTeam/AdguardFilters/issues/89875
 ! com.gitvdemo.video
 ||cupid.ptqy.gitv.tv/mixer?$replace=/"adSlots"/"adSlots_"/,app=com.gitvdemo.video
+!
+! French-language official catch-up TV mobile apps
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/103930
+||smartclip.net^$app=fr.m6.m6replay
+! https://github.com/AdguardTeam/AdguardFilters/issues/100525
+||delivery.tf1.fr/pub$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||dnl-adv-ssl.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||slpubmedias.tf1.fr^$media,redirect=noopmp3-0.1s,app=fr.tf1.mytf1
+||app-api.tf1.fr/params/player$xmlhttprequest,script,other,replace=/"url":"https?:\/\/adproxy\.tf1\.fr[^"]*"/"url":""/,app=fr.tf1.mytf1
+!


### PR DESCRIPTION
# Creating the pull request

This PR ensures that video ads never appear on `canalplus.com`.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [X] Missed ads or ad leftovers; &nbsp;_(Possibly, in rare instances.)_
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website; &nbsp;_(Currently undetected but improves/reinforces that side as well.)_
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [X] Filters maintenance. &nbsp;_(Unplanned reorganization included, which should have been done in a separate commit for easier review, sorry about that.)_

## What issue is being fixed?

### Enter the issue address

Fixes #123526, fixes #116568

### Add your comment and screenshots

**_1. Your comment_**

Hi. First of all, sorry for the delay.

In short, these two issues can _probably_ be explained either by a glitch (see in particular the fact that two instances of AdGuard are used simultaneously on one of the two issues, both of which seem to me to come from the same person by the way) or by the fact that some premium content (coming from their partnership with _6play_ here) would _potentially_ not use `.featPlayerAds`. Although that doesn't seem to be the case.

Anyway, the current solution, although never faulty in my tests, is a bit fragile on a glitch level because it must be correctly defined once the DOM of the page is loaded _(document)_ but before its use ~ 2 sec. later in `main.[…].js` _(script)_.

Therefore, for the possible rare case where my `set-constant` line wouldn't react fast enough, added:
- its `$document,replace=[…]` version (for AG products supporting it);
- a deletion of the following JSON content via the `json-prune` scriptlet, where `*` is any ad provider name:
  - `ads.*.default` _[binary]_ (to allow to never see [that](https://user-images.githubusercontent.com/4764956/141113868-85bdb3d1-1f24-4ac2-ac20-0000afc560b9.png) in this situation too — English translation: "Advertising: Your content is loading");
  - `ads.*.url` _[string]_ (to prevent contacting any ad provider, currently two present, now or later; with `ads.enableAntiAdBlocking` removed alongside);
  - `ads.enableMidrolls` _[binary]_ (to prevent any possible/future 'OSD' visual stuff showing before trying to show them).

The final `, 'ads'` _(another parameter)_ being for optimization purposes: if I understand it correctly, this will allow in this case for each "JSON data" where the `[ROOT].ads` property is absent, to only look for its presence once instead of 3 times.

**_2. Screenshots_**

<details>

<summary>:camera: Screenshot 1 <strong><em>(click to reveal)</em></strong></summary>

![firefox_GMvvbaaA6k](https://user-images.githubusercontent.com/4764956/177807367-266b69b5-7ada-45aa-8920-582eb4737d1b.png)

**Source:** `https://player.canalplus.com/one/configs/v2/10/mycanal/prod.json` _(**OnePlayer** is the name of their player)_
… but will also works on all variants visible here (`https://player.canalplus.com/one/configs/v2/10/mapping/mapping.json`), e.g.:
- `https://player.canalplus.com/one/configs/v2/10/mycanalch/prod.json`
- `https://player.canalplus.com/one/configs/v2/10/orange/prod.json`
- `https://player.canalplus.com/one/configs/v2/10/piwi/prod.json` (for kids, where we can see that `ads.enableMidrolls` is already `false` there for example)
- etc.

:bulb: And if you are wondering: `params.enableAd`, either removed or set to `false` via a `$replace` rule, has no influence on _video ads_.

</details>

<details>

<summary>:camera: Screenshot 2 <strong><em>(click to reveal)</em></strong></summary>

![firefox_ne8QfUSCNC](https://user-images.githubusercontent.com/4764956/177807419-4a8fff2d-fe28-47f9-862d-0ea400a88f3b.png)

_:information_source: If `json-prune` only used, production of this error but does not pose any problem (same result with an adequate **`redirect`** rule [noopvmap-1.0](https://github.com/AdguardTeam/Scriptlets/blob/master/wiki/about-redirects.md#noopvmap-1.0) on `proxy.ads.canalplus-bo.net/[…]` for example, by the way)._

</details>

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
