### PR TITLE
remove obsolete filters (nicovideo.jp)

### DIFF
--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -6908,8 +6908,6 @@ baomoi.com##a[data-href*="share"]
 nieuwsblad.be##.social-sticky-wrapper
 livepage.pro##.sharebox
 vnexpress.net###mshare_title > .btn_twitter
-nicovideo.jp##.VideoMenuContainer-areaRight > div[class="Snap Balloon"]
-nicovideo.jp##.Snap.Balloon-arrowWrap
 whale.naver.com,nicovideo.jp##button[class*="ShareButton"]
 indiatvnews.com##.social.pull-left
 indiatvnews.com##.social.pull-right


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms
- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

releated issues:
https://github.com/AdguardTeam/AdguardFilters/issues/71515 https://github.com/AdguardTeam/AdguardFilters/issues/73612#issuecomment-770210073

### Add your comment and screenshots

This element no longer exists on the site, so this rule can be removed.

<!-- Please write a comment here -->

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
