### PR TITLE
Remove Cloudflare challenge false positive and fix detection of JS error beacons

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -166,7 +166,7 @@
 ://wa.*/s?$image
 /pmc-google-universal-analytics/*
 /clicktrue_invocation.js?
-/cdn-cgi/challenge-platform/h/g/beacon/*$xmlhttprequest,~third-party
+/cdn-cgi/challenge-platform/h/*/beacon/*$xmlhttprequest,~third-party
 /?p=%2F*&h=https%3A%2F%2F*&r=&sid=*&qs=*&cid=$image,~third-party
 /video.counters.2.js?
 /w.gif?

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -548,7 +548,6 @@ androplus.org##a[href^="https://px.a8.net/"]
 ||cdn-gl.nmrodam.com/conf/
 ||ardmediathek.de/tp/
 ||cdn.threadloom.com/ga/
-||1ps.ru/cdn-cgi/challenge-platform/
 ||sportskeeda.com/service-workers/helpers/google-analytics
 ||3p-geo.yahoo.com/p?s=
 ||api.remanga.org/api/logging/
@@ -1038,7 +1037,6 @@ today.ua##.li-bi-container
 ||bmscdn.com/m6/scripts/libs/bms-analytics.js
 ||proxy.tproger.ru/yandex-metrika.js
 ||wurking.global.ssl.fastly.net/ingestly-ingest/
-||rjno1.com/cdn-cgi/challenge-platform/h/b/scripts/invisible.js
 ||static.foxnews.com/static/leap/sites/fnc/metrics.js
 ||web.snrbox.com/*?tracker=
 ||web.snrbox.com/tck/$xmlhttprequest,redirect=nooptext


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Fixes users being unable to solve Cloudflare's anti-bot challenge pages and widget.
Fixes incomplete JS error beacon URL.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [X] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [X] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

1) Removes Cloudflare Challenge/Turnstile path 

Requests to `/cdn-cgi/challenge-platform/*` on websites behind
Cloudflare are required for challenge pages and Turnstile to work
correctly.

References:
- https://blog.cloudflare.com/turnstile-private-captcha-alternative/
- https://developers.cloudflare.com/fundamentals/get-started/reference/cdn-cgi-endpoint/#cdn-cgi-endpoint:~:text=/cdn%2Dcgi/challenge%2Dplatform/

2) Fixes Cloudflare JavaScript error logging URL

This endpoint is used to log JavaScript errors while executing
challenges, but the `g` in the URL can be other values.

### Enter the issue address

None existing.

### Add your comment and screenshots

See comment above.

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
