### PR TITLE
social/annoyances filters maintenance

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -211,7 +211,7 @@ freundin.de,utopia.de,mein-schoener-garten.de,eveningnews24.co.uk,rollingstone.d
 !
 ! START: iubenda CMP
 ! No action required ##
-105.net,abwab.eu,danielesubrizi.it,gelocal.it,today.it,radiomontecarlo.net,r101.it,villacavalierisrl.it,villabetaniaroma.it,villamafalda.com,ambulatoriovillachiara.it,ambulatoriovillachiara.it,tvtech.it,crai-supermercati.it,centromedicoarcidiacono.it,usi.it,laboratoriodiegoangeli.it,analisiroma.it,edizioni.multiplayer.it,smartworld.it,pianteweb.com,cioccolatonippon.it,hwupgrade.it,iphoneitalia.com,mediaset.it,arduino.cc,virginradio.it##body #iubenda-cs-banner
+105.net,abwab.eu,danielesubrizi.it,gelocal.it,today.it,radiomontecarlo.net,r101.it,villacavalierisrl.it,villabetaniaroma.it,villamafalda.com,ambulatoriovillachiara.it,ambulatoriovillachiara.it,tvtech.it,crai-supermercati.it,centromedicoarcidiacono.it,usi.it,laboratoriodiegoangeli.it,analisiroma.it,edizioni.multiplayer.it,pianteweb.com,cioccolatonippon.it,hwupgrade.it,iphoneitalia.com,mediaset.it,arduino.cc,virginradio.it##body #iubenda-cs-banner
 ||cdn.iubenda.com^$domain=crazygames.com|caseecase-roma.it|smartworld.it
 ! No action required (scrolling is blocked) #$#
 urbanpost.it,synlab.it,dissapore.com,leganerd.com,siracusanews.it,tomshw.it,ansa.it,ilmessaggero.it,dilei.it,quifinanza.it,siviaggia.it,buonissimo.it,paginebianche.it,paginegialle.it,pgcasa.it,supereva.it,tuttocitta.it,virgilio.it#$##iubenda-cs-banner { display: none !important; }

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -83,19 +83,15 @@ hani.co.kr#?#ul[class^="ArticleToolbar_list_"] > li:is(:has(img[alt="인쇄"]), 
 brookings.edu##.tweet-it
 esports-world.jp##.post__share
 esports-world.jp##.post__detail__content > a[href="https://discord.gg/apgduv8rqN"]
-105.net##.vc_share_link_container
 salario.com.br##div[class^="ads_"]
 salario.com.br##div[style^="width: 100%; height: 280px; margin: 20px 0;"]
 dgabc.com.br##._noticiaCompartilhamento
 danielesubrizi.it##.nectar-social
-ilsecoloxix.it##.story__share
-ilsecoloxix.it##.story__utility__share
 bg-gledai.*##.swp_social_panel
 bg-gledai.*##.nc_wrapper
-gelocal.it##.story__share
-gelocal.it##.story__utility__share
-huffingtonpost.it,lastampa.it##.story__utility__share
-radiomontecarlo.net,r101.it##.vc_share_link_container
+ilsecoloxix.it,gelocal.it##.story__share
+ilsecoloxix.it,gelocal.it,huffingtonpost.it,lastampa.it##.story__utility__share
+105.net,radiomontecarlo.net,r101.it##.vc_share_link_container
 warnerbrosgames.com##.utility > .wrap > .shareables
 warnerbrosgames.com#?#.utility > .wrap > h6:contains(/^Share$/)
 toei-anim.co.jp##.c-box-share


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?


**Annoyances:**
- removed `smartworld.it` from `##body #iubenda-cs-banner` because already part of `||cdn.iubenda.com^$domain=crazygames.com|caseecase-roma.it|smartworld.it`
- currently `smartworld.it` belongs to `! No action required (scrolling is blocked) #$#` (see #170741 ), so maybe `||cdn.iubenda.com^$domain=smartworld.it` should be moved there. For example `crazygames.com|caseecase-roma.it` are different, because scrolling isn't blocked. Let me know.


**Socials:**
combined `##.story__share` , `##.story__utility__share` and `##.vc_share_link_container` because very similar sites.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met