### PR TITLE
Duplicate parameters

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -162,4 +162,3 @@ $removeparam=fb_action_types
 $removeparam=fb_comment_id
 $removeparam=fb_ref
 $removeparam=fb_source
-$removeparam=fbclid

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -738,7 +738,6 @@ $removeparam=dclid
 ||bilibili.com^$removeparam=share_medium
 ||bilibili.com^$removeparam=share_plat
 ||bilibili.com^$removeparam=share_session_id
-||bilibili.com^$removeparam=share_source
 ||bilibili.com^$removeparam=share_tag
 ||bilibili.com^$removeparam=timestamp
 ||bilibili.com^$removeparam=unique_k

--- a/TrackParamFilter/sections/whitelist.txt
+++ b/TrackParamFilter/sections/whitelist.txt
@@ -29,6 +29,7 @@
 @@||medonet.pl/*&srcc=ucs$removeparam
 @@||businessinsider.com.pl/*&srcc=ucs$removeparam
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34644
+! https://github.com/AdguardTeam/AdguardFilters/issues/63522
 @@||onet.pl/?utm_source=$removeparam
 ! https://github.com/ClearURLs/Rules/issues/30
 @@||tix.axs.com^$removeparam
@@ -65,20 +66,6 @@
 @@||gizmodo.com/embed/comments/$removeparam
 ! kotaku.com - "See all replies" button broken
 @@||kotaku.com/embed/comments$removeparam
-! https://github.com/AdguardTeam/AdguardFilters/issues/78392
-@@||lanacion.com.ar/*module$removeparam=utm_source
-! https://github.com/AdguardTeam/AdguardFilters/issues/69031 [Stealth Mode - Strip URLs from tracking parameters]
-@@||t.send.vt.edu/r/?id=$removeparam=utm_source
-@@||t.send.vt.edu/r/?id=$removeparam=utm_medium
-@@||t.send.vt.edu/r/?id=$removeparam=utm_campaign
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52925
 @@||fakt.pl/*&srcc=ucs$removeparam
 @@||przegladsportowy.pl/*&srcc=ucs$removeparam
-@@||auto-swiat.pl/*&srcc=ucs$removeparam
-@@||komputerswiat.pl/*&srcc=ucs$removeparam
-@@||noizz.pl/*&srcc=ucs$removeparam
-@@||plejada.pl/*&srcc=ucs$removeparam
-@@||medonet.pl/*&srcc=ucs$removeparam
-@@||businessinsider.com.pl/*&srcc=ucs$removeparam
-! https://github.com/AdguardTeam/AdguardFilters/issues/63522
-@@||onet.pl/?utm_source=$removeparam


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ ] This is not an ad/bug report;
- [ ] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [ ] I have performed a self-review of my own changes;
- [ ] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address



### Add your comment and screenshots



```
@@||onet.pl/?utm_source=$removeparam has been made redundant by @@||onet.pl/?utm_source=$removeparam
@@||businessinsider.com.pl/*&srcc=ucs$removeparam has been made redundant by @@||businessinsider.com.pl/*&srcc=ucs$removeparam
@@||medonet.pl/*&srcc=ucs$removeparam has been made redundant by @@||medonet.pl/*&srcc=ucs$removeparam
@@||plejada.pl/*&srcc=ucs$removeparam has been made redundant by @@||plejada.pl/*&srcc=ucs$removeparam
@@||noizz.pl/*&srcc=ucs$removeparam has been made redundant by @@||noizz.pl/*&srcc=ucs$removeparam
@@||komputerswiat.pl/*&srcc=ucs$removeparam has been made redundant by @@||komputerswiat.pl/*&srcc=ucs$removeparam
@@||auto-swiat.pl/*&srcc=ucs$removeparam has been made redundant by @@||auto-swiat.pl/*&srcc=ucs$removeparam
@@||t.send.vt.edu/r/?id=$removeparam=utm_campaign has been made redundant by @@||t.send.vt.edu/r/?id=$removeparam=utm_campaign
@@||t.send.vt.edu/r/?id=$removeparam=utm_medium has been made redundant by @@||t.send.vt.edu/r/?id=$removeparam=utm_medium
@@||t.send.vt.edu/r/?id=$removeparam=utm_source has been made redundant by @@||t.send.vt.edu/r/?id=$removeparam=utm_source
@@||lanacion.com.ar/*module$removeparam=utm_source has been made redundant by @@||lanacion.com.ar/*module$removeparam=utm_source
||bilibili.com^$removeparam=share_source has been made redundant by ||bilibili.com^$removeparam=share_source
$removeparam=fbclid has been made redundant by $removeparam=fbclid
```


<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/103899764/181637843-d02db7d5-f4e2-454b-9c4c-8a003d3de985.png)


</details>



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
