### PR TITLE
tarnkappe.info - tracking and obsolete filter

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -87,7 +87,6 @@ ciudad.com.ar###cxense-wrapper
 ||go-go.tech/0c.gif?
 ||pstatic.net/adimg3.search/adpost/
 ||resultspage.com/js/sli-spark.js
-||pf.as.tarnkappe.info/matOG.js
 ||cope.es/stats/services/recordEvent
 ||163.com/*/__utm.gif?
 ||maximum.ru/uploads/metrics.js

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -25,6 +25,7 @@
 ! Blocking piwik analytics subdomain(for DNS filtering)
 |piwik.
 !
+||as.tarnkappe.info^
 ||analytics.mall.tv^
 ||log.etoday.co.kr^
 ||u.zhugeapi.net^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

no issue

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->

There is a tracking script coming from `as.tarnkappe.info`. `pf.as.tarnkappe.info/matOG.js` is obsolete because the path is unstable


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
