### PR TITLE
fix video ads

### DIFF
--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -11,9 +11,6 @@
 !
 ! VAST video ads - e. g. https://github.com/AdguardTeam/AdguardFilters/issues/135687
 stern.de,desired.de,pcgames.de,t-online.de,vox.de,spieletipps.de,wetter.de,golem.de,autobild.de,buffed.de,gamesaktuell.de,kino.de,pcgameshardware.de,videogameszone.de,familie.de,tvnow.de,welt.de#%#//scriptlet('prevent-xhr', '.damoh.')
-!#if (adguard_ext_firefox)
-spiegel.de,t-online.de,giga.de,welt.de#%#//scriptlet('abort-on-stack-trace', 'XMLHttpRequest', 'onreadystatechange')
-!#endif
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/146229
 ! TODO: use scriptlet "inject-css-in-shadow-dom" when it will be available in apps
@@ -24,6 +21,9 @@ chip.de#%#//scriptlet('set-cookie', 'chipde-r2d2-view-state ', '1')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/135749
 ! https://github.com/AdguardTeam/AdguardFilters/issues/135687
 giga.de,spiegel.de,welt.de,t-online.de#%#(()=>{window.XMLHttpRequest.prototype.send=new Proxy(window.XMLHttpRequest.prototype.send,{apply:(a,b,c)=>{const d=b.urlCalled;return"string"!=typeof d||0===d.length?Reflect.apply(a,b,c):d.match(/\.damoh\./)?void 0:Reflect.apply(a,b,c)}})})();
+!#if (adguard_ext_firefox)
+giga.de,spiegel.de,welt.de,t-online.de#%#//scriptlet('abort-on-stack-trace', 'XMLHttpRequest', 'onreadystatechange')
+!#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/131890
 eispop.com#%#//scriptlet('set-constant', 'Object.prototype.AdOverlay', 'noopFunc')
 ! https://github.com/uBlockOrigin/uAssets/issues/6541#issuecomment-1140420880

--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -11,6 +11,7 @@
 !
 ! VAST video ads - e. g. https://github.com/AdguardTeam/AdguardFilters/issues/135687
 stern.de,desired.de,pcgames.de,t-online.de,vox.de,spieletipps.de,wetter.de,golem.de,autobild.de,buffed.de,gamesaktuell.de,kino.de,pcgameshardware.de,videogameszone.de,familie.de,tvnow.de,welt.de#%#//scriptlet('prevent-xhr', '.damoh.')
+spiegel.de,t-online.de,giga.de,welt.de#%#//scriptlet('abort-on-stack-trace', 'XMLHttpRequest', 'onreadystatechange')
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/146229
 ! TODO: use scriptlet "inject-css-in-shadow-dom" when it will be available in apps

--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -21,9 +21,8 @@ chip.de#%#//scriptlet('set-cookie', 'chipde-r2d2-view-state ', '1')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/135749
 ! https://github.com/AdguardTeam/AdguardFilters/issues/135687
 giga.de,spiegel.de,welt.de,t-online.de#%#(()=>{window.XMLHttpRequest.prototype.send=new Proxy(window.XMLHttpRequest.prototype.send,{apply:(a,b,c)=>{const d=b.urlCalled;return"string"!=typeof d||0===d.length?Reflect.apply(a,b,c):d.match(/\.damoh\./)?void 0:Reflect.apply(a,b,c)}})})();
-!#if (adguard_ext_firefox)
+!+ PLATFORM(ext_ff)
 giga.de,spiegel.de,welt.de,t-online.de#%#//scriptlet('abort-on-stack-trace', 'XMLHttpRequest', 'onreadystatechange')
-!#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/131890
 eispop.com#%#//scriptlet('set-constant', 'Object.prototype.AdOverlay', 'noopFunc')
 ! https://github.com/uBlockOrigin/uAssets/issues/6541#issuecomment-1140420880

--- a/GermanFilter/sections/general_extensions.txt
+++ b/GermanFilter/sections/general_extensions.txt
@@ -11,7 +11,9 @@
 !
 ! VAST video ads - e. g. https://github.com/AdguardTeam/AdguardFilters/issues/135687
 stern.de,desired.de,pcgames.de,t-online.de,vox.de,spieletipps.de,wetter.de,golem.de,autobild.de,buffed.de,gamesaktuell.de,kino.de,pcgameshardware.de,videogameszone.de,familie.de,tvnow.de,welt.de#%#//scriptlet('prevent-xhr', '.damoh.')
+!#if (adguard_ext_firefox)
 spiegel.de,t-online.de,giga.de,welt.de#%#//scriptlet('abort-on-stack-trace', 'XMLHttpRequest', 'onreadystatechange')
+!#endif
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/146229
 ! TODO: use scriptlet "inject-css-in-shadow-dom" when it will be available in apps


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

No open issues

### Add your comment and screenshots

Damoh Video ads on firefox. Example:

`https://www.t-online.de/nachrichten/ukraine/id_100157632/russin-fluechtet-offenbar-vor-ukrainischem-angriff-netz-spottet-ueber-video.html`

`https://www.welt.de/mediathek/dokumentation/gesellschaft/sendung243578373/Schusswunden-Klinikalltag-in-den-USA.html`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
