### PR TITLE
bugherd.com

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -21,6 +21,7 @@
 !
 ! The list of bug-tracker services(Sentry, etc.)
 ! Add as commented rules. Will be used in additional list and/or strict DNS
+! ||bugherd.com^$third-party
 ! ||in.appcenter.ms^
 ! ||api.loganalytics.io^
 ! ||crashlyticsreports-pa.googleapis.com^

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -1724,7 +1724,6 @@
 ||btstatic.com^$third-party
 ||btttag.com^$third-party
 ||bubblestat.com^$third-party
-||bugherd.com^$third-party
 ||burstbeacon.com^$third-party
 ||burt.io^$third-party
 ||bux1le001.com^$third-party


### PR DESCRIPTION
Bugherd is not a tracker or an ad platform. It is a platform for manually reporting bugs, used by developers and their clients. There's no reason for it to be blocked by a tracker list.

# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

No issue for this, I am removing what is essentially a false-positive. Bugherd.com is not a tracker or ad service, and so should not be blocked by this filter.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
