### PR TITLE
Fix AdguardTeam#125545 remove yottlyscript.com from tracking_servers.txt

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -127,7 +127,6 @@
 ||tracker.xgen.dev^
 ||p.data.cctv.com^
 ||unibots.in^$third-party
-||yottlyscript.com^
 ||wpfc.ml^
 ||weborama.com^$third-party
 ||quesid.com^


### PR DESCRIPTION
# Creating the pull request

remove yottlyscript.com from tracking_servers.txt as requested by issue #125545

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Reenable script used for web personalization

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/125545

### Add your comment and screenshots

Screenshot of the personalized component being blocked is in the linked issue

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
