### PR TITLE
Husky v9

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,11 @@
+// See: https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+
+// Do not initialize Husky in CI environments. GitHub Actions set the CI env variable automatically.
+// See: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if (process.env.CI === 'true') {
+    process.exit(0);
+}
+
+// Initialize Husky programmatically.
+const husky = (await import('husky')).default;
+console.log(husky());

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,3 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# TODO: Remove first 2 lines: https://github.com/AdguardTeam/AdguardFilters/pull/171886#issuecomment-1918731193
+
 # See https://git-scm.com/docs/githooks#_post_merge
 
 # This function checks if a file has changed between the current HEAD and the previous HEAD

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # See https://git-scm.com/docs/githooks#_post_merge
 
 # This function checks if a file has changed between the current HEAD and the previous HEAD

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # See https://git-scm.com/docs/githooks#_pre_commit
 
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# TODO: Remove first 2 lines: https://github.com/AdguardTeam/AdguardFilters/pull/171886#issuecomment-1918731193
+
 # See https://git-scm.com/docs/githooks#_pre_commit
 
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "devDependencies": {
         "@adguard/aglint": "^2.0.8",
         "husky": "^9.0.7",
-        "lint-staged": "^15.2.0"
+        "lint-staged": "^15.2.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "homepage": "https://github.com/AdguardTeam/AdguardFilters#readme",
     "scripts": {
         "lint": "aglint",
-        "prepare": "husky install"
+        "prepare": "node .husky/install.mjs"
     },
     "lint-staged": {
         "*.txt": "aglint"
     },
     "devDependencies": {
         "@adguard/aglint": "^2.0.8",
-        "husky": "^8.0.3",
+        "husky": "^9.0.7",
         "lint-staged": "^15.2.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,10 +386,10 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+husky@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.7.tgz#047f24ec1b6c681206af714b4217c13ee97fff20"
+  integrity sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==
 
 ignore@^5.2.4:
   version "5.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,26 +484,26 @@ lilconfig@3.0.0:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.0.0.tgz#f8067feb033b5b74dab4602a5f5029420be749bc"
   integrity sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==
 
-lint-staged@^15.2.0:
-  version "15.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.2.0.tgz#3111534ca58096a3c8f70b044b6e7fe21b36f859"
-  integrity sha512-TFZzUEV00f+2YLaVPWBWGAMq7So6yQx+GG8YRMDeOEIf95Zn5RyiLMsEiX4KTNl9vq/w+NqRJkLA1kPIo15ufQ==
+lint-staged@^15.2.1:
+  version "15.2.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.2.1.tgz#25beb6e587f54245b20163f5efede073f12c4d1b"
+  integrity sha512-dhwAPnM85VdshybV9FWI/9ghTvMLoQLEXgVMx+ua2DN7mdfzd/tRfoU2yhMcBac0RHkofoxdnnJUokr8s4zKmQ==
   dependencies:
     chalk "5.3.0"
     commander "11.1.0"
     debug "4.3.4"
     execa "8.0.1"
     lilconfig "3.0.0"
-    listr2 "8.0.0"
+    listr2 "8.0.1"
     micromatch "4.0.5"
     pidtree "0.6.0"
     string-argv "0.3.2"
     yaml "2.3.4"
 
-listr2@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.0.0.tgz#aa7c230995f8ce378585f7c96c0c6d1cefa4700d"
-  integrity sha512-u8cusxAcyqAiQ2RhYvV7kRKNLgUvtObIbhOX2NCXqvp1UU32xIg5CT22ykS2TPKJXZWJwtK3IKLiqAGlGNE+Zg==
+listr2@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.0.1.tgz#4d3f50ae6cec3c62bdf0e94f5c2c9edebd4b9c34"
+  integrity sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==
   dependencies:
     cli-truncate "^4.0.0"
     colorette "^2.0.20"


### PR DESCRIPTION
Update Husky to v9.

See migration guide: https://github.com/typicode/husky/releases/tag/v9.0.1