### PR TITLE
shutterstock.com - email tracking

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -4888,6 +4888,8 @@
 ! note that we don't use || prefixes because mail tracking pixels are often proxied by mail providers
 ! it's problematic that due to how Gmail proxy work, these domains aren't even exposed on the network level
 ! fortunately, extensions can see them (Gmail puts the real URL in the location.hash part of the src)
+! Shutterstock
+shutterstockmail.com/pub/as?_ri_=$image
 ! MailTrack
 mailtrack.io/trace/$image
 mltrk.io/pixel$image


### PR DESCRIPTION


## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [ ] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address



### Add your comment and screenshots

This is a promotional mail sent by Shutterstock to my temporary mailing address.

Sample:
`https://shutterstockmail.com/pub/as?_ri_=XXX&_ei_=XXX.`

<details><summary>Image</summary>

![image](https://user-images.githubusercontent.com/103899764/200665181-c64e8198-209d-4136-a9ef-850b5c4316a9.png)


</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
