### PR TITLE
Fix kakaku.com URL tracking parameter

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -8,8 +8,8 @@
 !
 ! https://mintj.com/msm/?adv=_3271__nelubcd57h9l2o0i2mejjp4os
 ||mintj.com^$removeparam=adv
-!https://s.kakaku.com/item/K0001285779/?lid=sp_pricemenu_ranking_item
-||s.kakaku.com^$removeparam=lid
+! https://github.com/AdguardTeam/AdguardFilters/pull/147247
+||kakaku.com^$removeparam=lid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/146439
 ||stacksocial.com^$removeparam=rid
 ||stacksocial.com^$removeparam=aid

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -8,6 +8,8 @@
 !
 ! https://mintj.com/msm/?adv=_3271__nelubcd57h9l2o0i2mejjp4os
 ||mintj.com^$removeparam=adv
+!https://s.kakaku.com/item/K0001285779/?lid=sp_pricemenu_ranking_item
+||s.kakaku.com^$removeparam=lid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/146439
 ||stacksocial.com^$removeparam=rid
 ||stacksocial.com^$removeparam=aid


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 https://s.kakaku.com/kaden/lcd-tv/

### Add your comment and screenshots

I found this at https://github.com/AdguardTeam/AdguardFilters/issues/147222

How to reproduce
1. Access this page https://kakaku.com/kaden/lcd-tv/
2. Select a product on the list "液晶テレビ・有機ELテレビ 注目ランキング"

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
