### PR TITLE
Fix #146466 propublica.org

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -1617,6 +1617,7 @@ theguardian.com##.contributions__adblock
 !
 ! SECTION: Self-promo - Regular rules
 !
+propublica.org##.site-header__banner[data-pp-location="promo-bar"]
 ashleyfurniture.com##a[aria-label="10% off* all outdoor furniture!"]
 dtf.ru##.content-feed--promo
 babycome.ne.jp##.miki_banner


### PR DESCRIPTION
Hides donate banner on propublica.org
Fixes #146466