### PR TITLE
Block Squarespace-powered popup overlays

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_general.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_general.txt
@@ -44,6 +44,7 @@
 ||api.callpage.io/*/widgets^$third-party
 ||api.cazamba.com^$third-party
 ||api.sorunapp.com^$third-party
+||assets.squarespace.com/universal/scripts-compressed/popup-overlay-*.js$third-party
 ||attantarow.ru^$third-party
 ||borgan.ru^$third-party
 ||cdn*.pdmntn.com^$third-party


### PR DESCRIPTION
Blocks popup overlays on Squarespace-powered sites

Example URL: `https://bittersoutherner.com/`

<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/110956608/185415050-705589b4-55f2-4a94-95bc-98387af2a1cf.png)

</details>
