### PR TITLE
remove bytedance related domain, block this domain may cause many byt…

### DIFF
--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -216,7 +216,6 @@
 ||static.hyprmx.com^
 ||prod.cm.publishers.advertising.a2z.com^
 ||events-*.op.hicloud.com^
-||isnssdk.com^
 ||app.adjust.world^
 ||app.adjust.net.in^
 ||ads.feelingtouch.com^


### PR DESCRIPTION
…edance related APP malfunction, such as Tiktok, Pico, Capcut and so on

When I use adguard and use this filter, I found i cannot make payment in PICO APP and tiktok APP. So I checked the blocked domain and found this.
So I removed this bytedance related domain, block this domain may cause many bytedance related APP malfunction, such as Tiktok, Pico, Capcut and so on.