### PR TITLE
Add `job` field to Slack report when AGLint fails

### DIFF
--- a/.github/workflows/aglint.yml
+++ b/.github/workflows/aglint.yml
@@ -59,4 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Matrix is required if the fields contain job or took
+          # See https://action-slack.netlify.app/usage/fields/
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}

--- a/.github/workflows/aglint.yml
+++ b/.github/workflows/aglint.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: failure
-          fields: workflow, repo, message, commit, author, eventName, ref
+          fields: workflow, repo, message, commit, author, eventName, ref, job
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Add `job` field to Slack report when AGLint fails

Reference:
https://action-slack.netlify.app/usage/fields/

> Generate a job run link of the job that was executed