### PR TITLE
fix: #147411 and #147412

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -66,6 +66,9 @@
 ||sgtm.fashionunited.
 ||mercury.coupang.com^
 ||client-telemetry.roblox.com^
+||ephemeralcounters.api.roblox.com^
+||ecsv2.roblox.com^
+||tracing.roblox.com^
 ||treatment.grammarly.com^
 ||rac.ruutu.fi^
 ||forecast.lemonde.fr^


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Relevant issues: #147411 and #147412

ephemeralcounters.api.roblox.com is the same thing as ecsv2.roblox.com - ecsv2 is just the v2 version of the API.

<details>

<summary>Screenshot 1:</summary>

![image](https://user-images.githubusercontent.com/41478239/229809796-e1802d84-855d-4215-8834-c7b36b18c73d.png)

</details>

<details>

<summary>Screenshot 2:</summary>

![image](https://user-images.githubusercontent.com/41478239/229823121-9b4b758c-89e7-4234-b509-52610e6fcdcf.png)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
