### PR TITLE
news.sky.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -9541,7 +9541,7 @@ blumixx.de,roesle.com,moses-verlag.de,radonline.de,arctic.de#$#.acris-cookie-con
 ! Misc rules, removed during optimization. If some rules are in groups, no need to move them here
 !
 !+ PLATFORM(ios)
-cdn.privacy-mgmt.com,news.sky.com#%#//scriptlet('trusted-click-element', 'button[title="Accept all"]')
+cdn.privacy-mgmt.com#%#AG_onLoad(function(){if(window.self!==window.top&&document.referrer.startsWith('https://news.sky.com/')){var a=new MutationObserver(function(){var b=document.querySelector('button[title="Accept all"]');b&&(a.disconnect(),b.click())});a.observe(document,{childList:!0,subtree:!0});setTimeout(function(){a.disconnect()},1E4)}});
 !+ NOT_OPTIMIZED
 tiktok.com##tiktok-cookie-banner
 !+ NOT_OPTIMIZED


### PR DESCRIPTION
I've tried some other options, but only the JS rule has some necessary limits to the site.
The goal is to limit this rule to only one site `news.sky.com`.

```adblock
AG_onLoad(function() {
    if (window.self !== window.top && document.referrer.startsWith('https://news.sky.com/')) {
        var a = new MutationObserver(function() {
            var b = document.querySelector('button[title="Accept all"]');
            b && (a.disconnect(), b.click())
        });
        a.observe(document, {
            childList: !0,
            subtree: !0
        });
        setTimeout(function() {
            a.disconnect()
        }, 1E4)
    }
});
```