### PR TITLE
Fix #159311 reuters.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -427,6 +427,7 @@ reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion#@#.Sid
 !
 ! Add same rules to the Admiral section of Tracking Protection filter
 !
+||scaredsnakes.com^$third-party
 ||bleachscarecrow.com^$third-party
 ||parentpicture.com^$third-party
 ||suspectmark.com^$third-party

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -3857,6 +3857,7 @@
 ! More info: https://getadmiral.com/products/measure
 ! Add same rules to the Admiral section of Annoyances filter
 !
+||scaredsnakes.com^$third-party
 ||bleachscarecrow.com^$third-party
 ||parentpicture.com^$third-party
 ||suspectmark.com^$third-party


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

<https://github.com/AdguardTeam/AdguardFilters/issues/159311>

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->
Unblocked Admiral url

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

![Reuters  Breaking International News   Views](https://github.com/AdguardTeam/AdguardFilters/assets/54487525/6c92f296-c8ec-459a-a4dc-c2828f2d6b29)

</details>


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
