### PR TITLE
Block bleacherreport.com newsletter popup

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -34,6 +34,7 @@ turkuazgazetesi.net,yenialanya.com,mansetaydin.com,seskocaeli.com,kocaelibarisga
 !
 ! SECTION: Subscriptions - Regular rules
 !
+bleacherreport.com##.newsletterSubsModule.flyIn
 cleananddelicious.com##.widget_reblex-widget
 cleananddelicious.com###text-18
 cleananddelicious.com##.wp-block-kadence-rowlayout


### PR DESCRIPTION
## What issue is being fixed?

Block newsletter popup on bleacherreport.com (e.g. `https://bleacherreport.com/articles/10047184-lakers-rumors-cam-reddish-interests-la-in-donovan-mitchell-knicks-3-team-trade-talks`)

<!-- Please write a comment here -->

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

<img width="928" alt="image" src="https://user-images.githubusercontent.com/110956608/187591390-fbaa2c6c-afa3-4b07-b1f6-a684761871de.png">

</details>
