### PR TITLE
Fix www.canva.com viewer (#147371)

### DIFF
--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -431,7 +431,6 @@ aptoide.com##div[class^="aptoide-installer"]
 live.line.me##.MdBtn01Download02
 spaceshipearth.jp##.boxzilla-bottom-right-container
 canva.com#$#body > div[style="position: relative; z-index: 1;"]:last-child { display: none !important; }
-canva.com#$#body { overflow: auto !important; }
 nbcnews.com##amp-list#branch-amp-journey
 kino.tricolor.tv#$##app-dock-trikolor-kino-i-tv { display: none !important; }
 kino.tricolor.tv#%#//scriptlet('remove-class', 'add_app-module', '.main')


### PR DESCRIPTION
# Creating the pull request

Fixes issue #147371; this is a bad blanket rule that is affecting desktop as well, making some Canva pages completely black and unusable.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/147371

### Add your comment and screenshots

Have left screenshot out as it's just a black page 😂 

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
