### PR TITLE
Block Newspack Popups WordPress plugin

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_general.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_general.txt
@@ -25,6 +25,7 @@
 /cdn-cgi/pe/bag2?r[]=*mailget.net
 /download.plagin.js
 /plugins/facebook-page-promoter-$~stylesheet
+/wp-content/plugins/newspack-popups/*
 /wp-content/plugins/arscode-ninja-popups/*
 /wp-content/plugins/chimpmatepro/*
 /wp-content/plugins/facebook-fanbox-popup/*

--- a/AnnoyancesFilter/Popups/sections/popups_general.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_general.txt
@@ -25,13 +25,13 @@
 /cdn-cgi/pe/bag2?r[]=*mailget.net
 /download.plagin.js
 /plugins/facebook-page-promoter-$~stylesheet
-/wp-content/plugins/newspack-popups/*
 /wp-content/plugins/arscode-ninja-popups/*
 /wp-content/plugins/chimpmatepro/*
 /wp-content/plugins/facebook-fanbox-popup/*
 /wp-content/plugins/icegram/*
 /wp-content/plugins/mailchimp/*
 /wp-content/plugins/modesco-zen-subscribe/*
+/wp-content/plugins/newspack-popups/*
 /wp-content/plugins/popup-maker/*$~stylesheet
 /wp-content/plugins/thrive-leads/*
 /wp-content/themes/Newspaper-child/*$~stylesheet,domain=~dyvys.info|~capital.de|~inside-digital.de|~expressvpn.com|~botanichka.ru


### PR DESCRIPTION
Blocks Newspack Popups WP plugin (https://github.com/Automattic/newspack-popups)

Example URL: `https://magazine.atavist.com/king-of-the-hill-omak-suicide-race-horse-washington-native-american/`

<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/110956608/185410793-cda2471a-bd83-4e9d-be85-205becf859a7.png)

</details>
