### PR TITLE
chip.de - ads and tracking

### DIFF
--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -73,7 +73,7 @@ bs.to#%#//scriptlet("abort-current-inline-script", "parseInt", "bsduid")
 stern.de#%#//scriptlet("json-prune", "enabled", "testhide")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31070
 !+ NOT_PLATFORM(windows, mac, android, ext_ff)
-chip.de#%#//scriptlet("json-prune", "enabled", "testhide")
+chip.de#%#//scriptlet("json-prune", "enabled", "force_disabled")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53011
 gload.to#%#//scriptlet("abort-on-property-write", "bullads")
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52959

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -207,6 +207,7 @@ meine-woche.de##.park-teaser--sugardaddy
 meine-woche.de##.park-opener--sugardaddy
 wa.de##.id-StoryElement-beepWrap
 chip.de##div[style="min-height:250px;"]
+chip.de##div[style="min-height:120px;"]
 rollingstone.de##.ph-ad-fallback-top-billboard
 ||rtl.de/phoenix/images-loaded/local.js
 mopo.de##a[href*="campaign"][target="_blank"]

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -56,6 +56,7 @@
 !||i.snssdk.com/log/*
 !||i.snssdk.com/slardar/sdk.js
 !
+||network.screen13.com^
 ||tracker.gleanview.com^
 ||pahtag.tech^$third-party
 ||rtc.dymatrix.cloud^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

no open issue

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->

damoh video ads and "sponsored" ads. Also there are pings to `network.screen13.com` coming from the ads.

<details>
<summary> Screenshot: </summary>
<img width="559" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/196053690-1110698c-ac1e-4dd6-99c4-0beea4a8775e.PNG">


</details>


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
