### PR TITLE
block nytimes.com sale banner

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -1626,6 +1626,9 @@ theguardian.com##.contributions__adblock
 !
 ! SECTION: Self-promo - Regular rules
 !
+nytimes.com#$#.top-sale-banner { display: none !important; }
+nytimes.com#%#//scriptlet('remove-class', 'top-sale-banner-spacing')
+nytimes.com#%#//scriptlet('remove-class', 'top-sale-banner-drawer', '.pz-nav-drawer')
 time.com##.campaign-five_red-border
 time.com##.campaign-four_red-border
 ||leechpremium.link/img/banner/


### PR DESCRIPTION
Blocks seasonal subscription sale banner on nytimes.com and fixes header and sidebar nav spacing due to removal of element.

<details><summary>Screenshot</summary>
<img width="1440" alt="Screenshot 2023-03-29 at 11 54 14 PM" src="https://user-images.githubusercontent.com/110956608/228725696-a2c9f47d-34e1-4211-b89f-a9e48fd894a0.png">
</details>