### PR TITLE
zodiakkidsandfamilydistribution.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_general.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_general.txt
@@ -1171,6 +1171,7 @@
 ##.cookie-permission
 ##.cookie-policy:not(body):not(html)
 ##.cookie-policy-banner
+##.cookie-policy__banner
 ##.cookie-policy-box
 ##.cookie-policy-message
 ##.cookie-policy-notice


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/144610

This is not the most popular class, based on the resource publicwww, but it will probably be able to block cookie messages on some sites with low traffic 