### PR TITLE
Upd Clickadu reinjection for Contents blocker

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -1086,6 +1086,8 @@ hqq.to#%#//scriptlet('abort-on-stack-trace', 'olplayer.error', 'Be.o.dispatcher.
 hqq.to#%#//scriptlet('set-constant', 'adblockcheck', 'false')
 ! Clickadu reinjection
 klmanga.io,manga1001.se,manga1001.tv,mangarawjp.io,syosetu.*,telorku.xyz,agupulsa.xyz,kissjav.li,lovingsiren.com,mesex.pro,tojav.net,vlxyz.tv,xanimeporn.com#%#//scriptlet('abort-on-stack-trace', 'atob', '_0x')
+!+ PLATFORM(ios, ext_android_cb, ext_safari)
+/^https:\/\/[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]+\.com\/[a-z\/][a-z\/]+\?id=19[0-9][0-9][0-9][0-9][0-9]$/$script,third-party,match-case,domain=klmanga.io|manga1001.se|manga1001.tv|mangarawjp.io|syosetu.*|telorku.xyz|agupulsa.xyz|kissjav.li|lovingsiren.com|mesex.pro|tojav.net|vlxyz.tv|xanimeporn.com
 /aas/r45d/vki/*$script,third-party,redirect=noopjs
 ! https://github.com/AdguardTeam/AdguardFilters/issues/155761
 wellness4live.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

NA

### Add your comment and screenshots

Revolving servers like `https://qwyaqhortog.com/ha/jkoj?id=1968745` on `https://mangarawjp.io/chapters/%E3%80%90%E7%AC%AC230%E8%A9%B1%E3%80%91%E5%91%AA%E8%A1%93%E5%BB%BB%E6%88%A6-raw/` as of now. You have to disable `#%#//scriptlet('abort-on-stack-trace', 'atob', '_0x')` and `/aas/r45d/vki/*$script,third-party,redirect=noopjs`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
