### PR TITLE
Remove youtrack.jetbrains.com aria-live="polite" rule

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -2004,7 +2004,7 @@ turcolegal.com#$#body { overflow: auto !important; }
 shopify.engineering,shopify.com##section[data-section-name="cookie-active-consent-notice"]
 flexiti.com#?##__next > div.min-h-screen > div.fixed:has(> div.flex > button#rcc-confirm-button)
 poehalisnami.ua##.jsAgreeWithCookie
-civey.com,youtrack.jetbrains.com##div[aria-live="polite"]
+civey.com##div[aria-live="polite"]
 silbonshop.com#$##consent-tracking { display: none !important; }
 silbonshop.com#$#.modal-backdrop { display: none !important; }
 silbonshop.com#$#body.modal-open { overflow: auto !important; }


### PR DESCRIPTION
# Creating the pull request

This filter is too strict https://github.com/AdguardTeam/AdguardFilters/commit/fe82a5ea7aa74ceb4835364444d2cc2b85f880fc It hides important messages without which the functionality of the site is seen by the user as broken.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/171419

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

N/A.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
