### PR TITLE
Fix atlus's websites cookie

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -284,6 +284,7 @@ farma2go.com#$#html { overflow: auto !important; }
 universal-credit.service.gov.uk###id-cookie-banner
 openbb.co#?#.fixed:has(> #analytics-form)
 s1live.com##div[data-v-00dd12df]
+13sar.jp,atlus-vanillaware.jp,atlus.co.jp,dragons-crown.com,ds2-p.atlusnet.jp,fullbody.jp,megaten4.jp,megaten5.jp,p3re.jp,p5r.jp,p5s.jp,p5t.jp,p-atlus.jp,persona4.jp,persona5.jp,persona-dance.jp,pq2.jp,radianthistoria.jp,rpg.jp,shin-megamitensei.jp,soul-hackers.jp,sq-atlus.jp##.atlus-cookie-message
 farmhopping.com##.AcceptCondition
 wpbakery.com###vcv-top-banner
 stern.de#$?#.i-amphtml-scroll-disabled { overflow-x: auto !important; overflow-y: auto !important; }


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 ```
http://atlus-vanillaware.jp/osl/
http://dragons-crown.com/
http://ds2-p.atlusnet.jp/
http://fullbody.jp/switch/
http://persona4.jp/
http://persona5.jp/
http://persona-dance.jp/p3d/
http://pq2.jp/
http://radianthistoria.jp/
http://shin-megamitensei.jp/3hd/
https://13sar.jp/switch/
https://megaten5.jp/
https://p3re.jp/
https://p5r.jp/
https://p5s.jp/
https://p5t.jp/
https://p-atlus.jp/p4u2/remastered/
https://p-ch.jp/remaster/p5r/
https://rpg.jp/
https://soul-hackers.jp/
https://sq-atlus.jp/sq123/
https://www.atlus.co.jp/
```

### Add your comment and screenshots

Should I move the rule to generic?
`##.atlus-cookie-message`

<details><summary>screenshot - example</summary>

![](https://i.slow.pics/pmpaIDmL.png)
</details><br/>



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
