### PR TITLE
Block Weebly Promote Forms popups

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_general.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_general.txt
@@ -50,6 +50,7 @@
 ||borgan.ru^$third-party
 ||cdn*.pdmntn.com^$third-party
 ||cdn-library.su/plusonet/lib/$domain=~pluso.net
+||cdn-promote.weebly.com/js/dist/lead-form.js$third-party
 ||cdn.pn.vg^$third-party
 ||cdn.swellrewards.com^$third-party
 ||chat.whatsappx.xyz^$third-party

--- a/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
@@ -17,7 +17,6 @@
 !
 /wp-content/plugins/mailoptin/*
 !
-||cdn-promote.weebly.com/js/dist/lead-form.js$third-party
 ||embeds.fanmatics.com^$third-party
 ||inyourarea.co.uk^$third-party
 ||js.emailable.com^$third-party

--- a/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
@@ -17,6 +17,7 @@
 !
 /wp-content/plugins/mailoptin/*
 !
+||cdn-promote.weebly.com/js/dist/lead-form.js$third-party
 ||embeds.fanmatics.com^$third-party
 ||inyourarea.co.uk^$third-party
 ||js.emailable.com^$third-party


### PR DESCRIPTION
## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Annoyances — pop-ups, cookie warnings, etc;


## What issue is being fixed?

### Enter the issue address

Example: `https://www.valeriewai.com`

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

1. This PR blocks Weebly Promote Forms popups `https://www.weebly.com/app-center/promote-forms`

<details><summary>screenshot</summary>

<img width="984" alt="image" src="https://user-images.githubusercontent.com/110956608/189576838-cd0e70ce-b3fe-4171-a8ab-3d90cd2c6c55.png">

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
