### PR TITLE
add filter for Dotdash Meredith sites with newsletter popup

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -48,12 +48,13 @@ jiji.com,edp24.co.uk,technologyreview.com,inews.co.uk,nordbayern.de,thelocal.ch,
 !
 ! SECTION: Subscriptions - Regular rules
 !
-allrecipes.com,foodandwine.com,health.com,investopedia.com,lifewire.com,mydomaine.com,parents.com,simplyrecipes.com,thespruce.com,thespruceeats.com,thesprucepets.com,travelandleisure.com,treehugger.com,tripsavvy.com,verywellfamily.com,verywellfit.com,verywellhealth.com,verywellmind.com$$div[data-a11y-dialog="newsletter-dialog"]
 hindustantimes.com##.googleFollow
 rtbf.be#?##id-text2speech-article > div.box-border:has(> div.container > div.bg-white > div.prose > div.flex > a[href="/mon-compte/newsletters"])
 ||fastcompany.com/gallery/lightboxinteractiontype/
 fastcompany.com##.bcToaster
 fastcompany.com##.post__footer__newsletter
+allrecipes.com,foodandwine.com,health.com,investopedia.com,lifewire.com,mydomaine.com,parents.com,simplyrecipes.com,thespruce.com,thespruceeats.com,thesprucepets.com,travelandleisure.com,treehugger.com,tripsavvy.com,verywellfamily.com,verywellfit.com,verywellhealth.com,verywellmind.com#$#div[data-a11y-dialog="newsletter-dialog"] { display: none !important; }
+allrecipes.com,foodandwine.com,health.com,investopedia.com,lifewire.com,mydomaine.com,parents.com,simplyrecipes.com,thespruce.com,thespruceeats.com,thesprucepets.com,travelandleisure.com,treehugger.com,tripsavvy.com,verywellfamily.com,verywellfit.com,verywellhealth.com,verywellmind.com#$#html { overflow: auto !important; }
 hackster.io##div[class^="article_layout__signupCTA"]
 hackster.io##div[data-hacksternova-key="ProjectCountBanner"]
 parniplus.com###eaa_post_between_content

--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -48,6 +48,7 @@ jiji.com,edp24.co.uk,technologyreview.com,inews.co.uk,nordbayern.de,thelocal.ch,
 !
 ! SECTION: Subscriptions - Regular rules
 !
+allrecipes.com,foodandwine.com,health.com,investopedia.com,lifewire.com,mydomaine.com,parents.com,simplyrecipes.com,thespruce.com,thespruceeats.com,thesprucepets.com,travelandleisure.com,treehugger.com,tripsavvy.com,verywellfamily.com,verywellfit.com,verywellhealth.com,verywellmind.com$$div[data-a11y-dialog="newsletter-dialog"]
 hindustantimes.com##.googleFollow
 rtbf.be#?##id-text2speech-article > div.box-border:has(> div.container > div.bg-white > div.prose > div.flex > a[href="/mon-compte/newsletters"])
 ||fastcompany.com/gallery/lightboxinteractiontype/


### PR DESCRIPTION
blocks newsletter popups for Dotdash Meredith sites
e.g., https://www.allrecipes.com/hidden-valley-pickle-ranch-launch-7369518

Relevant HTML:
```
<div id="campaign-dialog_1-0" class="comp campaign-dialog mntl-dialog--campaign mntl-dialog dialog dialog--visible" data-campaign-name="first-allrecipes-campaign" data-campaign-trigger-inactivity-timer="60000" data-a11y-dialog="newsletter-dialog" data-campaign-regsource="meghj9" data-defer="load" data-defer-params="" aria-modal="true" tabindex="-1" role="dialog">…</div>
```

<details><summary>Screenshot</summary>
<img width="1440" alt="Screenshot 2023-03-28 at 3 30 46 PM" src="https://user-images.githubusercontent.com/110956608/228347183-67aa5e75-1222-4e08-b271-d1c0be3330f6.png">
</details>