### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (MobileApp) part 1

### DIFF
--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -234,7 +234,6 @@ spanishdict.com#?#body > div#root > div:not([class]):has(> div[class][style*="ba
 lefigaro.fr#?#.fig-crosslinking:has(> .fig-crosslinking__list > .fig-crosslinking__item > a[href^="https://app.adjust.com/"])
 musescore.com#?#main[class] > section[class]:has(> div[class] > img[src^="/static/public/img/musescore/app_image/"])
 blogmura.com##.popup-app
-www-crictracker-com.cdn.ampproject.org###downloadApp
 ||liputan6.com/pages/widget-gateway-mobile-app
 liputan6.com##.gateway__mobile-app
 mail.google.com###nav > #speedbump
@@ -705,7 +704,7 @@ map.baidu.com###fis_elm__6
 map.baidu.com###fis_elm__12
 map.baidu.com#?#body > div[id]:has(> div#downloadnativepopupUlink)
 map.baidu.com#?##page-wrapper > div#common-bottombanner-widget-fis:has(> div.common-widget-bottom-banner-changeId > div.bottom-banner-float)
-m.economictimes.com###downloadApp
+m.economictimes.com,www-crictracker-com.cdn.ampproject.org###downloadApp
 m.economictimes.com###float_app_ET
 yay.space##.AppDownloadAds
 goo-net.com#$#.appBingWeb { display: none !important; }

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -151,7 +151,6 @@ bnnbreaking.com##.post__mobile-placement
 yimenapp.com##.widget_image_ad
 glavcom.ua##.banner_amp
 blove.jp##.app-store-link
-radio.de###app
 crmeb.com##body > div#side
 crmeb.com##.floatWindow
 973kkrc.com,mooseradio.com##.newsletter-overlay
@@ -1964,7 +1963,7 @@ cw.com.tw,www-livemint-com.cdn.ampproject.org,livemint.com##.openinApp
 besplatka.ua##.social-net
 m.xbiqugela.com,xs26.com##.show-app2
 radio.pl##a[title^="Pobierz aplikacju"]
-auctions.yahoo.co.jp,myvidster.com,radio.fr,radio.pl###app
+auctions.yahoo.co.jp,myvidster.com,radio.de,radio.fr,radio.pl###app
 wasd.tv##wasd-notification-app
 wasd.tv##wasd-mobile-app
 programiz.com##.get-app-link

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -361,7 +361,7 @@ mitem.lenovo.com.cn###open-app
 mitem.lenovo.com.cn###bottomOpenAppBtn
 robota.ua##alliance-shared-app-promo-banner
 ||shogidojo.net/images/app24_banner.png
-megamarket.ru##.mobile-app-widget
+megamarket.ru,sbermegamarket.ru##.mobile-app-widget
 hromadske.radio#?#.inner-content p:has(> strong > a[href*="bit.ly"][target="_blank"])
 mhrs.gov.tr###native-app
 concord.ua#?#div[class^="icon25-widget"][class$="wrapper"] li:not(:has(> a[href="https://my.neobank.one"]))
@@ -1489,7 +1489,6 @@ nikkei.com##a[data-rn-track="open_in_app"]
 booklive.jp##.app_btn_area
 nova.rs##.banner-footer
 meduza.io##body[class^="amp-"] div[class^="style__BannerTop-"]
-sbermegamarket.ru##.mobile-app-widget
 banzhu123.com##.s_m
 suumo.jp##.appIntroduction
 suumo.jp##.appbnr

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -3137,7 +3137,6 @@ search.yahoo.co.jp#?#div[class^="ContentWrapper_wrapper_"]:has(> article[class^=
 search.yahoo.co.jp##article[class^="W2ALink_"]
 baynews9.com##img[alt="Live News On The Go! Download the Spectrum News App"]
 rnd.de##div[class^="Articlestyled__"] div[data-testid="piano-container"]
-live.erinn.biz###win_appinstallhint
 kinarino.jp###js-appeal-top-banner
 radio.de###headerTopBar + style + div[class^="sc-"]
 hibiny.ru##.box-app
@@ -3170,7 +3169,7 @@ timesofindia-indiatimes-com.cdn.ampproject.org##a[data-vars-track-clicklabel="ap
 kufar.by##div[class^="styles_app_banner__"]
 unacademy.com##.top-sticky-head
 ||nbcnews.app.link/branch-amp-journeys?
-kukulu.erinn.biz###win_appinstallhint
+kukulu.erinn.biz,live.erinn.biz###win_appinstallhint
 m.nivod8.tv,m.nivod7.tv,m.nivod5.tv,m.nivod4.tv##.bottom-bar
 m.youtube.com##ytm-watch-metadata-app-promo-renderer
 jameda.de##div[data-banner-translations]

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -536,7 +536,6 @@ comick.app#?##__next > div:not([class]):has(> div.border-b > button.btn-primary)
 helsi.me##div[class*="AppLinkBtn_"]
 youku.com###app .callEnd_box
 yummly.com##.top_banner
-apkmody.fun###body-fixed-footer
 clearnotebooks.com#?#.grid-notes_container > div.base-component:has(> div.base-component > div.how-to-use)
 candidates.jobandtalent.com##.DownloadAppWidget
 outstanding.kr##.open_in_app
@@ -736,7 +735,7 @@ lingvanex.com##.seo-install-inner
 lingvanex.com##.modal-app-overlay
 manga-park.com##.right.pc-only
 thuisbezorgd.nl,takeaway.com,just-eat.ch,lieferando.at,lieferando.de,just-eat.fr,pyszne.pl,just-eat.dk,just-eat.no##div[data-selector-id="app-banner"]
-apkmody.io###body-fixed-footer
+apkmody.fun,apkmody.io###body-fixed-footer
 ||snoway.jp/img/v*/ad/snoway_300x80
 hesaplama.net##aside > div > a[href^="https://play.google.com/store/apps/"]
 haber.sol.org.tr#?#.tex2jax_process > div[aria-label="div widget"]:has(> div.ckewidget-container > div.ckewidget-editor-border a[href="https://t.me/solhaber"])


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/175520
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
