### PR TITLE
some domains are not loaded with `Protection from DPI` is enabled

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -12,6 +12,10 @@
 ! TODO: change the current modifier to `$stealth=dpi` when CL1.10 will be available in the app release channel, then the rules can be moved from the temporary section
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_android)
 !+ NOT_OPTIMIZED
+@@||kifir2.kir.hu^$stealth
+!+ NOT_OPTIMIZED
+@@||oktatas.hu^$stealth
+!+ NOT_OPTIMIZED
 @@||cnpack.org^$stealth
 !+ NOT_OPTIMIZED
 @@||nintendo.co.kr^$stealth


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

[<https://github.com/AdguardTeam/CoreLibs/issues/1645>](https://github.com/AdguardTeam/CoreLibs/issues/1645#issuecomment-1431999709)

### Add your comment and screenshots

These sites are fixed:

- [oktatas.hu](https://www.oktatas.hu)
- [kifir2.kir.hu](https://kifir2.kir.hu/TTJegyzekKereso)

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
