### PR TITLE
developer.mozilla.org: self-promo banner

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -1449,6 +1449,7 @@ theguardian.com##.contributions__adblock
 !
 ! SECTION: Self-promo - Regular rules
 !
+developer.mozilla.org##.mdn-cta-container
 spigotunlocked.org###notification_preview
 scientificamerican.com##.spw
 neeva.com##div[class^="app-layout__column"] > div[style="--group-height:238px;"]


### PR DESCRIPTION
Block MDN Plus self-promo banner. `https://developer.mozilla.org/en-US/`

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/110956608/187791313-dfd08acf-6f44-454e-92c7-8480b1299148.png)

</details>