### PR TITLE
Add api.viavarejo.com.br/fp/

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1765,6 +1765,7 @@ viva.ua##.footer-counters
 ||vtex.com.br/rc/rc.js
 ||rihappy.com.br/api/sessions?items
 ||vteximg.com.br/scripts/vtex.tagmanager.helper.js
+||api.viavarejo.com.br/fp/
 news.mynavi.jp##.articleList-along
 news.mynavi.jp##.articleList-attention
 ||t.rentcafe.com/rctv*.min.js


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Add your comment and screenshots
URL used for fingerprint.

All three sites belong to the "Grupo Casas Bahia", formerly "Via Varejo", so they share the same resources.
https://www.grupocasasbahia.com.br/

<details>

<summary>pontofrio.com.br</summary>

![image](https://github.com/AdguardTeam/AdguardFilters/assets/47755037/ac507afc-4c64-4818-ba2b-c080347ef8f8)

</details>

<details>

<summary>casasbahia.com.br</summary>

![image](https://github.com/AdguardTeam/AdguardFilters/assets/47755037/27d8b67a-e90b-4268-9379-0b1f99a4a930)

</details>

<details>

<summary>extra.com.br</summary>

![image](https://github.com/AdguardTeam/AdguardFilters/assets/47755037/dc97a5cf-dc80-41ea-a810-c4e458eda738)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
