### PR TITLE
Add host*.rigbyandpeller.com

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -985,6 +985,7 @@
 ||host*.nti.nl^
 ||host*.polaroid.com^
 ||host*.rvshare.com^
+||host*.rigbyandpeller.com^
 ||howmanyview.com^
 ||hrumpoc.hotels.com^
 ||hstats.hepsiburada.com^


### PR DESCRIPTION
This pull request adds host*.rigbyandpeller.com to the first party tracking list.

You can verify this with already existent [host*.nti.nl^](https://github.com/AdguardTeam/AdguardFilters/blob/master/SpywareFilter/sections/tracking_servers_firstparty.txt#L985)

- [https://host10.nti.nl/kuq.js](https://host10.nti.nl/kuq.js)
- [https://host10.rigbyandpeller.com/suin.js](https://host10.rigbyandpeller.com/suin.js)

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
