### PR TITLE
Add events-api.gazetadopovo.com.br

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -665,7 +665,7 @@
 ||vought.removeads.workers.dev^
 ||analytics.churnzero.net^
 ||trk.reclameaqui.com.br^
-||events-api.gazetadopovo.com.br
+||events-api.gazetadopovo.com.br^
 ||s.clickiocdn.com^$third-party
 ||i-cmg-amlg-prod.appspot.com^$third-party
 ||a.myfidevs.io^$third-party

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -665,6 +665,7 @@
 ||vought.removeads.workers.dev^
 ||analytics.churnzero.net^
 ||trk.reclameaqui.com.br^
+||events-api.gazetadopovo.com.br
 ||s.clickiocdn.com^$third-party
 ||i-cmg-amlg-prod.appspot.com^$third-party
 ||a.myfidevs.io^$third-party


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Add your comment and screenshots
A user tracker.

I tested it both in the browser and in the app, and no functions were compromised. It continues to work normally for visitors and registered users.

The same tracker is used on two other sites belonging to the same business group:
https://www.umdoisesportes.com.br/
https://www.semprefamilia.com.br/

![image](https://github.com/AdguardTeam/AdguardFilters/assets/47755037/370362c0-2e19-4b15-84cc-1082b31a2bfe)
![image](https://github.com/AdguardTeam/AdguardFilters/assets/47755037/13103e91-aee8-4234-9dd1-9725a53151d8)

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
