### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (MobileApp) part 2

### DIFF
--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -237,7 +237,7 @@ musescore.com#?#main[class] > section[class]:has(> div[class] > img[src^="/stati
 blogmura.com##.popup-app
 www-crictracker-com.cdn.ampproject.org###downloadApp
 ||liputan6.com/pages/widget-gateway-mobile-app
-liputan6.com##.gateway__mobile-app
+m.liputan6.com,liputan6.com##.gateway__mobile-app
 mail.google.com###nav > #speedbump
 sfes.rakuten-bank.co.jp#$#body[style^="padding-top:"] { padding-top: 0px !important; }
 sfes.rakuten-bank.co.jp#$##area_download-app { display: none !important; }
@@ -1481,7 +1481,6 @@ tanoshiiosake.jp##a[id^="appBanner"]
 tanoshiiosake.jp#%#//scriptlet('remove-class', 'app-appBannerOpen', 'body')
 jreast-timetable.jp,jreast.co.jp###jre_header_appLink
 chess.com##.ready-to-play-banner-component
-m.liputan6.com##.gateway__mobile-app
 keirin.netkeiba.com##.appeal_bnr_wrap
 sp.netkeiba.com##.HeadBnrWrap
 sp.netkeiba.com##.netkeiba_app_link01

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -3143,7 +3143,7 @@ radio.de###headerTopBar + style + div[class^="sc-"]
 hibiny.ru##.box-app
 minne.com##.smartAppBanner
 minne.com##aside[class^="MinneAppBanner_root_"]
-forum.donanimhaber.com##.open-with-app
+forum.donanimhaber.com,mobile.donanimhaber.com##.open-with-app
 tieba.baidu.com##.tb-forum-user__join-btn
 wear.jp#?#span[style="box-sizing:border-box;display:block;overflow:hidden;width:initial;height:initial;background:none;opacity:1;border:0;margin:0;padding:0;position:relative"]:has(> img[src^="/public/_next/static/media/want_banner."])
 wear.jp#?#.xl\:hidden > div.bg-gray-200.py-2:contains(アプリなら)
@@ -3342,7 +3342,6 @@ v.ifeng.com##div[class^="twoImg-"] p[class^="mark-"]
 v.ifeng.com##div[class^="toolbar-"] > div[class^="partMore-"]
 tour.ne.jp##.cmn-app-bnr-header
 dailymotion.com##div[class^="WebToNativeBanner__"]
-mobile.donanimhaber.com##.open-with-app
 coniugazione.it##img[width="300"][height="250"]
 spb.napopravku.ru,hltv.org,w.linovelib.com##.footer-app
 manga-park.com##.underSlider

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -252,7 +252,7 @@ locipo.jp##div[class^="app_bannar_"]
 nicomanga.com#?#.card-dark:has(> div.card-body > center > a[href="https://kutt.it/lovehugapk"])
 nar.sp.netkeiba.com#?#.Wrap > div[style].HeadBnrWrap:has(a[href^="https://netkeiba.onelink.me/"])
 linkedin.com##.cta-modal.windows-app-upsell
-zetfix-online.net##.fpage > div.ftitle + noindex
+hdi.zetfix.online,zetfix-online.net##.fpage > div.ftitle + noindex
 giga.de##a[href^="https://apps.apple.com/de/app/giga/"]
 nianticlabs.com##.supplementary-webstore-mhn-app
 nianticlabs.com##.supplementary-webstore-pgo-app
@@ -1133,7 +1133,6 @@ getmoneytree.com##.pp_text_externallink_article + div.div-block-35
 mts.by##.main-slider__item[style*="/content/app"]
 news.nifty.com##.widget_official_full_app
 vk.sportsbull.jp##.banner-area
-hdi.zetfix.online##.fpage > div.ftitle + noindex
 livelaw.in###header_ad_mobile
 sports.smt.docomo.ne.jp#$##app_ad_bnr { display: none!important; }
 sports.smt.docomo.ne.jp#$##wrapper_low[style^="top:"] { top: 0 !important; }

--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -60,7 +60,7 @@ clubd.co.jp##.dc-footer-banner
 nairametrics.com##.code-block.code-block-2
 tokybook.com##.banner-formtoky
 paircare.jp##nav[role="navigation"] button.bg-green-800
-japantravel.navitime.com##.app-modal
+japantravel.navitime.com,uniqlo.com.hk##.app-modal
 japantravel.navitime.com##.p__aside__app
 japantravel.navitime.com##.l-footer-app-list
 www.op.gg##html[lang="ko"] .tooltip__talkg_ad:has(> .react-tooltip-lite a[href*="talk.op.gg/app-download"])
@@ -616,7 +616,6 @@ navitime.co.jp##.app_dl_banner_frame
 ganma.jp#%#//scriptlet('set-cookie', 'isAppClosed', '1')
 trello.com#?##chrome-container > div[class]:has(> div[class]> a[href^="https://apps.apple.com/"])
 welovemanga.one#?#div[class^="col-"] > div.card:has(> div.card-header > h3.card-title:contains(Application))
-uniqlo.com.hk##.app-modal
 prcm.jp##.footer-introduction
 realtime.yahoo.co.jp##div[id^="apppr"]
 izi.travel##.app_message


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/175520
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
