### PR TITLE
Remove obsoleted rules computerworld.com

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -10634,8 +10634,6 @@ ipatriot.com#%#window.blockAdBlock = function() {};
 legalinsurrection.com#%#Object.defineProperty(window, 'gf', { get: function() { return {}; } });
 ! https://forum.adguard.com/index.php?threads/11577/
 @@||play-old-pc-games.com/wp-content/plugins/agreeable-vacation/assets/js/advertisement.min.js
-! https://forum.adguard.com/index.php?threads/11626/
-computerworlduk.com#%#Object.defineProperty(window, '_r3z', { get: function() { return; } });
 ! https://forum.adguard.com/index.php?threads/11437/
 thefreedictionary.com#$#div[class][id] > a > img:not([src^="http"]) { height: 1px; }
 thefreedictionary.com#$#div[class][id][style="height: auto;"] { position: absolute!important; left: -3000px!important; }

--- a/BaseFilter/sections/content_blocker.txt
+++ b/BaseFilter/sections/content_blocker.txt
@@ -3083,12 +3083,6 @@ televisaofutebol.com#@#iframe[width="300"][height="250"]
 @@||static.opensubtitles.org/libs/js/ad_
 @@||pagead2.googlesyndication.com/pagead/show_ads.js$domain=opensubtitles.org
 @@||ads2.opensubtitles.org/*www/delivery/afr.php?
-! https://forum.adguard.com/index.php?threads/11626/
-@@||computerworlduk.com^$generichide
-@@||securepubads.g.doubleclick.net/gampad/ads$domain=computerworlduk.com
-@@||z.moatads.com/idg235774026756/moatad.js$domain=computerworlduk.com
-computerworlduk.com#@#.jsAdContainer > #dynamicAd1
-computerworlduk.com#@#aside > div > .mpuHolder
 ! https://github.com/AdguardTeam/AdguardFilters/issues/2453
 @@||gofobo.com^$generichide
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1971


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [X] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 - https://github.com/AdguardTeam/AdguardFilters/issues/139027

### Add your comment and screenshots

 - https://forum.adguard.com/index.php?threads/resolved-http-www-computerworlduk-com-adblock-detected.11626/ (The linked URL returns HTTP 404 error.)
 - Tested with https://www.computerworld.com/article/3682771/how-to-buy-pcs-for-your-enterprise.html

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
