### PR TITLE
Remove obsolete filters for telkku.com

### DIFF
--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -2386,17 +2386,6 @@ mtvuutiset.fi##.ad-container
 mtvuutiset.fi##.leaderboard
 ! https://github.com/AdguardTeam/AdguardFilters/issues/9411
 ||ads-*.nelonenmedia.fi/ads/*.mp4
-! https://github.com/AdguardTeam/AdguardFilters/issues/23266
-||iltalehti.fi^$domain=telkku.com,third-party
-telkku.com##.nav__ekontakti
-telkku.com##.nav__alma
-telkku.com##.nav__alekoodi
-telkku.com#?#.rectangle-container:has(> .iframe-container > iframe[src^="https://ad.ilcdn.fi/"])
-telkku.com#?#.rectangle-container:has(> iframe[src^="http://www.iltalehti.fi/"])
-telkku.com#?#.rectangle-container:has(> #footer-split--iltalehti-first)
-telkku.com##.rectangle-divider-big
-telkku.com##.rectangle-divider-medium
-telkku.com##.rectangle-divider-small
 ! https://forum.adguard.com/index.php?threads/7957/
 ||amazonaws.com/www.katsomo.fi/config.json$replace=/"enabled": true\,/"enabled": false\,/i
 ||amazonaws.com/www.katsomo.fi/config.json$replace=/"enabled": true\,/"enabled": false\,/i,important


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?


### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/23266


### Add your comment and screenshots

Remove very old filters. `telkku.com` has been redirecting to `iltalehti.fi/telkku` for a few years already.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
