### PR TITLE
add m.bilibili.com mobile app banner filters

### DIFF
--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -13,6 +13,7 @@ m.bilibili.com##.openapp-dialog
 m.bilibili.com##.m-float-openapp.launch-app-btn
 m.bilibili.com##.related-openapp
 m.bilibili.com##.m-video2-awaken-btn
+m.bilibili.com##.nav-open-app-img
 ||s1.hdslb.com/bfs/static/jinkela/mstation-video-h5/assets/navOpenApp.png
 openrice.com###smart-banner-collection
 wear.jp###appAd

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -8,6 +8,12 @@
 ! HINTS are at the end of Specific section
 !
 ! SECTION: Mobile apps - Specific
+
+m.bilibili.com##.openapp-dialog
+m.bilibili.com##.m-float-openapp.launch-app-btn
+m.bilibili.com##.related-openapp
+m.bilibili.com##.m-video2-awaken-btn
+||s1.hdslb.com/bfs/static/jinkela/mstation-video-h5/assets/navOpenApp.png
 openrice.com###smart-banner-collection
 wear.jp###appAd
 beauty.hotpepper.jp##.nativeAppliArea


### PR DESCRIPTION
Fixes https://github.com/AdguardTeam/AdguardFilters/issues/126675

[//]: # (***You can delete or ignore strings starting with "[//]:" They will not be visible either way.)

***Description***:
* **Current behaviour**: 

[//]: # (Substitute this line with a description of the problem)

[//]: # (Replace %screenshot_url% below with a link to the screenshot of the problem. Also, you can paste image from clipboard instead. It will be automatically loaded.)
<details><summary>Screenshot:</summary>


![image](https://user-images.githubusercontent.com/54175165/184376632-713243da-205d-472f-8318-f2c2060cae2f.png)
![image](https://user-images.githubusercontent.com/54175165/184376651-4d76ead4-7602-40b9-bb81-f4475673db7c.png)

</details><br/>

* **Expected behaviour**: 

[//]: # (Substitute this line with a description of what should happen normally. If needed, provide a screenshot below, same as above)

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/54175165/184378408-6378c292-11b8-4e9a-96fc-ca0d5f29d035.png)

![image](https://user-images.githubusercontent.com/54175165/184378213-86e820fd-0bcd-4e4e-9d22-8dfe299077ad.png)

</details><br/>

***Steps to reproduce the problem***:

1. Go to https://m.bilibili.com/video/BV1nG4y1Y7rN
2. Dismiss the model dialog
3. Scroll down to the bottom
