### PR TITLE
Fix #165624 check-host.net

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -16833,9 +16833,9 @@ outlook.live.com#?#.customScrollBar[data-is-scrollable] > div[class] > div[class
 ! check-host.net
 check-host.net##div[class*="place-self-"]
 check-host.net###content > div.text-left > div[class^="m"] > div.relative a > img
-/^https:\/\/check-host\.net\/images\/[a-z]{2,9}[0-9]{1,3}_?[0-9]+[a-z]+(_|[0-9]?[a-z-])+(s?ale|en|ru)?\.png/$domain=check-host.net
+/^https:\/\/check-host\.net\/images\/[a-z]{2,10}[0-9]{1,3}_?[0-9]+[a-z]+(_|[0-9]?[a-z-])+(s?ale|en|ru)?\.png/$domain=check-host.net
 check-host.net#?#div + div[class*=" "]:last-child:contains(/^ ?[×✕✖X☓χx⨯✗\+\＋\﹢хХΧẊẋ]$/):upward(2)
-check-host.net#?#a[href]:contains(/^([Aa][eé]za|100[%％﹪⁒])/)
+check-host.net#?#a[href]:contains(/^([Aa][eé]za|100[%％﹪⁒]| )/)
 !
 ! quora.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/149846


### PR DESCRIPTION
# Creating the pull request

> This rule still needs to be updated.\
> `check-host.net#?#div + div[class*=" "]:last-child:contains(/^ ?[×✕✖X☓χx⨯✗\+\＋\﹢хХΧẊẋ]$/):upward(2)`

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

#165624

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
