### PR TITLE
Block .ticker-view on additional Condé Nast sites

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -533,7 +533,6 @@ booking.com##.emk_footer_update
 vsim.ua#$##modal_mail { display: none !important; }
 vsim.ua#$#.modal-backdrop { display: none !important; }
 vsim.ua#$#.modal-open { overflow: auto !important; }
-gqjapan.jp##.ticker-view
 gqjapan.jp##div[class^="LinkBannerMarquee-"]
 bezprovodoff.com##div[id^="mc4wp_form_widget-"]
 cyfral-group.ru#$#div[data-popup-subscribe-inited] { display: none !important; }
@@ -3032,7 +3031,7 @@ nv.ua##.collection_form__container
 wired.co.uk##.bb-newsletter
 inews.co.uk##.inews__email-signup
 cosmo.ru##.news-subscription
-vogue.*##.ticker-view
+ad-italia.it,ad-magazin.de,admagazine.com,admagazine.fr,admagazine.ru,allure.com,architecturaldigest.com,architecturaldigest.in,bonappetit.com,cntraveler.com,cntraveller.com,cntraveller.in,glamour.com,glamour.de,glamour.es,glamour.mx,glamour.ru,glamourmagazine.co.uk,gq-magazin.de,gq-magazine.co.uk,gq.com,gq.com.mx,gq.com.tw,gq.ru,gqindia.com,gqitalia.it,gqjapan.jp,gqmagazine.fr,houseandgarden.co.uk,lacucinaitaliana.it,newyorker.com,pitchfork.com,revistaad.es,revistagq.com,revistavanityfair.es,self.com,tatler.com,tatler.ru,teenvogue.com,them.us,traveler.es,vanityfair.com,vanityfair.fr,vanityfair.it,vogue.co.jp,vogue.co.uk,vogue.com,vogue.com.tw,vogue.de,vogue.es,vogue.fr,vogue.in,vogue.it,vogue.mx,vogue.ru,voguebusiness.com,wired.co.uk,wired.com,wired.it,wired.jp##.ticker-view
 vogue.ua##.subscribe_wrapper
 ekantipur.com#?#body > div[class]:has(> div.text-center > a[href="http://kmg.com.np/subscribe"])
 habr.com##.tm-editoral-subscription


### PR DESCRIPTION
## What problem does the pull request fix?

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Block `.ticker-view` on additional Condé Nast sites.

example URL: `https://www.ad-magazin.de/`

<details>

<summary>Screenshot 1:</summary>

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/110956608/187587455-024ba93b-c0f9-4cb6-b399-a6fe1099c620.png">

</details>


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
