### PR TITLE
www.nbc.com

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -6,6 +6,8 @@
 ! Bad: ||example.org^$xmlhttprequest,redirect=noopvast-3.0 (for instance, should be in specific.txt)
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/124745
+||player.theplatform.com^$removeparam=params
 ! https://github.com/AdguardTeam/AdguardFilters/issues/126438
 ||facebook.com^$removeparam=extid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/126807


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/124745


Removed the parameter from the iframe address. 
- Isn't this rule very wide ? Because it breaks video on [https://www.nbc.com/law-and-order-organized-crime/video/change-the-game/9000171392](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https%3A%2F%2Fwww.nbc.com%2Flaw-and-order-organized-crime%2Fvideo%2Fchange-the-game%2F9000171392) 
- Is it worth trying to change the rule and use `^$hls` syntax ?

<details><summary>Screenshot:</summary>

<img width="615" alt="Снимок экрана 2022-08-17 в 20 21 27" src="https://user-images.githubusercontent.com/91964807/185202625-eede0c5d-83d8-4217-81db-ea6733e21c26.png">

</details><br/>
