### PR TITLE
Remove obsolete filters for nicovideo.jp

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -3079,7 +3079,6 @@ eneba.com##.xmbBPq
 humblebundle.com###site-xpromo-banner
 infoworld.com#?#.sector > ul > li:not([class]):has(> div.item-eyebrow > span.sponsored)
 sp.nicovideo.jp###jsBlockedPremiumMiddleBannerContainer
-nicovideo.jp##.IchibaContainer.Card
 forhims.com#$#div[class*="promo-bannerstyle"] { display: none !important; }
 forhims.com#$#nav[role="navigation"] { top: 0 !important; }
 themeisle.com###text-7


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address
<https://github.com/AdguardTeam/AdguardFilters/issues/92278>

### Add your comment and screenshots
Remove rules no longer needed on nicovideo.jp
Niconico Ichiba has been closed at Nov. 30, 2023.
`https://qa.nicovideo.jp/faq/show/758?site_domain=default`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
