### PR TITLE
Remove two redundant rules

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -15,7 +15,6 @@ $removeparam=af_adset
 $removeparam=af_click_lookback
 $removeparam=af_force_deeplink
 $removeparam=is_retargeting
-$removeparam=af_force_deeplink
 &af_xp=$removeparam=c
 &af_xp=$removeparam=pid
 ! https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -281,7 +280,6 @@ $removeparam=adfrom
 $removeparam=nx_source
 $removeparam=_zucks_suid
 $removeparam=cmpid
-$removeparam=asgtbndr
 $removeparam=guccounter
 $removeparam=guce_referrer
 $removeparam=guce_referrer_sig


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

`$removeparam=asgtbndr` and `$removeparam=af_force_deeplink` both appear twice.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [X] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

N/A

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
