### PR TITLE
block eyeondesign.aiga.org newsletter box

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -48,6 +48,7 @@ jiji.com,edp24.co.uk,technologyreview.com,inews.co.uk,nordbayern.de,thelocal.ch,
 !
 ! SECTION: Subscriptions - Regular rules
 !
+eyeondesign.aiga.org###newsletter
 gazetaprawna.pl##.ecommerceDesktopLoader
 gazetaprawna.pl##.subscribeButton
 business-standard.com##.sbscrgoogle


### PR DESCRIPTION
blocks this big newsletter box at end of page (newsletter link in footer still works)

<img width="1440" alt="Screenshot 2023-03-30 at 2 16 11 AM" src="https://user-images.githubusercontent.com/110956608/228746407-79ef0452-fa93-47aa-b938-49be4514b29f.png">
