### PR TITLE
Add a fallback rule for PopAds

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -35,6 +35,9 @@
 !+ PLATFORM(ios, ext_safari)
 /^https?:\/\/[0-9a-z]*\.?[-0-9a-z][-0-9a-z][-0-9a-z][-0-9a-z]+\.[a-z][a-z]+\/([0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]+\/)?\/?\?[ou]=[0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]&[ou]=[0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]/$document,match-case
 !
+! PopAds
+.com/*=e3&*,0|$script,third-party
+!
 .com/1?z=$script,third-party
 .com/2?z=$script,third-party
 .net/1?z=$script,third-party


### PR DESCRIPTION
### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/pull/168292

### Add your comment and screenshots

If all other measures failed, PopAds calls scripts like `https://lcwoewvvmhj.com/pufrwrhyyztrau?SJrTMBOm=e3&wuDPRoBb=4&hjtaLXYg=5034003&xDUcayXI=&ReXxtyKl=0,0&tNzabXHw=&FYBsLOTG=https%3A%2F%2Fdiskusscan.com%2Fmanga%2Freturn-of-the-flowery-mountain-sect%2F&cTkzsiJy=1920,1080,1.01,1939.2,1090.8,0` (e.g. on `diskusscan.com`). This rule will mitigate at least popups/unders and can be generic as legitimate 3p scripts ending with `,0` will be unlikely. IDK if it is always `0`, but this has been the case on my end.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
