### PR TITLE
analytics.twitter.com is not used directly for tracking

### DIFF
--- a/BaseFilter/sections/allowlist.txt
+++ b/BaseFilter/sections/allowlist.txt
@@ -672,6 +672,9 @@ skincarie.com#@#.td-a-rec
 /^https?:\/\/.*\.(jpg|jpeg|gif|png|php|svg|ico|js|txt|css|srt)/$popup,domain=ymovies.to,badfilter
 ! https://github.com/AdguardTeam/AdguardFilters/issues/122390
 fontspace.com#@#.container-ads
+! https://github.com/AdguardTeam/AdguardFilters/issues/122424
+@@||ads-api.twitter.com/*/accounts/$domain=analytics.twitter.com
+@@||ads-api.twitter.com/*/apps?app_store_identifiers=$domain=analytics.twitter.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/122188
 forex-gold.net#@#.header-mnm
 ! https://github.com/uBlockOrigin/uAssets/issues/13094

--- a/BaseFilter/sections/allowlist.txt
+++ b/BaseFilter/sections/allowlist.txt
@@ -672,9 +672,6 @@ skincarie.com#@#.td-a-rec
 /^https?:\/\/.*\.(jpg|jpeg|gif|png|php|svg|ico|js|txt|css|srt)/$popup,domain=ymovies.to,badfilter
 ! https://github.com/AdguardTeam/AdguardFilters/issues/122390
 fontspace.com#@#.container-ads
-! https://github.com/AdguardTeam/AdguardFilters/issues/122424
-@@||ads-api.twitter.com/*/accounts/$domain=analytics.twitter.com
-@@||ads-api.twitter.com/*/apps?app_store_identifiers=$domain=analytics.twitter.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/122188
 forex-gold.net#@#.header-mnm
 ! https://github.com/uBlockOrigin/uAssets/issues/13094

--- a/SpywareFilter/sections/allowlist.txt
+++ b/SpywareFilter/sections/allowlist.txt
@@ -614,10 +614,6 @@ goodwillfinds.com#%#//scriptlet("set-constant", "_etmc", "emptyArr")
 ||cdn.segmentify.com/*/segmentify.js$script,important,redirect=noopjs,domain=gratis.com
 ! https://github.com/uBlockOrigin/uAssets/issues/13782
 @@||marketingautomation.services^$script,domain=leeuwerik.nl
-! https://github.com/AdguardTeam/AdguardFilters/issues/122424
-@@||analytics.twitter.com/*/api$domain=analytics.twitter.com
-@@||analytics.twitter.com/user/*.json?$domain=analytics.twitter.com
-@@||analytics.twitter.com/user/*/tweets/bundle?$domain=analytics.twitter.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/122171
 @@||googletagmanager.com/gtag/js?id=$domain=inforesist.org
 ||googletagmanager.com/gtag/js?id=$script,redirect=googletagmanager-gtm,domain=inforesist.org,important
@@ -2475,9 +2471,6 @@ demae-can.com#%#//scriptlet('remove-attr', 'data-trm-action|data-trm-category|da
 @@||googletagmanager.com/gtm.js$domain=imgur.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/25373
 @@||googletagmanager.com/gtm.js$domain=fooda.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/26787
-!+ PLATFORM(ios, ext_safari, ext_android_cb)
-@@||analytics.twitter.com/mob_idsync_click
 ! https://github.com/AdguardTeam/AdguardFilters/issues/26887
 @@||trackcmp.net^|
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/27035

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -581,7 +581,6 @@
 ||analytics.tout.com^
 ||analytics.tripoto.com^
 ||analytics.tver.jp^
-||analytics.twitter.com^
 ||analytics.upworthy.com^
 ||analytics.us.archive.org^
 ||analytics.vadio.com^


### PR DESCRIPTION
Only this request must be blocked (existing rule)
`||analytics.twitter.com/i/adsct?`
https://developer.twitter.com/en/docs/twitter-ads-api/audiences/overview/web#:~:text=the%20Twitter%20UI.-,Twitter%20Secure%20Pixel,-The%20Twitter%20secure