### PR TITLE
gu-global.com - remove obsolete rules

### DIFF
--- a/SocialFilter/sections/css_extended.txt
+++ b/SocialFilter/sections/css_extended.txt
@@ -286,7 +286,6 @@ news.ameba.jp#?#ul > li[class^="LowerSocialButtons"]:has(div[class^="TwitterButt
 news.ameba.jp#?#ul > li[class^="LowerSocialButtons"]:has(div[class^="FacebookButton"])
 freac.org#?##rightcol-broad > div.module:has(> div h3:contains(Share))
 thairath.co.th#?#.collapse > div[class^="css-"] > a.facebook-icon:upward(1)
-gu-global.com#?#.wuegps-0 > span:contains(シェアする：)
 meduza.global.ssl.fastly.net,meduza.io#?#div[data-testid] > ul[class^="Toolbar-module_list_"] > li[class^="Toolbar-module_item_"]:has( > button[data-testid="toolbar-button"] > span[class^="ToolbarButton-module_text"]:contains(/Telegram|Телеграм|Фб|Твиттер|Вк|Ок/))
 apexlegends-leaksnews.com#?#.cps-post-main > h2:contains(記事のシェアはこちら)
 sonre.ru#?#.single-content > .single-top:has(> .single-top-social)

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -2135,8 +2135,7 @@ monoreco.ameba.jp##.c-sns-follow
 lulucos-bys.jp##.p-article__fixed-social-buttons
 banger.jp##.p-single-sns
 bookwalker.jp##.p-share__list
-mohunadeanime.com,radwimps.jp,nierautomata-anime.com,gu-global.com##.p-share
-gu-global.com##.fHTQbF
+mohunadeanime.com,radwimps.jp,nierautomata-anime.com##.p-share
 style.nikkei.com##.sc-17icl5v-0
 music.line.me##ul[class^="_spi_release_"] > li:not([class^="_spi_cnt_"])
 community.atlassian.com##.atl-thread-social


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 

### Add your comment and screenshots

 
I think these rules are obsolete.
```
gu-global.com##.fHTQbF
gu-global.com##.p-share
gu-global.com#?#.wuegps-0 > span:contains(シェアする：)
```

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
