### PR TITLE
Fix #149538 simpleanalyticscdn.com

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -3316,6 +3316,8 @@
 ||signup-way.com^$third-party
 ||silverpop.com^$third-party
 ||silverpush.co^$third-party
+||simpleanalyticscdn.com^$third-party
+||simpleanalyticsexternal.com^$third-party
 ||simplehitcounter.com^$third-party
 ||simplereach.com^$third-party
 ||simpli.fi^$third-party


### PR DESCRIPTION


# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/en/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Add two domains to tracker blocklist:

- simpleanalyticscdn.com
- simpleanalyticsexternal.com

Tested as custom filtering rules for a few months, they appear to work without any issues.

Domains are based on Simple Analytics documentation and network observations.

- https://docs.simpleanalytics.com/script
- https://docs.simpleanalytics.com/bypass-ad-blockers

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

<https://github.com/AdguardTeam/AdguardFilters/issues/149538>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
