### PR TITLE
add regex to block propeller servers

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -63,6 +63,8 @@ _clickunder&pb=$popup
 /kzdh7.$script,~third-party
 /klesd7.$script,~third-party
 !
+! https://github.com/AdguardTeam/AdguardFilters/pull/136543
+/^https:\/\/[a-z-]{8,15}\.(?:com|net)\/(?:40[01]|5)\/\d{7}(?:\?\S+)?$/$script,third-party
 ! Popular on Japanese sites but seen in other countries too
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587#issuecomment-656098019
 ! Sample URL: ||js.passaro-de-fogo.biz/t/113/750/a1113750.js

--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -63,7 +63,7 @@ _clickunder&pb=$popup
 /kzdh7.$script,~third-party
 /klesd7.$script,~third-party
 !
-! https://github.com/AdguardTeam/AdguardFilters/pull/136543
+! https://github.com/AdguardTeam/AdguardFilters/pull/136624
 /^https:\/\/[a-z-]{8,15}\.(?:com|net)\/(?:40[01]|5)\/\d{7}(?:\?\S+)?$/$script,third-party
 ! Popular on Japanese sites but seen in other countries too
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587#issuecomment-656098019

--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -64,6 +64,7 @@ _clickunder&pb=$popup
 /klesd7.$script,~third-party
 !
 ! https://github.com/AdguardTeam/AdguardFilters/pull/136624
+! PropellerAds
 /^https:\/\/[a-z-]{8,15}\.(?:com|net)\/(?:40[01]|5)\/\d{7}(?:\?\S+)?$/$script,third-party
 ! Popular on Japanese sites but seen in other countries too
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58587#issuecomment-656098019


### PR DESCRIPTION
…/uAssets/commit/3263f950cb24351095fdcbda0d4549e9c2e4054e#r88736463)

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/uBlockOrigin/uAssets/commit/3263f950cb24351095fdcbda0d4549e9c2e4054e#r88736463

The regex has firstly been tested in my personal lists and then added to uBf, no problem has been reported. This catches parts of propeller revolving servers. 

https://regex101.com/r/sej8zq/1

Unfortunately I couldn't find `/401/` case in this short period, but as you see in the comment there certainly is.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
