### PR TITLE
Mass update to the GitHub report form to better accomodate AGH and uBO users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,6 +33,8 @@ body:
         - AdGuard for Mac
         - AdGuard for Safari
         - AdGuard for Windows
+        - AdGuard Home
+        - uBlock Origin (Firefox/MV2)
         - Other ad blocker
     validations:
       required: true
@@ -74,9 +76,10 @@ body:
         - Safari
         - Microsoft Edge
         - Opera
+        - Vivaldi
         - Yandex Browser
-        - other(specify in comment below)
-        - the problem is with app, not a site
+        - Other (Specify in comment below)
+        - The problem is with an app, not a site
     validations:
       required: true
 
@@ -88,6 +91,7 @@ body:
       options:
         - Desktop
         - Mobile
+        - Other (e.g. TV, game console)
     validations:
       required: true
 
@@ -121,9 +125,12 @@ body:
         - AdGuard URL Tracking filter
         - AdGuard Social Media filter
         - AdGuard Annoyances filter
+        - AdGuard Popups filter
+        - AdGuard Mobile App Banners filter
         - AdGuard DNS filter
         - AdGuard Experimental filter
         - Filter unblocking search ads and self-promotion
+        - AdGuard Browsing Security module
         - ---Third-party filters---
         - EasyList
         - ABPindo
@@ -190,6 +197,17 @@ body:
         - Dandelion Sprout's Nordic Filters
         - Dandelion Sprout's Annoyances List
         - Legitimate URL Shortener
+        - ---Frequently used other lists---
+        - uBlock Filters
+        - uBlock Filters – Badware Risks
+        - uBlock Filters – Privacy
+        - uBlock Filters – Quick fixes
+        - uBlock Filters – Resource abuse
+        - uBlock Filters – Unbreak
+        - Block Outsider Intrusion into LAN
+        - Dan Pollock's List
+        - Fanboy's Notifications Blocking List
+        
     validations:
       required: true
 


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [ ] My changes do not break web sites, apps and files structure. (I was unsure how this PR would affect the AdGuard site's report form and adguard-bot's color labels, if at all.)

## What problem does the pull request fix?

Missing lists, extensions, and tools where it is feasible to expect that AdGuard Filters lists are used by end-users.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

A fair few issues where users were supposed to pick "Other" or custom text for various questions, despite them frequently being used in setups where AdGuard Filters lists are being used.

The "Allow edits by maintainers" button has been turned on for this PR, enabling you guys to make any changes to the PR without having to ask me to do them for you.

### Enter the issue address

N/A

### Add your comment and screenshots

The report form, when initiated from GitHub's GUI, lacks options for things that are reasonable (or even probable) to expect to be used in user settings, including:
• 2 of the new split-up AdGuard Annoyances lists.
• AdGuard Home user environments.
• uBlock Origin configurations, as well as non-regional lists that are included in uBO but not in AdGuard.
• Vivaldi, a browser that is doing reasonably well as of late 2022.
• AdGuard's *Browsing Security* module.
• "Fanboy's Notifications Blocking List" for good measure.

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

N/A, from what I can tell at the time of writing.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
