### PR TITLE
feat: logrocket session replay

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -105,6 +105,7 @@
 ||emlsend.com^$third-party
 ||starszoom.re^
 ||lr-intake.com^
+||intake-lr.com^
 ||collector-api.frspecifics.com^
 ||carrick-ui.advoncommerce.com^
 ||smelel.icu^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Fix missing domain for [LogRocket](https://logrocket.com/)' session replay intake endpoint.
Looks like this used to be `lr-intake.com`, but they've migrated to `intake-lr.com`

The endpoint was discovered by manually reverse-engineering / proxying requests through app that uses it.
<details>
<summary>Screenshot of proxy</summary>

![CleanShot 2024-01-13 at 05 25 29](https://github.com/AdguardTeam/AdguardFilters/assets/2129163/358f374f-64fa-45e4-831c-f25a5f65534c)
</details>

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
