### PR TITLE
Block MailOptin popups (e.g., apex-magazine.com)

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
@@ -9,10 +9,11 @@
 !
 ! Genegic rules
 ! SECTION: Subscriptions - Generic
-##.mo-optin-form-lightbox
 ##.followit--follow-form-container
 ##.widget_blog_subscription
 ~theoatmeal.com,~copays.org,~nothing.tech,~mega-debrid.eu,~curvegames.com,~news.un.org,~norwichzen.org.uk,~dereferer.me###mc_embed_signup
+!
+/wp-content/plugins/mailoptin/*
 !
 ||embeds.fanmatics.com^$third-party
 ||inyourarea.co.uk^$third-party

--- a/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
@@ -9,6 +9,7 @@
 !
 ! Genegic rules
 ! SECTION: Subscriptions - Generic
+##.mo-optin-form-lightbox
 ##.followit--follow-form-container
 ##.widget_blog_subscription
 ~theoatmeal.com,~copays.org,~nothing.tech,~mega-debrid.eu,~curvegames.com,~news.un.org,~norwichzen.org.uk,~dereferer.me###mc_embed_signup


### PR DESCRIPTION
## What issue is being fixed?

Block MailOptin-powered newsletter popups

Example URL: `https://apex-magazine.com/`

<details>

<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/110956608/185409158-c03579a9-f430-49ea-8df8-416974d12331.png)

</details>
