### PR TITLE
Solve 171116 - Blocking PX makes Arcteryx unusable

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -155,7 +155,6 @@
 ||tgtag.io^$third-party
 ||track.gaconnector.com^
 ||trafico.prensaiberica.es^
-||collector-*.px-cloud.net^
 ||ediemidnightzombies.com^
 ||deqik.com^
 ||meowlytics.bignutty.xyz^
@@ -538,7 +537,6 @@
 ||lndata.com^$third-party
 ||quietyellowday.com^$third-party
 ||client.botchk.net^
-||b.px-cdn.net^
 ||wurfl.io^$third-party
 ||t.trsbf.com^
 ||t.powerreviews.com^$third-party
@@ -937,8 +935,6 @@
 ||usesfathom.com^$third-party
 ||fathomdns.com^$third-party
 ||tracking.atreemo.com^
-||collector-*.pxchk.net^$third-party
-||collector-*.px-cdn.net^$third-party
 ||thrtle.com^$third-party
 ||imhd.io^$third-party
 ||atom-log.3.cn^$third-party


### PR DESCRIPTION
Remove PX, resolving 171116

# Creating the pull request


## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ x] This is not an ad/bug report;
- [ x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [ x] I have performed a self-review of my own changes;
- [ x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Removed PX from tracking servers list.  Blocking PX makes the captcha unsolvable on sites that use those domains. In this case, arcteryx.com

### Enter the issue address

Example: https://github.com/AdguardTeam/AdguardFilters/issues/171116

### Add your comment and screenshots

(screenshots in issue)

1. Your comment

(details in original issue) -- Captcha is unsolvable unless adguard is disabled

2. Screenshots

(screenshots in issue)


### Terms

- [x ] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
