### PR TITLE
Fix #124958 yandex.ru

### DIFF
--- a/AnnoyancesFilter/Other/sections/annoyances.txt
+++ b/AnnoyancesFilter/Other/sections/annoyances.txt
@@ -15,6 +15,9 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76987
 youtube.com#%#AG_onLoad(function() {var a = new MutationObserver(function() {if (document.querySelector('yt-upsell-dialog-renderer')) {var b = document.querySelector('.ytd-popup-container[popup-size="UPSELL_DIALOG_RENDERER_POPUP_SIZE_LARGE"] #dismiss-button:not(.dismissed), .upsell-dialog-lightbox .upsell-dialog-dismiss-button button:not(.dismissed)');setTimeout(function() {b&&b.click()}, 3E2)}});a.observe(document, {childList: !0,subtree: !0});setTimeout(function() {a.disconnect()}, 3E3)});
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/124958
+[$path=/search]yandex.ru##.Warning_type_roskomnadzor
+[$path=/video/search]yandex.ru##.prevention_instance_rknWarning
 ! https://github.com/AdguardTeam/AdguardFilters/issues/124961
 [$path=/search]nova.rambler.ru##div[class^="SerpWarning__warning"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/124959


### PR DESCRIPTION
Fix #124958 yandex.ru

The second rule for https://yandex.ru/search/?lr=2&text=twitch