### PR TITLE
Add some Tencent trackers to spy filter

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -560,3 +560,4 @@ _analytics.js?
 _pagespeed_beacon?
 _social_tracking.js^
 _tracking.php?b=
+/aegis-sdk/$script

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -560,4 +560,4 @@ _analytics.js?
 _pagespeed_beacon?
 _social_tracking.js^
 _tracking.php?b=
-/aegis-sdk/$script
+/aegis-sdk/*$script

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -76,6 +76,7 @@
 ||us.tags.newscgp.com^
 ||smazaz.icu^
 ||mpraven.org^
+||rumt-zh.com^
 ||smatr.net^
 ||meet-buddy.com^
 ||adsmeasurement.com^

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -732,6 +732,7 @@
 ||beacon.netflix.com^
 ||beacon.nuskin.com^
 ||beacon.qq.com^
+||beacon.cdn.qq.com^
 ||beacon.riskified.com^
 ||beacon.samsclub.com^
 ||beacon.sojern.com^


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

`beacon.cdn.qq.com` and `beacon.qq.com` are used for Tencent Beacon, which is Tencent's big data analysis tool.

`aegis-web-sdk` is a front-end monitoring platform launched by Tencent Cloud Monitoring: https://www.npmjs.com/package/aegis-web-sdk

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
