### PR TITLE
fix https://recup.paylib.fr blank page

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_allowlist.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_allowlist.txt
@@ -14,6 +14,8 @@
 ||geolocation.onetrust.com/cookieconsentpub/*/geo/location$xmlhttprequest,redirect-rule=noopjson
 !
 !
+! fix https://recup.paylib.fr blank page
+@@||sdk.privacy-center.org^$domain=recup.paylib.fr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/142213
 @@||sdk.privacy-center.org/*/loader.js$domain=knack.be
 @@||sdk.privacy-center.org/ui-gdpr-nl-web.*.js$domain=knack.be


### PR DESCRIPTION
aka easylist/easylist#14914

# Creating the pull request

without this change https://recup.paylib.fr is blank page. Js needs the 3 scripts from sdk.privacy-center.org

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
