### PR TITLE
youtube.com

### DIFF
--- a/SocialFilter/sections/css_extended.txt
+++ b/SocialFilter/sections/css_extended.txt
@@ -10,7 +10,6 @@
 ! https://github.com/AdguardTeam/AdguardBrowserExtension/issues/2148
 media.toidas.net#?#.toidas-sns-embed-inner
 !
-youtube.com#?#ytd-button-renderer:has(> a > #button > #button[aria-label="Share"])
 cookpad.com#?#button[type="button"]:contains(レシピを共有):has(> svg)
 flightradar24.com#?#.elementor-widget-container > h5:contains(Share this article)
 m.bunjang.co.kr#?#div:has(> button[type="button"] > img[alt="페이스북 아이콘"][src^="data:image/png"])
@@ -833,7 +832,7 @@ and-engineer.com#?#div[class^="css-"]:has(> div[class] > a[href^="https://twitte
 and-engineer.com#?##__next div[class^="css-"]:has(> div[class] + div[class^="css-"] > div.chakra-stack > div[class^="css-"] > a[href^="https://twitter.com/share?url"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/102614#issuecomment-1056823395
 youtube.com#?#yt-third-party-share-target-section-renderer > .yt-third-party-share-target-section-renderer ~ yt-icon-button#scroll-button-forward
-youtube.com#?#yt-share-target-renderer > button[title] > div.style-scope:contains(/WhatsApp|Facebook|Twitter|카카오스토리|Reddit|ВКонтакте|Одноклассники|ОК|Pinterest|Blogger|Tumblr|LinkedIn|Skyrock|Mix|goo|KakaoTalk/):upward(button[title])
+youtube.com#?#yt-share-target-renderer > button[title] > div.style-scope:contains(/WhatsApp|Facebook|Twitter|카카오스토리|Reddit|ВКонтакте|Одноклассники|ОК|OK|VK|Pinterest|Blogger|Tumblr|LinkedIn|Skyrock|Mix|goo|KakaoTalk/):upward(button[title])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/105675
 sugorokuya.jp#?#.sns-share:upward(1)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100320


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [x] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

#126239 

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

- `youtube.com#?#ytd-button-renderer:has(> a > #button > #button[aria-label="Share"])`

	I think this rule is too much. and only supported for English.

- `ОК|OK`
I guess they are probably same.
However, the original rule and the character code (ОК of the left) were different.
I thought that the character code used might be different depending on the language.
So there are two.

<details><summary>screenshot</summary>

![](https://i.slow.pics/SnsmoXdE.png)
![](https://i.slow.pics/Ewpuz4df.png)


</details><br/>



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
