### PR TITLE
fix(tracking): removed redundant entries in tracking param list

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -251,7 +251,6 @@ mailchimp.com$removeparam=amp%3Bafl
 ||cnbc.com^$removeparam=__source
 ||cnbc.com^$removeparam=par
 ! Naver newsstand - https://newsstand.naver.com/
-$removeparam=utm_campaign,domain=joongang.co.kr|donga.com|hankyung.com|khan.co.kr|asiae.co.kr|fnnews.com|chosun.com
 $removeparam=plink,domain=sbs.co.kr
 $removeparam=cooper,domain=sbs.co.kr
 $removeparam=nv,domain=khan.co.kr
@@ -646,7 +645,6 @@ $removeparam=afid,domain=123chat.jp|kanochat.jp|live.fc2.com
 ||netflix.com^$removeparam=trackId
 ||netflix.com^$removeparam=tctx
 ! Emails from moodfabrics.com
-||moodfabrics.com^$removeparam=_kx
 ! georiot.com
 ||target.georiot.com/Proxy.ashx$removeparam=tsid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/126227
@@ -1075,7 +1073,6 @@ $removeparam=a_aid,domain=expressvpn.com|vpnarea.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/95523
 ||infoq.com^$removeparam=/topicPageSponsorship|^itm_/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/94797
-||coupondunia.in^$removeparam=itm_source
 ! https://github.com/AdguardTeam/AdguardFilters/issues/94722
 ||adshares.net^$removeparam=cid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/130919
@@ -1345,8 +1342,6 @@ $removeparam=at_medium,domain=bbc.com|bbc.co.uk
 ||zerkalo.io^$removeparam=tg
 ||zerkalo.io^$removeparam=vk
 !
-||microsoft.com^$removeparam=tduid
-||microsoft.com^$removeparam=irclickid
 ||microsoft.com^$removeparam=ranEAID
 ||microsoft.com^$removeparam=ranSiteID
 ||microsoft.com^$removeparam=ocid
@@ -1361,7 +1356,6 @@ $removeparam=dclid
 ||trendyol.com^$removeparam=utm_subaff
 !
 ||realitykings.com^$removeparam=ats
-||duda.co^$removeparam=irclickid
 ||marktjagd.de^$removeparam=client
 ||kaspersky.com^$removeparam=icid
 ||coursera.org^$removeparam=siteID
@@ -1435,7 +1429,6 @@ $removeparam=dclid
 ||flipkart.com^$removeparam=/^affExtParam/
 ||flipkart.com^$removeparam=affid
 ||flipkart.com^$removeparam=cid
-||flipkart.com^$removeparam=cmpid
 ||flipkart.com^$removeparam=iid
 ||flipkart.com^$removeparam=lid
 ||flipkart.com^$removeparam=/^otracker/


### PR DESCRIPTION
fixes #163338

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [ ] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

redundant entries in tracking param list are removed, see #163338

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

issue #163338

### Enter the issue address

<https://github.com/AdguardTeam/AdguardFilters/issues/163338>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
