### PR TITLE
remove video ad on eigobu.jp

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -3359,6 +3359,7 @@ so-zou.jp###g-ad
 wezz-y.com###adEntryRectangleBottom
 wezz-y.com##div[id^="adSideRectangle"]
 eigobu.jp##.mp-Article_Ad
+eigobu.jp##.gliaplayer-container
 smatu.net##.wp-block-wp-quads-adds
 smatu.net##amp-iframe
 ||bbs.xvideosmtm.com/img/vip/


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

No issue assigned

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

**Warning:** Please remove personal information before uploading screenshots!

1. Your comment

PR removes video ad on eigobu.jp
example: https://eigobu.jp/magazine/sonokokoroha

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

![20230828_08h26m11s_grim](https://github.com/AdguardTeam/AdguardFilters/assets/6215916/59f84979-6022-455f-ab42-d0b152216427)


</details>

<details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
