### PR TITLE
Fix #166244 www.detroitnews.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -54,7 +54,6 @@ newscientist.com,jiji.com,edp24.co.uk,technologyreview.com,nordbayern.de,theloca
 !
 ! SECTION: Subscriptions - Regular rules
 !
-||cm.detroitnews.com/overlay/$domain=detroitnews.com
 rzd-partner.ru##.text-telegram
 indianexpress.com##.subscriber_hide
 grassrootshealth.net#$#html.pum-open-overlay { overflow: auto !important; }
@@ -70,6 +69,7 @@ tlgrm.ru##.top-line-banner
 nomura.co.jp##.floating_bnr
 nomura.co.jp##.sns_follow
 multiplayer.it###adv-head
+||cm.detroitnews.com/overlay/$domain=detroitnews.com
 octane.jp##.memberRegistration
 nv.ua##a.promo
 gushiwen.cn###threeWeixin2

--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -54,6 +54,7 @@ newscientist.com,jiji.com,edp24.co.uk,technologyreview.com,nordbayern.de,theloca
 !
 ! SECTION: Subscriptions - Regular rules
 !
+||cm.detroitnews.com/overlay/$domain=detroitnews.com
 rzd-partner.ru##.text-telegram
 indianexpress.com##.subscriber_hide
 grassrootshealth.net#$#html.pum-open-overlay { overflow: auto !important; }


### PR DESCRIPTION
# Creating the pull request

> It seems to get triggered when changing news articles.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

detroitnews: <https://github.com/AdguardTeam/AdguardFilters/issues/166244#issuecomment-1812871971>

<details>

`"s": [28800, "https://cm.detroitnews.com/overlay/entrance_111423_BlackFriday#", "a0802e", "https://subscribe.detroitnews.com/specialoffer?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=2023BLKFRD&itm_source=digital&itm_term=outmark", "https://subscribe.detroitnews.com/specialoffer?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=2023BLKFRD&itm_source=digital&itm_term=inmark", "https://cm.detroitnews.com/overlay/entrance_111423_BlackFridayWB#", "fmd0802e", "https://subscribe.detroitnews.com/formerdigital?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=2023WBBLKFRD&itm_source=digital&itm_term=outmark", "https://subscribe.detroitnews.com/formerdigital?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=2023WBBLKFRD&itm_source=digital&itm_term=inmark", "https://cm.detroitnews.com/overlay/rescue_111423_BlackFridayWB#", "fmd0802x", "https://subscribe.detroitnews.com/formerdigital?gps-source=CPEOCON&itm_medium=onsite&itm_campaign=2023WBBLKFRD&itm_source=digital&itm_term=outmark", "https://subscribe.detroitnews.com/formerdigital?gps-source=CPEOCON&itm_medium=onsite&itm_campaign=2023WBBLKFRD&itm_source=digital&itm_term=inmark", "https://cm.detroitnews.com/overlay/entrance_110122_PrintWinbackBAU#", "fmp915e", "https://subscribe.detroitnews.com/formerprint?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=PONWBAU&itm_source=digital&itm_term=outmark", "https://subscribe.detroitnews.com/formerprint?gps-source=CPINTRS&itm_medium=onsite&itm_campaign=PONWBAU&itm_source=digital&itm_term=inmark", "https://cm.detroitnews.com/overlay/exit_110122_PrintWinbackBAU#", "fmp915x", "https://subscribe.detroitnews.com/formerprint?gps-source=CPEOCON&itm_medium=onsite&itm_campaign=PONWBAU&itm_source=digital&itm_term=outmark", "https://subscribe.detroitnews.com/formerprint?gps-source=CPEOCON&itm_medium=onsite&itm_campaign=PONWBAU&itm_source=digital&itm_term=inmark"]
 `

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
