### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (push notifications) 

### DIFF
--- a/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
@@ -61,7 +61,6 @@ infranken.de##.cleverpush-widget
 am730.com.hk##.noti-accept-box
 gobearcats.com#?#body > div:not([class]):has(> div[class^="ss-"] > button > i.sf-bell)
 ||kontur.ru/front/*/build/js/notification-alert.js
-vesti.kz##.push-form-container
 vkusnoitochka.ru##.confirm-push-notifications
 t-online.de#?#div[role="presentation"]:has(> div[class] > section[data-testid="PushNotification.ModalView"])
 ||static.antaranews.com/js/notification.min.js
@@ -314,7 +313,7 @@ masrawy.com##.lstNwsNtfy
 ||storage.googleapis.com/dito/sdk.js$domain=newbalance.com.br
 tvi.iol.pt,cnnportugal.iol.pt,tviplayer.iol.pt##.bell
 tvi.iol.pt,cnnportugal.iol.pt,tviplayer.iol.pt###popover
-tengrinews.kz##.push-form-container
+tengrinews.kz,vesti.kz##.push-form-container
 protranslate.net###pushModal
 protranslate.net###pushModal ~ .modal-backdrop
 ||ziare.com/firebase-messaging-init.js

--- a/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
@@ -106,7 +106,6 @@ rtde.life##.notification-bell
 vesti.ua##.show-prompt
 ||vesti.ua/sp-push-worker-fb.js
 corrieredellosport.it##div[class^="Header_containerToast"]
-forum.redfox.bz##.notice--enablePush
 ||cdn.iterwebcms.com/_proxy_https_/mas.protecmedia.com/mas-push-min.js
 ||bws0wvqt3k.ru^
 ||sendsay.ru/js/push/push.js
@@ -431,7 +430,7 @@ takiedela.ru##.b-push-notification
 justnutritive.com##.order-notification
 ||api-analytics.rozetka.com.ua/js/exponea.min.js
 ||7themes.su/sw.js
-macrumors.com,platinmods.com##.notice--enablePush
+forum.redfox.bz,macrumors.com,platinmods.com##.notice--enablePush
 wvnews.com,mdjonline.com,wfmz.com,tv6tnt.com##.notification-button
 ||tr.link/push/push.js
 ||s.aimg.sk/sport_symfony/build/sport-push-notification.$domain=aktuality.sk

--- a/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/push-notifications_specific.txt
@@ -44,7 +44,7 @@ gizbot.com##.instant-updates-bottom
 ||dc-static.wondershare.cc/wgp_notification/js/wsNotification-$script
 thedailystar.net###bellIcon
 ||alerts.thedailystar.net/js/alerts.js
-minsknews.by###perfecty-push-dialog-container
+banglatech24.com,minsknews.by###perfecty-push-dialog-container
 minsknews.by##.perfecty-push-settings-container
 sacbee.com##.ab-in-app-message
 youla.ru##article[role="alert"]
@@ -264,7 +264,6 @@ tvn24.pl##iframe.__ipPerunElement
 trashbox.ru###div_bottom_subscribe_placeholder
 ||push.1plus1.ua/js/app.js
 caracoltv.com,shock.co##.PushSubscription-content
-banglatech24.com###perfecty-push-dialog-container
 nevnov.ru##.pushSubscribe
 ||maximizly.*/sources/webpush/production/js/maximizly-push.js
 ||cosplay-porn.me/swps.js


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/175023
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
