### PR TITLE
plst.com remove obsolete rule

### DIFF
--- a/SocialFilter/sections/css_extended.txt
+++ b/SocialFilter/sections/css_extended.txt
@@ -239,7 +239,6 @@ color-site.com#?##right_navi > div.right_navi01:has(> div.right_navi03 > div.sns
 kayseriolay.com#?#.bg-slate-100 > .flex > ul > li > a.ssk-facebook:upward(3)
 sweet-tv.net#?#td:contains(/^Поделиться:$/)
 [$path=/maps]google.*#?#div[class][data-js-log-root]:has(> div[class] > button[jsaction^="pane"] > div[jstcache]:contains(Facebook))
-plst.com#?#.fr-ec-mb-spacer-32 + div.fr-ec-gutter-container:has( > div.fr-ec-content-alignment > h5[class^="fr-ec"] + ul[class^="fr-ec"])
 digi24.ro#?#.col-4 > h2:contains(Urmărește-ne și pe)
 zakarpattya.net.ua#?##pubMenu > p:has(> img[alt="Share"])
 novynarnia.com#?#.home-widget > span.home-widget-header > h3:contains(TWITTER):upward(2)


### PR DESCRIPTION
   
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

### Add your comment and screenshots

I think this rule obsolete.

`plst.com#?#.fr-ec-mb-spacer-32 + div.fr-ec-gutter-container:has( > div.fr-ec-content-alignment > h5[class^="fr-ec"] + ul[class^="fr-ec"])`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
