### PR TITLE
rtl.de - broken videos and tracker

### DIFF
--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -115,6 +115,7 @@ vergleich.focus.de,chip.de,gutefrage.net,reisefrage.net,motorradfrage.net,autofr
 ! ##.adsbygoogle
 winfuture.de,netzwelt.de,quoka.de,farmeramania.de,bravofly.de,computerbild.de,digitalfernsehen.de,hl-live.de,chinamobilemag.de,focus.de,pcwelt.de##.adsbygoogle
 !
+||rtl.de/phoenix/images-loaded/local.js
 mopo.de##a[href*="campaign"][target="_blank"]
 chip.de##.l-DownloadDetail > div[style="min-height:250px;"]
 np-coburg.de###hcsb-topteaser-upper

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -54,6 +54,7 @@
 !||i.snssdk.com/log/*
 !||i.snssdk.com/slardar/sdk.js
 !
+||analytics.audionow.de^$third-party
 ||cdn.kaizenplatform.net^
 ||oaprodlogging.yo-digital.com^
 ||analytics.e2estudios.com^

--- a/SpywareFilter/sections/whitelist.txt
+++ b/SpywareFilter/sections/whitelist.txt
@@ -431,7 +431,7 @@ ntp.msn.com#@%#navigator.getBattery = undefined;
 ! http://forum.ru-board.com/topic.cgi?forum=5&topic=50480&start=1420#13
 @@||chat-webim.rsb.ru/l/v/track.php?
 ! https://github.com/AdguardTeam/AdguardFilters/issues/103991
-@@||technical-service.net/api?$domain=n-tv.de|vip.de
+@@||technical-service.net/api?$domain=n-tv.de|vip.de|rtl.de
 ! https://github.com/AdguardTeam/AdguardFilters/issues/105034
 @@||cdn.clerk.io/clerk.js$domain=batteribyen.dk|batterionline.no|batterionline.se
 ! https://github.com/AdguardTeam/AdguardFilters/issues/106697


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

<https://github.com/easylist/easylistgermany/issues/200>

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->

Example video: `https://www.rtl.de/cms/warum-zu-verschenken-boxen-von-privatpersonen-nicht-immer-eine-gute-idee-sind-4783926.html`
Example for the ad script and the tracker: `https://www.rtl.de/`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met