### PR TITLE
fix #171947 developers.google.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1214,7 +1214,7 @@ nakedoptics.net,tartanblanketco.com#$?##gdpr-blocking-page-overlay { display: no
 nakedoptics.net,tartanblanketco.com#$##gdpr-blocking-page-overlay { display: none !important; position: absolute !important; left: -3000px !important; z-index: 0 !important; }
 phonegigant.nl##.cookie-fade
 gov.wales###wg_cookie
-landing.google.*,edu.google.com,ai.google,android.com##.glue-cookie-notification-bar
+developers.google.com,cloud.google.com,landing.google.*,edu.google.com,ai.google,android.com##.glue-cookie-notification-bar
 redd.it##reddit-cookie-banner
 imkergut.de##.page-wrap--cookie-permission-background
 trucksbook.eu#$#.modal-backdrop { display: none !important; }
@@ -9700,7 +9700,7 @@ tweakboxapp.com##cookiless-div
 travelchannel.co.uk#$##cppd { display: none!important; }
 datanyze.com#$#.overlay-gdpr { display:none!important; }
 datanyze.com#$#body { overflow:visible!important; }
-opensource.google,cloud.google.com,firebase.google.com,fuchsia.dev,developers.google.com,source.android.com,developer.chrome.com##devsite-snackbar[type="cookie-notification"]
+opensource.google,firebase.google.com,fuchsia.dev,source.android.com,developer.chrome.com##devsite-snackbar[type="cookie-notification"]
 hotnews.ro##div#avert
 opengapps.org##div.mdl-snackbar[aria-live]
 plume.com##div[class^="GDPR-module_GDPR_"]
@@ -9996,7 +9996,7 @@ discountreactor.com,promkod.ru##.cookies-mass
 xmind.app,linex.ru,xmind.net,moiglaza.ru##.cookies-prompt
 easyhits4u.com,reji.me##.cookies-warn
 raspberry-pi-geek.de,areamobile.de,buffed.de,gamesaktuell.de,gamezone.de,linux-community.de,linux-magazin.de,pcgames.de,pcgameshardware.de,videogameszone.de##.dataPrivacyOverlay
-android.com,cloud.google.com,developers.google.com##.devsite-notification-eu-cookie
+android.com##.devsite-notification-eu-cookie
 toomac.me,designmodo.com##.dialog[data-dialog-id="dm-accept-cookies"]
 makeagency.ru,bridgeland.com,community.hero-wars.com,fuckbook.com,froneri.pl,swapspace.co,animesdigital.net,musikersuche.musicstore.de,haeger-versicherungen.de,dielinke-nrw.de,dielinke-dortmund.de,linke-darmstadt.de,wmk-hvb.de,trud.com,pzonline.com,linksfraktion-nord.de,sinfonia.is,snipboard.io,countwordsfree.com,tudogostoso.com.br,die-linke.de,net.hr##.disclaimer
 vesselfinder.com##.downfooter .column
@@ -10195,7 +10195,7 @@ gmanetwork.com##.ckn-container
 podpisnie.ru,vn1.ru,leroymerlin.ro,surprize.lidl.ro,moia.io##.container-cookie
 arriva.cz,kingdomcomerpg.com##.container__cookiesPolicy
 welt.de,player.pl,tvn24.pl##.cookie-notice
-firebase.google.com,radiotimes.com,tichyseinblick.de##.cookie-notification
+radiotimes.com,tichyseinblick.de##.cookie-notification
 startefacts.com,kinoafisha.info,err.ee##.cookieOverlay
 bitfeed.co##.cookiebanner
 tes.com##.cookielaw-panel


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

fix https://github.com/AdguardTeam/AdguardFilters/issues/171947

### Add your comment

- Added  `##.glue-cookie-notification-bar` for both `developers.google.com` and `cloud.google.com`
- Removed `##.devsite-notification-eu-cookie` because it looks like an obsolete rule
- Removed `##devsite-snackbar[type="cookie-notification"]` because it looks like an obsolete rule, even though still present for `developers.google.com` :

<details>
<img width="475" alt="f" src="https://github.com/AdguardTeam/AdguardFilters/assets/1375223/97a13455-e61b-45bc-b10c-4500e7ac281a">
</details>

- Removed `##.cookie-notification` for `firebase.google.com` because it looks like an obsolete rule, its cookies popup is already hidden by the rule `firebase.google.com##devsite-snackbar[type="cookie-notification"]`

Please check.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
