### PR TITLE
upd #170936

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -180,6 +180,11 @@ youtubekids.com,youtube-nocookie.com,youtube.com#%#//scriptlet('set-constant', '
 /youtubei/v*/player?key=$replace=/\"playerAds.*?\}\}\]\,//,domain=youtubekids.com|youtube-nocookie.com|youtube.com
 !#endif
 !#if (!adguard_app_windows && !adguard_app_mac && !adguard_app_android && !adguard_ext_firefox)
+! https://github.com/AdguardTeam/AdguardFilters/pull/170936
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167440
 ! The rule trusted-replace-xhr-response with '\"adPlacements.*?([A-Z]"\}|"\}{2})\}\]\,' causes breakage on tv.youtube.com
 ! The problem is that rules with '~' do not work correctly in Safari, the same might be for exceptions,

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -181,10 +181,10 @@ youtubekids.com,youtube-nocookie.com,youtube.com#%#//scriptlet('set-constant', '
 !#endif
 !#if (!adguard_app_windows && !adguard_app_mac && !adguard_app_android && !adguard_ext_firefox)
 ! https://github.com/AdguardTeam/AdguardFilters/pull/170936
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', '/playlist\?list=|player\?key=|watch\?v=/')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', '/playlist\?list=|player\?key=|watch\?v=/')
+www.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
+www.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
+www.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', '/playlist\?list=|player\?key=|watch\?v=/')
+www.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', '/playlist\?list=|player\?key=|watch\?v=/')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167440
 ! The rule trusted-replace-xhr-response with '\"adPlacements.*?([A-Z]"\}|"\}{2})\}\]\,' causes breakage on tv.youtube.com
 ! The problem is that rules with '~' do not work correctly in Safari, the same might be for exceptions,

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -183,8 +183,8 @@ youtubekids.com,youtube-nocookie.com,youtube.com#%#//scriptlet('set-constant', '
 ! https://github.com/AdguardTeam/AdguardFilters/pull/170936
 youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
 youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', '/playlist\?list=|player\?key=|watch\?v=/')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', '/playlist\?list=|player\?key=|watch\?v=/')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167440
 ! The rule trusted-replace-xhr-response with '\"adPlacements.*?([A-Z]"\}|"\}{2})\}\]\,' causes breakage on tv.youtube.com
 ! The problem is that rules with '~' do not work correctly in Safari, the same might be for exceptions,

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -181,10 +181,10 @@ youtubekids.com,youtube-nocookie.com,youtube.com#%#//scriptlet('set-constant', '
 !#endif
 !#if (!adguard_app_windows && !adguard_app_mac && !adguard_app_android && !adguard_ext_firefox)
 ! https://github.com/AdguardTeam/AdguardFilters/pull/170936
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
-youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-fetch-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '', 'player?key=')
+youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com#%#//scriptlet('trusted-replace-xhr-response', '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2', 'player?key=')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167440
 ! The rule trusted-replace-xhr-response with '\"adPlacements.*?([A-Z]"\}|"\}{2})\}\]\,' causes breakage on tv.youtube.com
 ! The problem is that rules with '~' do not work correctly in Safari, the same might be for exceptions,


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/pull/170936

### Add your comment and screenshots

1. Your comment

Let's expand the coverage. IDK if the `www.` issue on iOS was fixed, if it is, the rule can be changed to `www.`. I didn't add
```
youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-node-text', 'script', 'ytInitialPlayerResponse', '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', '')
youtube.com,~accounts.youtube.com,~m.youtube.com,~payments.youtube.com,~tv.youtube.com,~youtubekids.com,~youtube-nocookie.com#%#//scriptlet('trusted-replace-node-text', 'script', 'ytInitialPlayerResponse', '("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/', '$1$2')
```
as they never worked, meaning user may see the warning after the first load. `set-constant` alternatives OTOH cause error for some reason.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
