### PR TITLE
Block widespread push notification scam ads

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -21,6 +21,9 @@
 ! /asset/angular.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 ! /asset/jquery/slim-3.2.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 !
+! push notification scam
+/?clck=*&sid=$document
+/?pl=*&sm=$document
 ! Lucky visitor and video scam ex. https://1821.antbenjaw.live/jiehxxgr/?u=1nup806&o=0wywy2l&t=...
 /^https?:\/\/[0-9a-z]*\.?[-0-9a-z]{4,}\.[a-z]{2,11}\/(?:[0-9a-z]{6,8}\/)?\/?\?[ou]=[0-9a-z]{7}&[ou]=[0-9a-z]{7}/$document,match-case
 !+ PLATFORM(ios, ext_safari)


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Push notification scam ads trying to fool user to subscribe their push notification which then deliver malicious ads.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

NA

### Enter the issue address

NA

### Add your comment and screenshots

E.g. `https://adzmusic.com/ZLsNoEPrQn3DK8bMvPdo-gxu4H9USwHDKQ_StreN9jI/?clck=1d58d79744476eed686a0537d2a3bc86&sid=14892298`
`https://www.stonecarver.top/play-music-video/?pl=cY0ooXMxhEOdj-8NgPIvCw&sm=play-music-video&click_id=8c17egmfvu3hqfeecb&hash=vOmj42LBq2tQilhQn41t6w&exp=1682311985`
The second link is now suspended, I can grab a new one if needed. These two rules have been time-tested, no FP and blocking lots of those sites. There is another regex rule useful to block them but for this PR I'll focus on non-regex rules.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
