### PR TITLE
Extension recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.vscode
+.vscode/*
+# allow .vscode/extensions.json
+!.vscode/extensions.json
 .DS_Store
 .idea
 node_modules

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "adguard.adblock"
+    ]
+}


### PR DESCRIPTION
This way VSCode offers to install recommended extensions when the user opens the repo (if not already installed):
![image](https://github.com/AdguardTeam/AdguardFilters/assets/57285466/9020698f-ee4f-4380-bbad-6a365ed0ee04)
