### PR TITLE
hide mcsweeneys.net floating banner

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -7,6 +7,7 @@
 !
 ! SECTION: Popups - Regular rules
 !
+mcsweeneys.net###floating-footer-container
 spinoff.com.br###gridPopupCTA
 shibarinashi-wifi.jp###entry_fix
 bunshun.jp##.article-followed-related


### PR DESCRIPTION
This PR hides mcsweeneys.net floating banner

<details>
<summary>Screenshots</summary>

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/110956608/190595034-1c0d93cb-e24a-4c13-a299-c595cfac2229.png">


</details>