### PR TITLE
General url rule to block tracking pixel (from hubspot/hsforms)

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -181,6 +181,7 @@
 /bypassma.js
 /fprnt.min.js
 /collect.gif?
+/counters.gif?
 /healthanalytics.js
 /snowplow/*$script
 /w_js.php|$script,~third-party


### PR DESCRIPTION
# Creating the pull request

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
Blocks a tracking pixel coming from hsforms.com
This domain is used by hubspot.com forms 
See: https://www.hubspot.com/products/marketing/forms

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Add your comment and screenshots

https://go.exponea.com/packages

![ksnip_tmp_ElYWPE](https://user-images.githubusercontent.com/47755037/184377667-8ae068a8-1cc3-4712-b352-ed1df591dfd5.png)

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met


