### PR TITLE
Fix travel.co.jp Ad

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -2699,6 +2699,7 @@ withonline.jp##div[style="width:670px ; height:300px;"]
 bm.best-hit.tv,j-baseball.club,j-basketball.club##div[style^="margin-top"] div[style="font-size:0.8em;"]
 fujinkoron.jp##.ad-article-rect
 efight.jp,fujinkoron.jp##.billboard
+travel.co.jp##.billboard_wrap
 onayamifree.com##.brain_banner
 workch.jp,onayamifree.com##.affiliate_tags
 workch.jp,mikle.jp,onayamifree.com##.wrapper_right_ad


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 https://www.travel.co.jp/guide/matome/6086/

### Add your comment and screenshots

<details><summary>screenshot</summary>

![](https://i.ibb.co/QQd1N1n/image.png)
</details><br/>




### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
