### PR TITLE
Cleanup duplicate rule in DutchFilter

### DIFF
--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -20,7 +20,6 @@ alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
-androidworld.nl##.r89-desktop-billboard-atf
 cinenews.be,handbal.nl,webmastersunited.com,wegdamnieuws.nl##.ads
 ans-online.nl#?#.theiaStickySidebar > aside.penci_latest_news_widget > h4.widget-title:contains(Advertentie)
 antilliaansdagblad.com,dolcevia.com,h2owaternetwerk.nl,lokaleomroepzeewolde.nl,radiolelystad.nl##.bannergroup
@@ -31,7 +30,7 @@ autosport.nl##.advertentie_links
 autosport.nl##.bigbanner
 autowereld.nl###banner-lister-top
 autowereld.nl###mainbanner
-mannenzaken.nl##.r89-desktop-billboard-atf
+androidworld.nl,mannenzaken.nl##.r89-desktop-billboard-atf
 mannenzaken.nl##.r89-desktop-leaderboard-btf
 mannenzaken.nl##.r89-desktop-hpa-atf
 fr12.nl##.sda


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

Fix https://github.com/AdguardTeam/AdguardFilters/issues/174445

 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rule.
Some rules were left unmerged. Please advise whether these rules should be merged as well.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
