### PR TITLE
Block cjr.org interstitial popup

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -7,6 +7,8 @@
 !
 ! SECTION: Popups - Regular rules
 !
+cjr.org###interContainer
+cjr.org###interVeil
 times.zt.ua#$#html
 times.zt.ua#$#.pum-overlay { display: none !important; }
 postupi.online##.asterisk-nd_sm

--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -7,14 +7,12 @@
 !
 ! SECTION: Popups - Regular rules
 !
-cjr.org###interContainer
-cjr.org###interVeil
 times.zt.ua#$#html
 times.zt.ua#$#.pum-overlay { display: none !important; }
 postupi.online##.asterisk-nd_sm
 goboo.com#$#section[class^="popIndexBox_"] { display: none!important; }
 goboo.com#$#body { overflow: auto!important; }
-brazzers.com##img[src$="/catfish.png"] + div > a[href="/joinf"] 
+brazzers.com##img[src$="/catfish.png"] + div > a[href="/joinf"]
 coub.com#%#//scriptlet('set-local-storage-item', 'music-announce-showed', 'true')
 stolichki.ru###popupSpecial ~ div.iziModal-overlay
 stolichki.ru###popupSpecial

--- a/EnglishFilter/sections/general_extensions.txt
+++ b/EnglishFilter/sections/general_extensions.txt
@@ -133,7 +133,7 @@ ganooll.co,idtube.me,idxx1.net,185.224.130.67,idxx1.rocks,103.194.171.75,underur
 imgrock.info,dir50.net,thevideo.me,voodaith7e.com,imgrock.net,imgoutlet.com,doyki.com,vidup.me,imgoutlet.com#%#Object.defineProperty(window, 'jsPopunder', { get: function() { return function() {}; } });
 !
 ! initPu, puShown
-shemaleporn.xxx,lizardporn.com,downace.com,javstyle.com,yts.ag,qwertty.net,imgsin.com#%#Object.defineProperty(window, 'puShown', { get: function() { return true; } }); 
+shemaleporn.xxx,lizardporn.com,downace.com,javstyle.com,yts.ag,qwertty.net,imgsin.com#%#Object.defineProperty(window, 'puShown', { get: function() { return true; } });
 123pandamovie.me,adultvideoz.net,mangovideo.pw,cartoonporno.xxx,69games.xxx,mirrorace.com,xxxhost.me,4fuckr.com#%#Object.defineProperty(window, 'initPu', { get: function() { return; } });
 thetodaypost.com,yukfilmizle.com,safirfilmizle1.com,filese.me,mylink.vc#%#//scriptlet("abort-on-property-read", "initPu")
 seyredeger.com,masterplayer.*,elil.cc,balfilmizle1.com,filmseyretizlet.com,altyazilifilm.*,milfzr.com,movies07.live,adly.fun,hotscopes.*,hentaianimedownloads.com,indiatoday.tech,erotikfilmsitesi.com,mobileflasherbd.com,eroticpub.com,boobsrealm.com,myli3k.com,kickass.ws,naughtymachinima.com,mangovideo.club,22pixx.xyz,xxxparodyhd.net,torrentproject.cc,pandamovies.me,porcore.com,dbupload.co,fileru.me,mangoporn.net,pornkino.cc,watchpornfree.info,imguur.pictures,xxxmoviestream.xyz,mangoporn.co,kickass.vc,pandavideo.pw,freshscat.com,playpornfree.xyz,kickass.love,desiupload.in,xopenload.me,streamporn.pw#%#//scriptlet("set-constant", "puShown", "true")
@@ -1090,7 +1090,7 @@ upstream.to#%#//scriptlet('prevent-window-open')
 comixzilla.com#%#//scriptlet("abort-current-inline-script", "document.createElement", ".parentNode.insertBefore(")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83749
 nyafilmer2.com,nyafilmer1.com,nyafilmer.*#%#//scriptlet("prevent-window-open")
-! abandonmail.com - site does not allow private mode in Firefox 
+! abandonmail.com - site does not allow private mode in Firefox
 abandonmail.com#%#//scriptlet("set-constant", "db.onerror", "undefined")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83343
 coursedown.com#%#//scriptlet("prevent-addEventListener", "DOMContentLoaded", "adlinkfly_url")
@@ -1189,7 +1189,7 @@ hoastie.com#%#//scriptlet("abort-on-property-read", "open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/79407
 coin.mg#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/80254
-vladan.fr#%#//scriptlet("abort-on-property-read", "wpsite_clickable_data") 
+vladan.fr#%#//scriptlet("abort-on-property-read", "wpsite_clickable_data")
 ! popup on click
 sportbet.tips#%#//scriptlet("abort-on-property-read", "_wm")
 ! auto redirect after click
@@ -1289,7 +1289,7 @@ nbaup.live,goalup.live#%#//scriptlet("abort-on-property-read", "popup")
 nflup.live#%#//scriptlet("abort-on-property-read", "S9tt")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72379
 !+ NOT_PLATFORM(windows, mac, android, ext_ff)
-isaiminiweb.online#%#AG_onLoad(function(){document.querySelector('meta[http-equiv="REFRESH"]')&&setTimeout(function(){window.stop()},4E3)}); 
+isaiminiweb.online#%#AG_onLoad(function(){document.querySelector('meta[http-equiv="REFRESH"]')&&setTimeout(function(){window.stop()},4E3)});
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76395
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_ext_firefox)
 bing.com#%#//scriptlet('prevent-setInterval', 'logQueue', '10000')
@@ -1405,7 +1405,7 @@ clipwatching.*#%#//scriptlet("set-constant", "dtGonza.playeradstime", "-1")
 animax.*#%#//scriptlet("abort-on-property-read", "_run")
 ! pop-ups in uploader.link, zeefiles.download
 zeefiles.download,uploader.link#%#//scriptlet("prevent-window-open")
-! marvelousga.com - popups 
+! marvelousga.com - popups
 marvelousga.com#%#//scriptlet("abort-current-inline-script", "$", "openNewWindow")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/74749
 downloadtwittervideo.com#%#//scriptlet('prevent-window-open')
@@ -1543,7 +1543,7 @@ ddl-music.to#%#//scriptlet('abort-current-inline-script', 'current_location')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71805
 userload.co#%#//scriptlet("prevent-window-open")
 userload.co#%#//scriptlet("abort-current-inline-script", "$", "popunder")
-userload.co#%#(function(){window.addEventListener("load",function(){var a=document.getElementById("videooverlay");a&&a.click()})})(); 
+userload.co#%#(function(){window.addEventListener("load",function(){var a=document.getElementById("videooverlay");a&&a.click()})})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71773
 ytmp3.mobi#%#//scriptlet("prevent-window-open", "1", "ad.ytmp3.mobi")
 ! https://forum.adguard.com/index.php?threads/25917/
@@ -2203,12 +2203,12 @@ rifurl.com#%#//scriptlet("abort-on-property-read", "_cpp")
 playvids.com#%#document.cookie="rpuShownDesktop=1; path=/;";
 playvids.com#%#//scriptlet("set-constant", "pop_clicked", "1")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52726
-girlwallpaper.pro#%#AG_onLoad(function(){document.querySelectorAll('a[href^="st/out.php?"][href*="/out.php?u="]').forEach(function(a){var b=a.getAttribute("href").split("/out.php?u=");a.setAttribute("href",b[1])})}); 
+girlwallpaper.pro#%#AG_onLoad(function(){document.querySelectorAll('a[href^="st/out.php?"][href*="/out.php?u="]').forEach(function(a){var b=a.getAttribute("href").split("/out.php?u=");a.setAttribute("href",b[1])})});
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52666
 voyeurhit.com#%#//scriptlet("set-constant", "adver", "noopFunc")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52651
 sextvx.com#%#//scriptlet("prevent-setTimeout", "window.location.href=link")
-sextvx.com#%#(function(){try{if("undefined"!=typeof localStorage&&localStorage.setItem){var a=(new Date).getTime();localStorage.setItem("popseen",JSON.stringify(a))}}catch(b){}})(); 
+sextvx.com#%#(function(){try{if("undefined"!=typeof localStorage&&localStorage.setItem){var a=(new Date).getTime();localStorage.setItem("popseen",JSON.stringify(a))}}catch(b){}})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52612
 ushrt.me#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52586
@@ -2259,7 +2259,7 @@ adclic.pro#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51416
 hentaiworld.tv#%#//scriptlet("abort-on-property-read", "calculate_interstitial")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51302
-dwrfslsqpdfqfwy.net#%#(function(){var a;Object.defineProperty(window,"initLbjs",{get:function(){return a},set:function(c){a=function(a,b){b.AdPop=!1;return c(a,b)}}})})(); 
+dwrfslsqpdfqfwy.net#%#(function(){var a;Object.defineProperty(window,"initLbjs",{get:function(){return a},set:function(c){a=function(a,b){b.AdPop=!1;return c(a,b)}}})})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51286
 xxxhentai.net#%#//scriptlet('remove-attr', 'data-id', '.gallery-list > div[itemprop="associatedMedia"] > a[href][data-id]')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51069
@@ -2294,7 +2294,7 @@ cloudgallery.net,imgair.net#%#//scriptlet("abort-current-inline-script", "docume
 cloudgallery.net,imgair.net#%#//scriptlet("prevent-window-open", "1", "/tripedrated\.xyz|salaure\.pro|imgair\.net\/vip\//")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50378
 teenskitten.com#%#AG_onLoad(function(){document.querySelectorAll("a[href^='/gallery/'][data-href]").forEach(function(a){var b=a.getAttribute("data-href"),c=a.href;b=c.substring(0,c.indexOf(b));a.setAttribute("href",b)})});
-wetpussy.sexy#%#AG_onLoad(function(){document.querySelectorAll('a[href^="/cc/out.php?"][href*="/o.php?u=http"]').forEach(function(a){var b=a.getAttribute("href").split("/o.php?u=");a.setAttribute("href",b[1])})}); 
+wetpussy.sexy#%#AG_onLoad(function(){document.querySelectorAll('a[href^="/cc/out.php?"][href*="/o.php?u=http"]').forEach(function(a){var b=a.getAttribute("href").split("/o.php?u=");a.setAttribute("href",b[1])})});
 ! api.youtube-mp3.org.in - popups
 api.youtube-mp3.org.in#%#//scriptlet("prevent-window-open")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50106
@@ -2410,7 +2410,7 @@ antarvasnaphotos.com#%#document.cookie = "poppied=true";
 ! https://github.com/AdguardTeam/AdguardFilters/issues/46280
 freehentaistream.com#%#//scriptlet("abort-on-property-read", "dataPopUnder")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/46145
-zootube1.com#%#AG_onLoad(function(){document.querySelectorAll('a[href^="/zoo/play.php?hd="]').forEach(function(a){var b=a.getAttribute("href").split("/zoo/play.php?hd=");a.setAttribute("href",b[1])})}); 
+zootube1.com#%#AG_onLoad(function(){document.querySelectorAll('a[href^="/zoo/play.php?hd="]').forEach(function(a){var b=a.getAttribute("href").split("/zoo/play.php?hd=");a.setAttribute("href",b[1])})});
 ! express-cut.ovh - popups
 !+ NOT_PLATFORM(windows, mac, android)
 express-cut.ovh#%#//scriptlet("prevent-window-open")
@@ -2525,7 +2525,7 @@ xsexvideos.pro,mature-tube.sexy#%#//scriptlet('prevent-setTimeout', '/window\.lo
 !+ PLATFORM(windows, mac, android)
 xsexvideos.pro,mature-tube.sexy#%#(function(){var b=window.setTimeout;window.setTimeout=function(a,c){if(!/window\.location\.href = ("\/sell\.php"|popURL)/.test(a.toString()))return b(a,c)};})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43481
-moneymanagement.com.au#%#(function(){if(-1!=window.location.href.indexOf("/intro-mm"))for(var c=document.cookie.split(";"),b=0;b<c.length;b++){var a=c[b];a=a.split("=");"redirect_url_to_intro"==a[0]&&window.location.replace(decodeURIComponent(a[1]))}})(); 
+moneymanagement.com.au#%#(function(){if(-1!=window.location.href.indexOf("/intro-mm"))for(var c=document.cookie.split(";"),b=0;b<c.length;b++){var a=c[b];a=a.split("=");"redirect_url_to_intro"==a[0]&&window.location.replace(decodeURIComponent(a[1]))}})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/43470
 iddeas.xyz#%#//scriptlet("prevent-window-open")
 iddeas.xyz#%#window.open = function() {};
@@ -2784,7 +2784,7 @@ mediafire.com#%#//scriptlet("set-constant", "InfCustomFPSTAFunc", "noopFunc")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/34854
 stfly.io#%#window.open = function() {};
 ! https://forum.adguard.com/index.php?threads/upload-ac.32152/
-upload.ac#%#AG_onLoad(function() { setTimeout(function() { var el = document.getElementById("chkIsAdd"); if(el) { el.click(); } }, 300); });   
+upload.ac#%#AG_onLoad(function() { setTimeout(function() { var el = document.getElementById("chkIsAdd"); if(el) { el.click(); } }, 300); });
 ! https://forum.adguard.com/index.php?threads/userscloud-com.32800
 userscloud.com#%#//scriptlet("remove-attr", "onclick", "#btn_download")
 ! dancers `Popping Tool`
@@ -2849,7 +2849,7 @@ kastream.biz#%#window.open = function() {};
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31976
 fileflares.com#%#(function(){var c=document.addEventListener;document.addEventListener=function(a,b,d,e){"click"!=a&&-1==b.toString().indexOf('bi()')&&c(a,b,d,e)}.bind(document);})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/15133
-link.tl#%#AG_onLoad(function() { setTimeout(function() {if(window.location.href.indexOf("/i/") != -1) { document.querySelector(" .skip > a").click(); }}, 300); }); 
+link.tl#%#AG_onLoad(function() { setTimeout(function() {if(window.location.href.indexOf("/i/") != -1) { document.querySelector(" .skip > a").click(); }}, 300); });
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31204
 x1337x.eu,1337x.to,1337x.st,x1337x.ws#%#//scriptlet("set-constant", "S9tt", "noopFunc")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30037
@@ -3568,7 +3568,7 @@ myasiantv.se#%#Object.defineProperty(window, 'was_init', { get: function() { ret
 ! https://forum.adguard.com/index.php?threads/mirrorcreator-com.16889/
 mirrorcreator.com#%#(function(){var b=window.addEventListener;window.addEventListener=function(c,a,d){if(a&&-1==a.toString().indexOf("data:application/pdf;base64,JVBERi0"))return b(c,a,d)}.bind(window)})();
 ! https://forum.adguard.com/index.php?threads/vodlocker-lol.16910/
-vidup.me#%#Object.defineProperty(window, 'adsShowPopup', { get: function() { return false; } }); 
+vidup.me#%#Object.defineProperty(window, 'adsShowPopup', { get: function() { return false; } });
 ! https://forum.adguard.com/index.php?threads/http-www-semprot-com.15120/
 93.115.24.210,semprot.com#%#Object.defineProperty(window, 'semprot_abp', { set:function(){ throw new TypeError(); }});
 ! https://forum.adguard.com/index.php?threads/16792/
@@ -3691,7 +3691,7 @@ streamlive.to#%#window.open = function() {};
 ! http://forum.adguard.com/showthread.php?9805
 adlice.com#%#Object.defineProperty(window, 'inc_popup', { get: function() { return {}; } });
 ! http://forum.adguard.com/showthread.php?9782
-byetv.org#%#window.open = function() {}; 
+byetv.org#%#window.open = function() {};
 ! http://forum.adguard.com/showthread.php?9532
 ! background ads
 dailymail.co.uk#%#Object.defineProperty(window, 'adBlockQueue', { get: function() { return; }, set: function() {} });
@@ -3706,7 +3706,7 @@ youjizz.com#%#Object.defineProperty(window, 'th_ab_pop', { get: function() { ret
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1642
 play3r.net#%#(function() { var w_open = window.open, regex = /goo.gl/; window.open = function(a, b) { if (typeof a !== 'string' || !regex.test(a)) { w_open(a, b); } }; })();
 ! cpmstar ads
-armorgames.com,onrpg.com,mmohuts.com,newgrounds.com#%#Object.defineProperty(window, 'cpmstar_siteskin', { get: function() { return {}; } }); 
+armorgames.com,onrpg.com,mmohuts.com,newgrounds.com#%#Object.defineProperty(window, 'cpmstar_siteskin', { get: function() { return {}; } });
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1607
 ! spectrum.ieee.org - disable splash screen
 spectrum.ieee.org#%#//scriptlet("set-constant", "splashpage", "undefined")
@@ -3719,7 +3719,7 @@ turbobita.com,turbobit.net,turboot.ru#%#AG_onLoad(function() { setCookie('turbob
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1573
 libertyalliance.com#%#Object.defineProperty(window, 'zy', { get: function() { return {}; } });
 ! custompcreview.com - remove clickunder
-custompcreview.com#%#Object.defineProperty(window, 'bg_backgrounds', { get: function() { return []; } }); 
+custompcreview.com#%#Object.defineProperty(window, 'bg_backgrounds', { get: function() { return []; } });
 ! benchmarkreviews.com - remove clickunder
 benchmarkreviews.com#%#Object.defineProperty(window, 'bg_backgrounds', { get: function() { return []; } });
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1416
@@ -3784,6 +3784,10 @@ mobilapk.com#%#AG_onLoad(function() { setTimeout(function() {document.getElement
 !-------CSS---------
 !-------------------
 !
+! https://github.com/AdguardTeam/AdguardFilters/pull/128485
+cjr.org#$#html { overflow: auto !important; }
+cjr.org#$##interContainer { display: none !important; }
+cjr.org#$##interVeil { display: none !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/128039
 yourdictionary.com#$#.advertising-container ~ header.header { top: 0 !important; }
 yourdictionary.com#$#body .advertising-container:not(#style_important) { display: none !important; }
@@ -4152,8 +4156,8 @@ mokkaofficial.com#$#.adsbygoogle { position: absolute!important; left: -3000px!i
 notube.net#$##download2-add { display: none !important; }
 notube.net#$#download2 { display: inline-block !important; }
 ! https://forum.adguard.com/index.php?threads/unable-to-use-live-sports-website-since-last-years-adguard-update.39785
-firstr0w.eu#$##sunInCenter + .cover { position: absolute!important; left: -2000px!important; } 
-! 
+firstr0w.eu#$##sunInCenter + .cover { position: absolute!important; left: -2000px!important; }
+!
 eprice.com.tw#$#.parallax-ads-container { position: absolute!important; left: -3000px!important; }
 ! vladan.fr - branding
 vladan.fr#$#html > body { background-image: none !important; }
@@ -4314,7 +4318,7 @@ riotpixels.com#$#body .bottom-bar { top:0 !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39816
 pornflip.com#$#.bottom-banner > .a-label { visibility: hidden!important; }
 ! digitaltrends.com - ad text in article
-digitaltrends.com#$#.dtads-slot { position: absolute!important; left: -2000px!important; } 
+digitaltrends.com#$#.dtads-slot { position: absolute!important; left: -2000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38399
 ytss.unblocked.to#$#html[style] header.nav-bar { margin-top: 0!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/38211
@@ -4331,7 +4335,7 @@ smh.com.au#$#div[id^="adspot-"] { position: absolute!important; left: -3000px!im
 forum.xda-developers.com#$#.twig { display: none !important; }
 forum.xda-developers.com#$#body.twig-body > header[role="banner"] { top: 0!important; }
 ! viprow.net - overlay over video
-viprow.net#$#.embed-responsive > iframe + .position-absolute { position: absolute!important; left: -2000px!important; } 
+viprow.net#$#.embed-responsive > iframe + .position-absolute { position: absolute!important; left: -2000px!important; }
 ! https://forum.adguard.com/index.php?threads/why-website-ask-you-these-questions.33046/
 space.com#$#.hawk-disclaimer-container { border-top:none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33845
@@ -4374,7 +4378,7 @@ seattlepi.com#$#header > #homepage-timestamp { position: relative!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/29163
 brisbanetimes.com.au#$#div[id^="adspot-"] { position: absolute!important; left: -3000px!important; }
 ! pornhub.com ad left-over on main page
-pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; } 
+pornhub.com,pornhub.org,pornhub.net,pornhubthbh7ap3u.onion#$#iframe[title*="Campaign"] { position: absolute!important; left: -3000px!important; }
 ! https://forum.adguard.com/index.php?threads/up-4-net.30856/
 up-4.net#$##btn_downloadLink { display:block!important; }
 up-4.net#$##btn_downloadPreparing { display:none!important; }
@@ -4448,7 +4452,7 @@ leechpremium.link#$#.modal-backdrop { display: none!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/24323
 oregonlive.com#$##adTower { margin-top: 0px; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23773
-vporn.com#$#a[href^="//bongacams2.com"] { position: absolute!important; left: -3000px!important; } 
+vporn.com#$#a[href^="//bongacams2.com"] { position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/23644
 digit.in#$##main { padding: 59px 0 0!important; }
 digit.in#$##sub_header { top: 40px!important; }
@@ -4604,7 +4608,7 @@ tempostorm.com#$#.bg-override {background-color: #1b141d!important; }
 dvbtmap.eu#$##leftCol { top: 50px!important; }
 dvbtmap.eu#$##content-container { margin-top: 0!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/10712
-bitfun.co#$#div[class^="flex"][class*="Ad"] { position: absolute!important; left: -2000px!important; } 
+bitfun.co#$#div[class^="flex"][class*="Ad"] { position: absolute!important; left: -2000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/11379
 redtube.com,redtube.net#$#.video_left_section > .hd .subtxt {position: absolute!important; left: -3000px!important; }
 redtube.com,redtube.net#$#.remove_ads {position: absolute!important; left: -3000px!important; }
@@ -4647,7 +4651,7 @@ dailyfreebits.com#$#a[href^="//mellowads.com/"] { visibility: hidden!important; 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8455
 opensnow.com#$#.mobile-ad { position: absolute!important; left: -4000px!important; }
 opensnow.com#$#.wide-ad { position: absolute!important; left: -4000px!important; }
-opensnow.com#$#.web-ad { position: absolute!important; left: -4000px!important; } 
+opensnow.com#$#.web-ad { position: absolute!important; left: -4000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8370
 blockersurvive.com#$#.ads-content { height: 1px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7699
@@ -4933,7 +4937,7 @@ gamepedia.com#$#.ad-placement { position: absolute!important; left: -3000px!impo
 ndtv.com#$#div[class^="ad300"] { position: absolute!important; left: -3000px!important; }
 ! https://forum.adguard.com/index.php?threads/13435/
 inoreader.com#$##reader_pane.reader_pane_sinner { padding-right: 0!important; }
-! upload.so - force activate original download button 
+! upload.so - force activate original download button
 upload.so#$#button#downloadBtnClickOrignal { display: block!important; }
 upload.so#$#button#downloadBtnClick { display: none!important; }
 ! https://forum.adguard.com/index.php?threads/12853/


### PR DESCRIPTION
## What issue is being fixed?

Block interstitial popup on cjr.org (e.g. `https://www.cjr.org/the_media_today/laflamme_canada_media_diversity.php`)

<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/110956608/187594466-c637e32e-8253-4884-9fd9-40c432ae920b.png)

</details>
