### PR TITLE
$removeparam=erid

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -7,6 +7,8 @@
 ! Good: $removeparam=utm_id
 ! Bad:  $removeparam=utm_id,domain=example.org (for instance, should be in specific.txt)
 !
+! https://interactivead.ru/wp-content/uploads/2022/08/arir22_rkn.pdf
+$removeparam=erid
 ! Cxense clickthrough tracking
 $removeparam=cx_click
 ! Marketo email tracking
@@ -202,4 +204,3 @@ $removeparam=fb_comment_id
 $removeparam=fb_ref
 $removeparam=fb_source
 !
-$removeparam=erid

--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -201,3 +201,5 @@ $removeparam=fb_action_types
 $removeparam=fb_comment_id
 $removeparam=fb_ref
 $removeparam=fb_source
+!
+$removeparam=erid


### PR DESCRIPTION
Роскомнадзор хочет вешать метки на всю интернет-рекламу:

https://thebell.io/kto-budet-uchityvat-vsyu-reklamu-v-internete-chto-budet-s-vizami-i-kak-raskryt-moshennichestvo-po-fotografii

Вот здесь подробные жутко бюрократические пояснения:

https://interactivead.ru/wp-content/uploads/2022/08/arir22_rkn.pdf

Короче:

> "Получить идентификатор креатива может любой участник рынка, обратившись в ОРД и предоставив необходимые для регистрации данные. "Повесить" полученный идентификатор на креатив агенство может при прямом размещении, добавив идентификатор (erid=XXX) в кликовую ссылку рекламного объявления "

Еще короче:
$removeparam=erid
