### PR TITLE
fix #138963 rocketnews24.com,youpouch.com,soranews24.com

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -3857,7 +3857,7 @@ soranews24.com#@#.ad
 ||pagead2.googlesyndication.com/pagead/$script,redirect=noopjs,important,domain=soranews24.com
 ||googletagservices.com/tag/js/gpt.js$script,redirect=googletagservices-gpt,important,domain=soranews24.com
 soranews24.com#$#div[style="width: 1px; height: 1px; position: absolute; left: -10000px; top: -10000px; z-index: -10000;"] { display: block !important; }
-!#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_app_ios || adguard_ext_safari || adguard_ext_chromium || adguard_ext_edge)
+!#if (adguard && !adguard_ext_firefox && !adguard_ext_opera)
 soranews24.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||soranews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 soranews24.com#%#AG_onLoad(function(){const a=document.querySelectorAll("img[data-sco-src]");a.forEach(a=>{const b=a.getAttribute("data-sco-src");a.setAttribute("src",b),a.style.opacity="1"})});

--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -3839,8 +3839,6 @@ adzsafe.com#%#//scriptlet("set-constant", "chk_ads_block", "noopFunc")
 @@||sst.soranews24.com/gtm.js$script,~third-party
 soranews24.com#%#//scriptlet('prevent-fetch', 'tpc.googlesyndication.com')
 ||g.doubleclick.net/gampad/ads?$xmlhttprequest,removeparam=/^(cookie|ga_|u_)/,domain=soranews24.com
-!+ PLATFORM(windows,mac,android,ext_ff)
-||soranews24.com/_static/$script,replace=/\w+\.onload=//
 soranews24.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-sidebottom')
 soranews24.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-footer')
 soranews24.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-pagebottom')
@@ -3859,15 +3857,9 @@ soranews24.com#@#.ad
 ||pagead2.googlesyndication.com/pagead/$script,redirect=noopjs,important,domain=soranews24.com
 ||googletagservices.com/tag/js/gpt.js$script,redirect=googletagservices-gpt,important,domain=soranews24.com
 soranews24.com#$#div[style="width: 1px; height: 1px; position: absolute; left: -10000px; top: -10000px; z-index: -10000;"] { display: block !important; }
-!#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
+soranews24.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||soranews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 soranews24.com#%#AG_onLoad(function(){const a=document.querySelectorAll("img[data-sco-src]");a.forEach(a=>{const b=a.getAttribute("data-sco-src");a.setAttribute("src",b),a.style.opacity="1"})});
-!#endif
-!!#if (adguard_app_ios || adguard_ext_safari)
-!soranews24.com#%#//scriptlet("abort-on-property-read", "document.createElement")
-!soranews24.com#$#img[data-sco-src] { display: none !important; }
-!soranews24.com#%#AG_onLoad(function(){let a=document.querySelectorAll("img+noscript");let ns=function(b){let f=new DOMParser();let g=f.parseFromString(b.textContent,'text/html');return document.adoptNode(g.querySelector('img'));};for(let b of a){let c=ns(b);b.parentNode.replaceChild(c,b);}});
-!!#endif
 !#safari_cb_affinity(privacy)
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$domain=soranews24.com
 @@||tpc.googlesyndication.com/simgad/$image,domain=soranews24.com

--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -3857,9 +3857,11 @@ soranews24.com#@#.ad
 ||pagead2.googlesyndication.com/pagead/$script,redirect=noopjs,important,domain=soranews24.com
 ||googletagservices.com/tag/js/gpt.js$script,redirect=googletagservices-gpt,important,domain=soranews24.com
 soranews24.com#$#div[style="width: 1px; height: 1px; position: absolute; left: -10000px; top: -10000px; z-index: -10000;"] { display: block !important; }
+!#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_app_ios || adguard_ext_safari || adguard_ext_chromium || adguard_ext_edge)
 soranews24.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||soranews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 soranews24.com#%#AG_onLoad(function(){const a=document.querySelectorAll("img[data-sco-src]");a.forEach(a=>{const b=a.getAttribute("data-sco-src");a.setAttribute("src",b),a.style.opacity="1"})});
+!#endif
 !#safari_cb_affinity(privacy)
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$domain=soranews24.com
 @@||tpc.googlesyndication.com/simgad/$image,domain=soranews24.com

--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -47,20 +47,10 @@ rocketnews24.com,youpouch.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-re
 @@||rocketnews24.com^$generichide
 ||googlesyndication.com/safeframe/$subdocument,redirect=noopframe,domain=rocketnews24.com|youpouch.com
 ||fundingchoicesmessages.google.com^$script,redirect-rule=noopjs,domain=rocketnews24.com|youpouch.com
-!#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_ext_firefox)
-||rocketnews24.com/_static/$script,replace=/\w+\.onload=//
-||youpouch.com/_static/$script,replace=/\w+\.onload=//
-!#endif
-!#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
+rocketnews24.com,youpouch.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||youpouch.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 ||rocketnews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 youpouch.com,rocketnews24.com#%#AG_onLoad(function(){const a=document.querySelectorAll("img[data-sco-src]");a.forEach(a=>{const b=a.getAttribute("data-sco-src");a.setAttribute("src",b),a.style.opacity="1"})});
-!#endif
-!!#if (adguard_app_ios || adguard_ext_safari)
-!rocketnews24.com,youpouch.com#%#//scriptlet("abort-on-property-read", "document.createElement")
-!rocketnews24.com,youpouch.com#$#img[data-sco-src] { display: none !important; }
-!rocketnews24.com,youpouch.com#%#AG_onLoad(function(){let a=document.querySelectorAll("img+noscript");let ns=function(b){let f=new DOMParser();let g=f.parseFromString(b.textContent,'text/html');return document.adoptNode(g.querySelector('img'));};for(let b of a){let c=ns(b);b.parentNode.replaceChild(c,b);}});
-!!#endif
 !#if (adguard_app_ios || adguard_ext_android_cb)
 @@||googlesyndication.com/safeframe/$domain=rocketnews24.com|youpouch.com
 @@||tpc.googlesyndication.com/simgad/$image,domain=rocketnews24.com|youpouch.com

--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -47,7 +47,7 @@ rocketnews24.com,youpouch.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-re
 @@||rocketnews24.com^$generichide
 ||googlesyndication.com/safeframe/$subdocument,redirect=noopframe,domain=rocketnews24.com|youpouch.com
 ||fundingchoicesmessages.google.com^$script,redirect-rule=noopjs,domain=rocketnews24.com|youpouch.com
-!#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_app_ios || adguard_ext_safari || adguard_ext_chromium || adguard_ext_edge)
+!#if (adguard && !adguard_ext_firefox && !adguard_ext_opera)
 rocketnews24.com,youpouch.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||youpouch.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 ||rocketnews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script

--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -47,10 +47,12 @@ rocketnews24.com,youpouch.com#%#//scriptlet('remove-attr', 'id', '#div-gpt-ad-re
 @@||rocketnews24.com^$generichide
 ||googlesyndication.com/safeframe/$subdocument,redirect=noopframe,domain=rocketnews24.com|youpouch.com
 ||fundingchoicesmessages.google.com^$script,redirect-rule=noopjs,domain=rocketnews24.com|youpouch.com
+!#if (adguard_app_windows || adguard_app_mac || adguard_app_android || adguard_app_ios || adguard_ext_safari || adguard_ext_chromium || adguard_ext_edge)
 rocketnews24.com,youpouch.com#%#//scriptlet('prevent-setTimeout', 'b.s.reject', '1000')
 ||youpouch.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 ||rocketnews24.com/_static/$replace=/(!1|!0!)=?==SCO\.imgLazyLoad/1===1/,script
 youpouch.com,rocketnews24.com#%#AG_onLoad(function(){const a=document.querySelectorAll("img[data-sco-src]");a.forEach(a=>{const b=a.getAttribute("data-sco-src");a.setAttribute("src",b),a.style.opacity="1"})});
+!#endif
 !#if (adguard_app_ios || adguard_ext_android_cb)
 @@||googlesyndication.com/safeframe/$domain=rocketnews24.com|youpouch.com
 @@||tpc.googlesyndication.com/simgad/$image,domain=rocketnews24.com|youpouch.com


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/138963

### Add your comment and screenshots

1. Your comment

New idea, prevent them to override images. Please test on iOS with DNS filtering enabled. Removed `replace=/\w+\.onload=//` as no more needed.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
