### PR TITLE
Sorted some mishaps in the LV and LT sections

### DIFF
--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -5436,7 +5436,6 @@ koreanz.fun##.basic-banner
 !------------------------------ Latvian ------------------------------
 !---------------------------------------------------------------------
 ! NOTE: Latvian
-!
 la.lv##.toolsofthesaeson
 ||vesti.lv/www/imgget/imgjs.php?
 mixnews.lv##.advert
@@ -5453,24 +5452,6 @@ latviesi.com##.container > div > div[class^="sc-"] > a[href="https://ekiosks.lv/
 play.tv3.lv#%#//scriptlet('set-constant', 'Object.prototype.isNoAds', 'trueFunc')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/155360
 la.lv##.app > div[style="min-height:400px"]
-! https://github.com/AdguardTeam/AdguardFilters/issues/153109
-play.tv3.lt#%#//scriptlet('set-constant', 'Object.prototype.isNoAds', 'trueFunc')
-! https://github.com/AdguardTeam/AdguardFilters/issues/151120
-lrytas.lt##.LGalleryLightbox__ads
-lrytas.lt##.LGalleryMain__popup
-lrytas.lt##.LGalleryLightbox__popup
-! https://github.com/AdguardTeam/AdguardFilters/issues/149212
-play.tv3.lt#@##AdHeader
-play.tv3.lt#@##AD_Top
-play.tv3.lt#@##homead
-play.tv3.lt#@##ad-lead
-! https://github.com/AdguardTeam/AdguardFilters/issues/136100
-||lrvalstybe.lt/storage^*200x200$image
-||lrvalstybe.lt/storage^*790x100$image
-||lrvalstybe.lt/storage^*125x125$image
-||lrvalstybe.lt/storage^*1200x100$image
-||lrvalstybe.lt/storage/*/Arvikta_baneris.gif
-lrvalstybe.lt##.bnr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/125513
 tvnet.lv,apollo.lv#%#//scriptlet("prevent-setTimeout", "adblockNotif")
 tvnet.lv,apollo.lv#$#body > div[id] > div[style^="height: 1px; width: 1px; background-color: transparent;"] { display: block !important; }
@@ -5503,58 +5484,12 @@ nra.lv##.bl-cont-ad
 failiem.lv#@#.show_ads
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70785
 salidzini.lv###AM_giga
-! https://github.com/AdguardTeam/AdguardFilters/issues/159415
-! https://github.com/AdguardTeam/AdguardFilters/issues/148522
-! https://github.com/AdguardTeam/AdguardFilters/issues/48215
-!+ NOT_PLATFORM(windows, mac, android)
-15min.lt#%#//scriptlet('abort-on-stack-trace', 'Promise', 'inlineScript')
-!+ PLATFORM(windows, mac, android)
-15min.lt$$script[tag-content="banner"]
-! 15min.lt#%#//scriptlet('abort-current-inline-script', '$', '/(performance|googletag|offsetHeight)[\s\S]*?googlesyndication/')
-!#if (adguard_ext_safari)
-15min.lt##body > .top-banner + script + div[class]:empty
-15min.lt##div[class^="col-right"] > .widget-group > div[class][style="height: 700px;"]:empty
-15min.lt##div[class^="col-right"] > .widget-group > div[style="height: 600px;"]:empty:not([class]):not([id])
-15min.lt#?#body > [class][style*="display:"]:not(div):has(img[src^="https://s1.15min.lt/static/cache/"][alt=""]:not([style]))
-!#endif
 ! https://github.com/AdguardTeam/AdguardFilters/issues/30887
 balticlivecam.com##.vjs-poster
-! https://github.com/AdguardTeam/AdguardFilters/issues/34539
-autogidas.lt##.header-ann
-!
-! delfi.lt
-delfi.lt###ads-bottom-bar-container
-delfi.lt###al-580x150
-delfi.lt###al-infoblock
-delfi.lt##.ads-rudelfi-friends
-delfi.lt##.right img[width="300"][height="600"]
-delfi.lt##body > div[style^="position:fixed;"][style*="z-index:9999999"]:not([class]):not([id])
-delfi.lt##iframe[src*="//track.adform.net/"]
-delfi.lt##iframe[src*="//www.alio.lt/"]
-delfi.lt##iframe[src^="https://www.delfi.lt/apps/banners/"]
-delfi.lt##img[alt="topsport"]
-||delfi.lt/b?region=
-||alio.lt^$domain=delfi.lt
-! Anti-adblock
-@@||s1.adform.net/banners/scripts/adx.js$domain=delfi.lt
-delfi.lt#%#//scriptlet('set-constant', '_dlf.adfree', '1')
-!#if (adguard_ext_firefox || adguard_ext_opera || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb || ext_ublock)
-delfi.lt##div[itemprop="articleBody"] > div[style="float:left;margin: 0 25px 25px 0;"]
-delfi.lt##body > #header-top-banner + [class]:not(div):not(iframe):not(span):not(table):not(form)
-delfi.lt##.row > .left + div[class]:not(.right):not([id]) > :not(iframe):not(span):not(table):not(form):not([class])
-!#endif
-cloudycdn.services#%#//scriptlet("json-prune", "source.ads")
-||adocean.pl/*ad.xml$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/,domain=cloudycdn.services
 !#if (adguard_app_ios || adguard_ext_android_cb)
 @@||1188lv.adocean.pl/*ad.xml$domain=embed.cloudycdn.services
 @@||1188lv.adocean.pl/files/*.mp4$domain=embed.cloudycdn.services
 !#endif
-!
-!---------------------------------------------------------------------
-!------------------------------ Lithuanian ---------------------------
-!---------------------------------------------------------------------
-! NOTE: Lithuanian
-!
 ! delfi.lv
 @@||ads.delfi.lv^$elemhide
 @@||delfi.lv/celojumi^$elemhide
@@ -5571,6 +5506,10 @@ delfi.lv##div[data-ad-placement]
 delfi.lv##div[id^="zave_"]
 delfi.lv#%#//scriptlet("set-constant", "Adform", "emptyObj")
 delfi.lv#?#section > div[style]:has(> span:contains(/^Реклама$|^Reklāma$/))
+!---------------------------------------------------------------------
+!------------------------------ Lithuanian ---------------------------
+!---------------------------------------------------------------------
+! NOTE: Lithuanian
 !
 ||alio.lt/infoblock.html
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151119
@@ -5635,6 +5574,45 @@ topzone.lt##div[id^="edit"] > .tborder:not([id^="post"])
 filmux.org#?##box-main > .box-rekbar:has(> noindex > div[id*="ScriptRoot"])
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7902
 ||static.vz.lt/files/antsrauto/countsJS.php^
+! delfi.lt
+delfi.lt###ads-bottom-bar-container
+delfi.lt###al-580x150
+delfi.lt###al-infoblock
+delfi.lt##.ads-rudelfi-friends
+delfi.lt##.right img[width="300"][height="600"]
+delfi.lt##body > div[style^="position:fixed;"][style*="z-index:9999999"]:not([class]):not([id])
+delfi.lt##iframe[src*="//track.adform.net/"]
+delfi.lt##iframe[src*="//www.alio.lt/"]
+delfi.lt##iframe[src^="https://www.delfi.lt/apps/banners/"]
+delfi.lt##img[alt="topsport"]
+||delfi.lt/b?region=
+||alio.lt^$domain=delfi.lt
+! Anti-adblock
+@@||s1.adform.net/banners/scripts/adx.js$domain=delfi.lt
+delfi.lt#%#//scriptlet('set-constant', '_dlf.adfree', '1')
+!#if (adguard_ext_firefox || adguard_ext_opera || adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb || ext_ublock)
+delfi.lt##div[itemprop="articleBody"] > div[style="float:left;margin: 0 25px 25px 0;"]
+delfi.lt##body > #header-top-banner + [class]:not(div):not(iframe):not(span):not(table):not(form)
+delfi.lt##.row > .left + div[class]:not(.right):not([id]) > :not(iframe):not(span):not(table):not(form):not([class])
+!#endif
+! https://github.com/AdguardTeam/AdguardFilters/issues/159415
+! https://github.com/AdguardTeam/AdguardFilters/issues/148522
+! https://github.com/AdguardTeam/AdguardFilters/issues/48215
+!+ NOT_PLATFORM(windows, mac, android)
+15min.lt#%#//scriptlet('abort-on-stack-trace', 'Promise', 'inlineScript')
+!+ PLATFORM(windows, mac, android)
+15min.lt$$script[tag-content="banner"]
+! 15min.lt#%#//scriptlet('abort-current-inline-script', '$', '/(performance|googletag|offsetHeight)[\s\S]*?googlesyndication/')
+!#if (adguard_ext_safari)
+15min.lt##body > .top-banner + script + div[class]:empty
+15min.lt##div[class^="col-right"] > .widget-group > div[class][style="height: 700px;"]:empty
+15min.lt##div[class^="col-right"] > .widget-group > div[style="height: 600px;"]:empty:not([class]):not([id])
+15min.lt#?#body > [class][style*="display:"]:not(div):has(img[src^="https://s1.15min.lt/static/cache/"][alt=""]:not([style]))
+!#endif
+! https://github.com/AdguardTeam/AdguardFilters/issues/34539
+autogidas.lt##.header-ann
+cloudycdn.services#%#//scriptlet("json-prune", "source.ads")
+||adocean.pl/*ad.xml$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/,domain=cloudycdn.services
 !
 m.basketnews.lt##div[style^="text-align: center; width: 300px; height: 250px;"]
 m.basketnews.lt##.main_title > div[style="text-align: center;"] > a > img

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -5510,6 +5510,24 @@ delfi.lv#?#section > div[style]:has(> span:contains(/^Реклама$|^Reklāma$
 !------------------------------ Lithuanian ---------------------------
 !---------------------------------------------------------------------
 ! NOTE: Lithuanian
+! https://github.com/AdguardTeam/AdguardFilters/issues/153109
+play.tv3.lt#%#//scriptlet('set-constant', 'Object.prototype.isNoAds', 'trueFunc')
+! https://github.com/AdguardTeam/AdguardFilters/issues/151120
+lrytas.lt##.LGalleryLightbox__ads
+lrytas.lt##.LGalleryMain__popup
+lrytas.lt##.LGalleryLightbox__popup
+! https://github.com/AdguardTeam/AdguardFilters/issues/149212
+play.tv3.lt#@##AdHeader
+play.tv3.lt#@##AD_Top
+play.tv3.lt#@##homead
+play.tv3.lt#@##ad-lead
+! https://github.com/AdguardTeam/AdguardFilters/issues/136100
+||lrvalstybe.lt/storage^*200x200$image
+||lrvalstybe.lt/storage^*790x100$image
+||lrvalstybe.lt/storage^*125x125$image
+||lrvalstybe.lt/storage^*1200x100$image
+||lrvalstybe.lt/storage/*/Arvikta_baneris.gif
+lrvalstybe.lt##.bnr
 !
 ||alio.lt/infoblock.html
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151119


### PR DESCRIPTION
# Creating the pull request

In relation to https://github.com/EasyList-Lithuania/easylist_lithuania/pull/26#issuecomment-1818342187, I took a look at https://github.com/AdguardTeam/AdguardFilters/blob/master/BaseFilter/sections/foreign.txt, noticed `delfi.lv` entries in the Lithuanian section, and thought "Wait, that can't be right?"

So I attempted to place various entries for at least 6 sites into the correct sections. 🌞

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

*De facto* https://github.com/EasyList-Lithuania/easylist_lithuania/pull/26

### Enter the issue address

https://github.com/EasyList-Lithuania/easylist_lithuania/pull/26

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

1. Add screenshots of the problem. You can drag and drop images or paste them from clipboard

 <details>

![image](https://github.com/AdguardTeam/AdguardFilters/assets/22780683/f7ff500e-dfb2-430d-80d6-3af7273655bd)

</details>

(The Linguist linter seems a bit broken this week, but you'll get the gist of it.)

2. Your comment

Some .lv entries are incorrectly placed in the Lithuanian section, while many .lt entries are incorrectly placed in the Latvian section.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
