### PR TITLE
add shared tweets tracking params filters

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -655,6 +655,9 @@ $removeparam=at_medium,domain=bbc.com|bbc.co.uk
 ! Embedded tweets
 ||twitter.com^$removeparam=ref_src
 ||twitter.com^$removeparam=ref_url
+! Shared tweets
+||twitter.com^$removeparam=s
+||twitter.com^$removeparam=t
 !
 ||zerkalo.io^$removeparam=tg
 ||zerkalo.io^$removeparam=vk


### PR DESCRIPTION
[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:

If you share a link with Twitter's built-in share button in the status page, it will generate a link with tracking parameters that have no effects on the actual browsing.

* **Current behaviour**: 

e.g. `https://twitter.com/ubuntu_sec/status/1558002535037734912?s=45&t=Aqv7QihzYXk85uK`

* **Expected behaviour**: 

`https://twitter.com/ubuntu_sec/status/1558002535037734912`

***Steps to reproduce the problem***:

1. Go to `https://twitter.com/ubuntu_sec/status/1558002535037734912`
2. Click on the share button
3. Select `Copy link to Tweet`
4. You get a link with tracking parameters when sharing

<details>

![image](https://user-images.githubusercontent.com/54175165/184366020-f5fde6cf-2a0b-4654-a950-b7bdb8bf0206.png)

</details>

***System configuration***

**Filters:**

AdGuard URL Tracking Protection

