### PR TITLE
Add v.qq.com specific to Chinese filter

### DIFF
--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -499,6 +499,8 @@ news.mydrivers.com##.baidu_left
 meijutt.tv##.a960_index
 ||meijutt.tv/js/pcjs/alltop_960_1.js
 v.qq.com##.player-side-ads
+v.qq.com##.game-switch-ad
+v.qq.com###iwan-gamependant-page
 mamibuy.com.tw##.content-ad-spa
 youku.com##.videolist_s_body > div.common_container > div[id^="ab_"]
 ||158zm.com/top.js


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/pull/167263#issuecomment-1846986069

The two rules here were not added to the Chinese filter

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met