### PR TITLE
Fix #169856 `Dutch domains starting with "A"`

### DIFF
--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -26,7 +26,7 @@ androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,weg
 ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
-arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
+arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info##.component__pubble-banner
 arenalokaal.nl#?#.content-start > * > div[style]:contains(/Externe links|Externe websites/i)
 autosport.nl##.advertentie_links
 autosport.nl##.bigbanner

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -14,7 +14,6 @@ agconnect.nl##div[class$="_ad-slot"]
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
-alkmaarguardians.nl###footer
 alle-tests.nl,bloovi.be###advertising
 almere-nieuws.nl###containerx
 almere-nieuws.nl#?#.advertisement_block:upward(1)

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -28,7 +28,6 @@ antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,r
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
 arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
 arenalokaal.nl#?#.content-start > * > div[style]:contains(/Externe links|Externe websites/i)
-autosport.nl#?#.active.first:style(margin-top: 0px !important;)
 autosport.nl##.advertentie_links
 autosport.nl##.bigbanner
 autowereld.nl###banner-lister-top

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -15,7 +15,6 @@ alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
-almere-nieuws.nl,sexjobs.nl##div[id^="banner-"]
 androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,wegdamnieuws.nl##.ads
 ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -13,7 +13,7 @@ adultwebmaster.nl##.main-promo-bn-responsive
 afkortingen.nu###banner_rectangle
 afkortingen.nu###banner_right
 afkortingen.nu###banner_top
-agconnect.nl##[class$="_ad-slot"]
+agconnect.nl##div[class$="_ad-slot"]
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-widget
 alblasserdamsnieuws.nl#?#.adv-link:not([href*="alblasserdamsnieuws.nl"]):upward(div[id^="albl"])

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -4,6 +4,39 @@
 ! Good: example.org###rek; ||example.com/ads/
 ! Bad: example.org#$##rek { display: none !important; } (for instance, should be in general_extensions.txt)
 !
+112achterhoek-nieuws.nl###sidebar
+402online.com##.bannerblock
+7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.dfp-space
+7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,hln.be,pzc.nl##.page-header__section--spacer
+7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl#?#.tile:has(:scope >.ankeiler--advertisement)
+adultwebmaster.nl##.main-promo-bn-responsive
+afkortingen.nu###banner_rectangle
+afkortingen.nu###banner_right
+afkortingen.nu###banner_top
+agconnect.nl##[class$="_ad-slot"]
+alblasserdamsnieuws.nl##.albla-adlabel
+alblasserdamsnieuws.nl##.albla-widget
+alblasserdamsnieuws.nl#?#.adv-link:not([href*="alblasserdamsnieuws.nl"]):upward(div[id^="albl"])
+alblasserdamsnieuws.nl#?#.sidebarbox > .widgettitle:has-text(Banner)
+alkmaarguardians.nl###footer
+alle-tests.nl,bloovi.be###advertising
+almere-nieuws.nl###containerx
+almere-nieuws.nl#?#.advertisement_block:upward(1)
+almere-nieuws.nl#?#.darksection:has-text(/Door onze partners/i):has(.postbox.owl-carousel)
+almere-nieuws.nl#?#.promocentered:upward(section)
+almere-nieuws.nl,sexjobs.nl##div[id^="banner-"]
+androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,wegdamnieuws.nl##.ads
+ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
+antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
+apparata.nl#?#.widget:has(h2:has-text(/Partners/i))
+arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
+arenalokaal.nl#?#.content-start > * > div[style]:has-text(/Externe links|Externe websites/i)
+arenalokaal.nl,dehavenloods.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl#?#.component__pubble-banner:has([advobject]):upward(.bg-gray-100):has-text(/Uit de krant/i)
+autosport.nl#?#.active.first:style(margin-top: 0px !important;)
+autosport.nl##.advertentie_links
+autosport.nl##.bigbanner
+autowereld.nl###banner-lister-top
+autowereld.nl###mainbanner
 mannenzaken.nl##.r89-desktop-billboard-atf
 mannenzaken.nl##.r89-desktop-leaderboard-btf
 mannenzaken.nl##.r89-desktop-hpa-atf
@@ -20,7 +53,6 @@ androidplanet.nl#?#.sidebar > .widget_static_device_widget:has(.device-ad)
 androidplanet.nl#?#.pd-results-container > .results-inner > .pd-advisor-offer-container:first-child:has(> .pd-advisor-offer > .result-badge:contains(Adv.))
 gpblog.com#?#.articles > li.injection:has(> aside.betting)
 rtlnieuws.nl#?#.off-canvas-content > div:has(> div.dfp-rectangle-wrapper)
-ad.nl#?#ol > li.tile:has(> article.ankeiler--advertisement)
 knack.be#?##below_para_1:has(> a[href^="https://e093.knack.be/"])
 bnnvara.nl#?#div[id^="ster-ad-bnnvara-"]:upward(1)
 gfcnieuws.com#?#.entry-content div[class]:has(> ins.adsbygoogle)
@@ -53,7 +85,6 @@ ad.nl##iframe[src^="https://cdn.reclamefolder.org/"]
 iculture.nl##div[style="min-height:250px"]
 538.nl###eCommerce
 ad.nl##.ankeiler--advertisement
-ad.nl##.dfp-space
 nu.nl##div.articlelist[data-section="advertorial-belastingdienst-adverteerder"]
 ad.nl##.advertising-container-top
 focus-wtv.be##a[href^="https://ads.focus-wtv.be/"]

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -15,9 +15,8 @@ afkortingen.nu###banner_right
 afkortingen.nu###banner_top
 agconnect.nl##div[class$="_ad-slot"]
 alblasserdamsnieuws.nl##.albla-adlabel
-alblasserdamsnieuws.nl##.albla-widget
-alblasserdamsnieuws.nl#?#.adv-link:not([href*="alblasserdamsnieuws.nl"]):upward(div[id^="albl"])
-alblasserdamsnieuws.nl#?#.sidebarbox > .widgettitle:has-text(Banner)
+alblasserdamsnieuws.nl##.albla-adlabel
+alblasserdamsnieuws.nl##div[id^="albla-"]
 alkmaarguardians.nl###footer
 alle-tests.nl,bloovi.be###advertising
 almere-nieuws.nl###containerx

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -8,7 +8,7 @@
 402online.com##.bannerblock
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.dfp-space
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,hln.be,pzc.nl##.page-header__section--spacer
-7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl#?#.tile:has(:scope >.ankeiler--advertisement)
+7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.tile:has(> article.ankeiler--advertisement)
 adultwebmaster.nl##.main-promo-bn-responsive
 afkortingen.nu###banner_rectangle
 afkortingen.nu###banner_right

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -5,7 +5,6 @@
 ! Bad: example.org#$##rek { display: none !important; } (for instance, should be in general_extensions.txt)
 !
 402online.com##.bannerblock
-7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.dfp-space
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,hln.be,pzc.nl##.page-header__section--spacer
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.tile:has(> article.ankeiler--advertisement)
 adultwebmaster.nl##.main-promo-bn-responsive

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -5,7 +5,6 @@
 ! Bad: example.org#$##rek { display: none !important; } (for instance, should be in general_extensions.txt)
 !
 402online.com##.bannerblock
-7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,hln.be,pzc.nl##.page-header__section--spacer
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.tile:has(> article.ankeiler--advertisement)
 adultwebmaster.nl##.main-promo-bn-responsive
 afkortingen.nu###banner_rectangle

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -17,7 +17,7 @@ alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
 androidworld.nl##.r89-desktop-billboard-atf
 cinenews.be,handbal.nl,webmastersunited.com,wegdamnieuws.nl##.ads
-ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
+ans-online.nl#?#.theiaStickySidebar > aside.penci_latest_news_widget > h4.widget-title:contains(Advertentie)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
 arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info##.component__pubble-banner

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -15,7 +15,8 @@ alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
-androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,wegdamnieuws.nl##.ads
+androidworld.nl##.r89-desktop-billboard-atf
+cinenews.be,handbal.nl,webmastersunited.com,wegdamnieuws.nl##.ads
 ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -15,10 +15,6 @@ alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
-almere-nieuws.nl###containerx
-almere-nieuws.nl#?#.advertisement_block:upward(1)
-almere-nieuws.nl#?#.darksection:has-text(/Door onze partners/i):has(.postbox.owl-carousel)
-almere-nieuws.nl#?#.promocentered:upward(section)
 almere-nieuws.nl,sexjobs.nl##div[id^="banner-"]
 androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,wegdamnieuws.nl##.ads
 ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -28,7 +28,6 @@ antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,r
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
 arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
 arenalokaal.nl#?#.content-start > * > div[style]:contains(/Externe links|Externe websites/i)
-arenalokaal.nl,dehavenloods.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl#?#.component__pubble-banner:has([advobject]):upward(.bg-gray-100):has-text(/Uit de krant/i)
 autosport.nl#?#.active.first:style(margin-top: 0px !important;)
 autosport.nl##.advertentie_links
 autosport.nl##.bigbanner

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -4,7 +4,6 @@
 ! Good: example.org###rek; ||example.com/ads/
 ! Bad: example.org#$##rek { display: none !important; } (for instance, should be in general_extensions.txt)
 !
-112achterhoek-nieuws.nl###sidebar
 402online.com##.bannerblock
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,hln.be,pzc.nl,tubantia.nl##.dfp-space
 7sur7.be,ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,hln.be,pzc.nl##.page-header__section--spacer

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -25,7 +25,7 @@ almere-nieuws.nl,sexjobs.nl##div[id^="banner-"]
 androidworld.nl,cinenews.be,handbal.nl,openrotterdam.nl,webmastersunited.com,wegdamnieuws.nl##.ads
 ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
-apparata.nl#?#.widget:has(h2:has-text(/Partners/i))
+apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
 arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
 arenalokaal.nl#?#.content-start > * > div[style]:has-text(/Externe links|Externe websites/i)
 arenalokaal.nl,dehavenloods.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl#?#.component__pubble-banner:has([advobject]):upward(.bg-gray-100):has-text(/Uit de krant/i)

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -27,7 +27,7 @@ ans-online.nl#?#.theiaStickySidebar > .widget:has-text(/Advertentie\b/)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
 apparata.nl#?#.ct-sidebar > div.widget:has(h2:contains(Partners))
 arenalokaal.nl,dehavenloods.nl,dekrantnieuws.nl,destreekkrant.nu,gooieneembode.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl,nnp.nl,weespernieuws.nl,zuidenvelder.info#?#.component__pubble-banner:has([advobject])
-arenalokaal.nl#?#.content-start > * > div[style]:has-text(/Externe links|Externe websites/i)
+arenalokaal.nl#?#.content-start > * > div[style]:contains(/Externe links|Externe websites/i)
 arenalokaal.nl,dehavenloods.nl,hetkrantje-online.nl,laardercourant.nl,leiderdorpsweekblad.nl#?#.component__pubble-banner:has([advobject]):upward(.bg-gray-100):has-text(/Uit de krant/i)
 autosport.nl#?#.active.first:style(margin-top: 0px !important;)
 autosport.nl##.advertentie_links


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites
### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 #169856 
### Add your comment and screenshots

<!-- #### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

0. **DO NOT** upload screenshots with sexually explicit material on GitHub directly.\
 Instead, upload it to a third-party image hosting and post the link to it without preview (!) here.\
 Also, mention if the link leads to NSFW content;

1. Add screenshots of the problem. You can drag and drop images or paste them from clipboard

    Use `<details> </details>` tag to hide screenshots under the spoiler;

2. Describe the issue in detail until it is absolutely clear from the screenshot what the problem is

    You can also indicate any other information that you think the developers should know.

**Warning:** Please remove personal information before uploading screenshots! -->

1. Your comment

The normal EasyList Dutch filter list is outdated a lot and in the past they wouldn't approve my new rules as it didn't meet their syntax. But that really hindered me, as some rules need the advanced Adguard/uBlock syntax. 

Below is a list of domains, so you can verify my rules. I have tested them recently (today and max 1 week old):

<details><summary>List with domains where you can find ads or left-overs</summary>

```
https://www.112achterhoek-nieuws.nl/
https://www.402online.com/

7sur7.be, ad.nl, bd.nl, bndestem.nl, destentor.nl, ed.nl, gelderlander.nl, hln.be, pzc.nl, tubantia.nl --> all on homepage

https://adultwebmaster.nl/forums/

https://www.afkortingen.nu/bios & other 2 on https://www.afkortingen.nu/

https://www.ajax1.nl/

https://www.alkmaarguardians.nl/

https://www.alle-tests.nl/ & https://www.bloovi.be/

https://www.alblasserdamsnieuws.nl/

https://allecijfers.nl/verkiezingsuitslagen/

1st: https://almere-nieuws.nl/p2000/
2nd: https://www.almere-nieuws.nl/nieuws/25595/mogelijk-verkeersconflict-voorafgaand-aan-schietpartij-in-tussen-de-vaarten/
3-5: https://www.almere-nieuws.nl/ (& [NSFW] https://www.sexjobs.nl/)

https://ans-online.nl/

https://www.apparata.nl/

https://autosport.nl/

1st: https://www.autowereld.nl/goedkope-occasions
2nd: https://www.autowereld.nl/

https://www.arenalokaal.nl/
https://www.dehavenloods.nl/
https://www.dekrantnieuws.nl/
https://www.destreekkrant.nu/
https://www.gooieneembode.nl/
https://www.hetkrantje-online.nl/
https://www.laardercourant.nl/
https://www.leiderdorpsweekblad.nl/
https://www.nnp.nl/
https://www.weespernieuws.nl/
https://www.zuidenvelder.info/

`.bannergroup`: all on homepage & https://www.dolcevia.com/nl/italie-magazine/lifestyle/4779-kerstavond-in-italie-het-feest-van-de-zeven-vissen

https://www.autowereld.nl/goedkope-occasions
https://www.autowereld.nl/
```
</details>

If I missed an URL then the element is on the homepage.

2. Screenshots

*To many to add*

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
