### PR TITLE
stackcommerce.com

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -4900,6 +4900,8 @@
 ! fortunately, extensions can see them (Gmail puts the real URL in the location.hash part of the src)
 ! Shutterstock
 shutterstockmail.com/pub/as?_ri_=$image
+! Stackcommerce
+track.email.stackcommerce.com/q/$image
 ! MailTrack
 mailtrack.io/trace/$image
 mltrk.io/pixel$image


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ ] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?



### Add your comment and screenshots

**Steps to reproduce:**

Click the link below
`https://deals.ghacks.net/sales/microsoft-office-professional-plus-2021-for-windows`

You will see a popup offering a 10% discount. 

<details><summary>Image</summary>

![image](https://user-images.githubusercontent.com/103899764/204036893-6e3be66a-f757-449a-9214-d157e72e21af.png)


</details>

Type an email address and check the incoming mail.




### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
