### PR TITLE
Cleanup duplicate rules in ChineseFilter

### DIFF
--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -282,7 +282,7 @@ liantu.cn##.side > .h250
 liantu.cn##.wrapper > .inner.h90
 world68.com##.content_l_flml.zzs
 world68.com##.head_m
-world68.com##.ad
+1905.com,news.ltn.com.tw,commonhealth.com.tw,health.tvbs.com.tw,idreamx.com,xchina.co,99kubo.tv,manhuafen.com,world68.com##.ad
 world68.com##.guanggao
 world68.com##.zzs_ad
 onebox.mydown.com##.fcGg
@@ -1535,7 +1535,6 @@ onemanhua.com##div[id^="rn_ad_native"]
 ||hboav.com/guga/*.php$domain=5278.cc
 forum.hkgolden.com##div[id^="Super Banner"]
 sokoc2.com##.rHHc
-1905.com,news.ltn.com.tw,commonhealth.com.tw,health.tvbs.com.tw,idreamx.com,xchina.co,99kubo.tv,manhuafen.com##.ad
 pianku.me###playad
 javdove.com##.dn_fix_bottom
 javdove.com##.recommend-link

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -352,7 +352,7 @@ today.line.me##div[id^="ad-module-"]
 gameapps.hk##.adClick
 gameapps.hk##a[class^="top-ad-"]
 gameapps.hk##.pc-header-video > a[class^="top-ad-"] + .youtube-container
-war.163.com##.hotset
+ent.163.com,war.163.com##.hotset
 money.163.com##.ad1200
 xueqiu.com##div[class$="__ad"]
 qiniu.com##.extra___2cdPz > div.pc___3nUEX.extraBlock___1mGPY
@@ -378,7 +378,6 @@ wd.znds.com##.dxb_bc
 iplaysoft.com###_cblzx
 iplaysoft.com###section_postbanner
 iplaysoft.com##div[style="background:#fcf0ef;width:680px;height:130px;border-radius:8px;margin-top:28px;position:relative"]
-ent.163.com##.hotset
 chinaz.com##.media-banner__auto
 chinaz.com##.media-banner_auto
 laogu.cc##.rowIvy

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -75,7 +75,6 @@ douyin.com#?##douyin-right-container > div[class] > div[class]:has(> ul[class] >
 4gamers.com.tw#?#.aroma-news-detail-side > div[media-width]:has(div.aols-wrapper > a[target="_blank"][rel="noopener"])
 ||adsv.svc.litv.tv/ads?ad_unit=$xmlhttprequest,redirect=noopvast-3.0,important,domain=ani.gamer.com.tw
 ||pubads.g.doubleclick.net/gampad/ads?*&description_url=https%3A%2F%2Fani.gamer.com.tw$xmlhttprequest,redirect=noopvast-3.0,important
-gonglue.us###custom_html-6
 hgamefree.info###text-7
 /bookhaitang\.com\/assets\/.+\.js(?<!\.min\.js|pageTran\.js)/$domain=bookhaitang.com
 qdmm.com###page-ops
@@ -689,7 +688,7 @@ cardu.com.tw##.diamond-txt-ad
 cardu.com.tw###crazy_layer
 cardu.com.tw##img[src*="/ad_images/"]
 kocpc.com.tw##.Zi_ad_ar_O_3
-kocpc.com.tw###custom_html-6
+gonglue.us,kocpc.com.tw###custom_html-6
 unwire.hk###post-sidebar-ad
 bbs.colg.cn##.hdc > a[onclick][target="_blank"]
 south-plus.net##a[onclick*="'ad'"]

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -414,7 +414,7 @@ cupfox.app##.banner > div.banner-content.right
 right.com.cn###hd > div.wp > div.hdc > h2
 ||right.com.cn/forum/static/image/common/logo
 helloyishi.com.tw##.article-desktop-ad-wrapper
-dy.xdf.cn##.ad2
+dy.xdf.cn,haoweichi.com##.ad2
 ||api.nivodz.com/commercial/incr/
 nivod5.tv,nivod4.tv##a.focus_title_inner[href*=".ad_click"]
 newmobilelife.com###ATS_sticky
@@ -1339,7 +1339,6 @@ ddrk.me##a[onclick^="ClickobayST();"]
 kairos.news#?#.theiaStickySidebar > div.widget:has(> div.textwidget a[href^="https://kairos.shopping/product/"])
 hmoe.one#?#.widget_text > .inn-sidebar__widget:has(> .poi-panel__header > .poi-panel__header__title:contains(赞助商))
 ||ustv123.com/images/axd.js
-haoweichi.com##.ad2
 m.tvsou.com##.story_ad_android
 m.tvsou.com##.sogou-temp-hidden
 bbs.liyuans.com##div[class="panel panel-infot"] > a[href^="https://www."] > img[height="100%"][width="100%"]


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/174441

 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.
Some rules were left unmerged. Please advise whether these rules should be merged as well.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
