### PR TITLE
tidal.com tracker

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1772,6 +1772,7 @@ maxpark.com###listOfCounters
 ||sdwnet.me/index.php?action=tracking_script^
 ||trivago.*/log?sLog=
 ||tracking.tidalhifi.com/wimp/tracking/
+||tidal.com/t^
 westnews.com.ua##a[href="http://www.bigmir.net/"]
 ||d17m68fovwmgxj.cloudfront.net/js/appier-track-
 ||alteregoru.ru/js/counter

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1772,7 +1772,7 @@ maxpark.com###listOfCounters
 ||sdwnet.me/index.php?action=tracking_script^
 ||trivago.*/log?sLog=
 ||tracking.tidalhifi.com/wimp/tracking/
-||tidal.com/t^
+||tidal.com/t|
 westnews.com.ua##a[href="http://www.bigmir.net/"]
 ||d17m68fovwmgxj.cloudfront.net/js/appier-track-
 ||alteregoru.ru/js/counter


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
Blocks an event tracker on tidal.com pages

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

<details>

<summary>Screenshot 1:</summary>

![ksnip_tmp_dRAngL](https://user-images.githubusercontent.com/47755037/180650891-bda3ba17-78b0-4fd5-8e9f-791cc8f7762a.png)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met


