### PR TITLE
Remove obsoleted rule 380cc.cc

### DIFF
--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -343,7 +343,6 @@ video.tv-tokyo.co.jp#@#.ad-placeholder
 !+ PLATFORM(windows, mac, android)
 ||pubads.g.doubleclick.net/gampad/ads?*/video.tv-tokyo.co.jp$redirect=nooptext,important,domain=video.tv-tokyo.co.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/21737
-380cc.cc#%#Object.defineProperty(window, 'myaabpfun12', { get: function() { return; } });
 380cc.cc#$##playertopads { height: 51px!important; position: absolute!important; left: -3000px!important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20703
 !+ PLATFORM(ios, ext_android_cb, ext_safari)


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [X] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 - https://github.com/AdguardTeam/AdguardFilters/issues/139027

### Add your comment and screenshots

 - https://github.com/AdguardTeam/AdguardFilters/issues/21737

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
