### PR TITLE
tver.jp - unused rule

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -216,7 +216,6 @@ $app=com.miui.analytics
 ||analytics.liveact-vault.com^
 ||dex50.deteql.net^
 ||analytics.300624.com^
-||measure.ic.tver.jp^
 ||toblog.ctobsnssdk.com^
 ||tobapplog.ctobsnssdk.com^
 ||t.castle.io^

--- a/SpywareFilter/sections/mobile_allowlist.txt
+++ b/SpywareFilter/sections/mobile_allowlist.txt
@@ -8,8 +8,6 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/121419
 @@||eum-blue-saas.instana.io^$app=com.kaufland.Kaufland
 @@||swasc.kaufland.com^$app=com.kaufland.Kaufland
-! https://play.google.com/store/apps/details?id=jp.hamitv.hamiand1 broken on startup
-@@||measure.ic.tver.jp^$app=jp.hamitv.hamiand1
 ! https://github.com/AdguardTeam/AdguardFilters/issues/100669
 @@||amplify.outbrain.com^$app=jp.co.alc.eow
 @@||b92.yahoo.co.jp^$app=jp.co.alc.eow


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://tver.jp/

### Add your comment and screenshots

This is an unused rule because the domain `measure.ic.tver.jp` is only used in `jp.hamitv.hamiand1` app.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
