### PR TITLE
Remove obsoleted rules pasty.link

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -6629,15 +6629,6 @@ freevpn4you.net#$##adbanner { display: block !important; }
 ||freevpn4you.net/*.php$replace=/ins\.clientHeight =/ins.clientHeight !/
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||freevpn4you.net^$generichide
-! https://github.com/AdguardTeam/AdguardFilters/issues/34116
-||pasty.link/javascript/js.js$replace=/(function (thatEnjoyment)\(\)\{)[\s\S]*?(}function)/\$1return true;\$3/
-pasty.link#%#AG_onLoad(function() { window.thatEnjoyment = function() { return true; }; });
-pasty.link#$##adsense2 { display: block!important; position: absolute!important; left: -3000px!important; }
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=pasty.link
-pasty.link#%#AG_onLoad(function() { var el=document.querySelector(".adsbygoogle"),ce=document.createElement("iframe");ce.style="width: 0px !important; border: none !important;";el&&el.appendChild(ce);var eli=document.querySelector(".adsbygoogle iframe");eli&&eli.contentWindow.document.body.appendChild(ce); });
-@@||pasty.link^$content
-!+ PLATFORM(ext_ff, ext_opera, ios, ext_android_cb, ext_safari, ext_ublock)
-@@||pasty.link^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33986
 gamekit.com#$#.ad.ads.adBanner { display: block!important; }
 !+ PLATFORM(ios, ext_android_cb, ext_safari)


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [X] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 - https://github.com/AdguardTeam/AdguardFilters/issues/139027

### Add your comment and screenshots

 - https://github.com/AdguardTeam/AdguardFilters/issues/34116

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
