### PR TITLE
Block Pendo Guide popups

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_general.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_general.txt
@@ -53,6 +53,7 @@
 ||chat.whatsappx.xyz^$third-party
 ||chatinator.com^$third-party
 ||code.clicktex.ru^$third-party
+||data.pendo.io/data/guide.js^$third-party
 ||delivery.satr.jp^$third-party
 ||downloads.mailchimp.com/js/signup-forms/
 ||elp.evolok.net^$third-party


### PR DESCRIPTION
Block Pendo Guide popups (https://help.pendo.io/resources/support-library/guides/getting-started-with-guides.html)

Example URL: `https://lareviewofbooks.org/`

<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/110956608/185413205-4d826c9a-7640-48af-b4a6-ac2a4d7c0dcc.png)

</details>
