### PR TITLE
hide mcsweeneys.net self-promo ads

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -1472,6 +1472,7 @@ theguardian.com##.contributions__adblock
 !
 ! SECTION: Self-promo - Regular rules
 !
+mcsweeneys.net##.house-ad-right
 [$path=/search]yandex.*##.DistrPopup
 gofile.io###adsAads
 detail.chiebukuro.yahoo.co.jp###v_bnr


### PR DESCRIPTION
This PR hides mcsweeneys.net self-promo ads

e.g., `https://www.mcsweeneys.net/articles/becoming-a-new-dad-in-middle-age-as-told-by-the-sheriff-from-no-country-for-old-men`

<details>
<summary>Screenshots</summary>

<img width="581" alt="image" src="https://user-images.githubusercontent.com/110956608/190594001-7c364606-d4ce-4967-bf59-7479f1fd08fa.png">

</details>