### PR TITLE
Added parameters for hepsiburada

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -390,6 +390,7 @@ $removeparam=dt_dapp,domain=douban.com|163.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/127888
 ||hepsiburada.com^$removeparam=af_ad
 ||hepsiburada.com^$removeparam=af_adset
+||hepsiburada.com^$removeparam=af_click_lookback
 ||hepsiburada.com^$removeparam=af_force_deeplink
 ||hepsiburada.com^$removeparam=pid
 ||hepsiburada.com^$removeparam=c
@@ -698,6 +699,7 @@ $removeparam=dclid
 ||mag2.com^$removeparam=trflg
 ||dailymail.co.uk^$removeparam=ito
 ||hepsiburada.com^$removeparam=wt_af
+||hepsiburada.com^$removeparam=wt_gl
 ||mioga.de^$removeparam=pl
 ||mioga.de^$removeparam=idealoid
 ||ejoker.de^$removeparam=sPartner


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

`af_click_lookback` referrer
`app.hps.im/d7ct/cbad17e8`

The purpose of `af_click_lookback` is explained in the link below.
https://support.appsflyer.com/hc/en-us/articles/207447163#attribution-link-parameters

---

`wt_gl`

`https://www.hepsiburada.com/supradyn-koenzim-q10-30-tablet-pm-HB0000039E1L?wt_gl=cpc.6813.dsa.nelk.saglik-guzellik-vitaminler&isFashion=true&gclid=Cj0KCQjwyZmEBhCpARIsALIzmnL0IwSbY-6T5_3RhIPGV9344V0fu1Yyv7NL5e7tTeJKt2V3Y-tMIy0aAkKREALw_wcB`



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
