### PR TITLE
No longer allowed as pseudo-class in uBo 1.46.1rc0

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -419,7 +419,7 @@ mooseknucklescanada.com##.transform.opacity-100.border-gray-200[class^="FeatureB
 ridestore.com##div[class^="CookieBanner-module--cookieBanner--"]
 prada.com#$##__tealiumGDPRecModal { display: none !important; }
 prada.com#$#body[class*=stopScrollPrada] { position: static !important; }
-prada.com#$#.overlayOpen body:after { display: none !important; }
+prada.com#$#.overlayOpen body::after { display: none !important; }
 ||tags.tiqcdn.com/utag/*/prod/utag.js$domain=hs.fi|radissonhotels.com|louisvuitton.com
 caseking.de###cookie_consent_backdrop
 sketch.metademolab.com###root > div[style^="position: fixed; left:"][style*="z-index:"]
@@ -2107,7 +2107,7 @@ newtimes.ru##.disclame_block
 ssm.lnk.to##.lnk-c-footnote
 boohoo.com#$#body { overflow: auto !important; height: auto !important; }
 boohoo.com#$#.header-cookies-gdpr { display: none !important; }
-boohoo.com#$#.header-gdrp-cookies-visible body:before { display: none !important; }
+boohoo.com#$#.header-gdrp-cookies-visible body::before { display: none !important; }
 boohoo.com#$##consent-dialog { display: none !important; }
 boohoo.com#$#.m-has_dialog .l-header { padding-right: 0 !important; }
 boohoo.com#$#.m-has_dialog .l-page-content { padding-right: 0 !important; }
@@ -3771,7 +3771,7 @@ online-teile.com##.as-modoil[data-qa="oil-Layer"]
 elleair.jp##.tf-cookiePolicyModal
 stromnetz-hamburg.de#$#body { overflow: visible !important; }
 stromnetz-hamburg.de#$##cookie-bar { display: none !important; }
-stromnetz-hamburg.de#$#body.cookie-overlay:before { opacity: 0 !important; visibility: hidden !important; }
+stromnetz-hamburg.de#$#body.cookie-overlay::before { opacity: 0 !important; visibility: hidden !important; }
 cision.com###cision-cookie-policy-banner
 euautoteile.de,rexbo.de,motordoctor.de,autodoc.pl,pkwteile.de,autodoc24.ro,autodoc.de##.popup-choose-cookies
 taschenhirn.de#$#.cookie-notice:not(body):not(html) { display: none !important; }

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -162,7 +162,7 @@ digitalproduction.com##.widget a[href^="https://service.digitalproduction.com/dp
 ||cdn.pear.focus.de/clients/widget.js
 mainpost.de##.bineos-content-box-recommendations
 wartezeiten.app###freiraum
-ksta.de##.dm-slot__skyContainer:before
+ksta.de##.dm-slot__skyContainer::before
 plastverarbeiter.de,neue-verpackung.de###billboard-container
 plastverarbeiter.de,neue-verpackung.de##.ce_banneradbox
 plastverarbeiter.de,neue-verpackung.de##div[class*="adrow_"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [ ] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

Compatibility with new version of uBo, rejected as regression by [gwarser](https://github.com/gwarser) and [uBlock-user](https://github.com/uBlock-user).

> - [ ] My changes do not break web sites, apps and files structure.

This will disable compatiblility with IE 6-8 on XP for 4 rules.

It also requires verification that the webpages still require these rules in 2023.

*Also remember  Samsung Internet with any content blocker can't hide `::before` / `::after` https://github.com/AdguardTeam/ContentBlocker/issues/232.*

### Enter the issue address

Example: https://github.com/uBlockOrigin/uBlock-issues/issues/2483

### Add your comment and screenshots

N/A

### Terms

-  [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
