### PR TITLE
Fix #166061 coinmarketcap.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -7,6 +7,7 @@
 !
 ! SECTION: Popups - Regular rules
 !
+/75027.f98ffb777033e1b.js$domain=coinmarketcap.com
 iobit.com##.br-botpop-right
 ec-store.net###rt\.popup-overlay_rt_popup_sws
 ec-store.net###rt_popup_sws


### PR DESCRIPTION
# Creating the pull request

> If you did not want to block the JS script itself, this would also work `coinmarketcap.com##.sc-5933e4b7-0`. Blocking the JS script does not seem to break anything; from what I can tell, it looks to be only used for the survey banner.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

#166061

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
