### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Widgets) part 1

### DIFF
--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -789,7 +789,8 @@ tsubamesoku.blog.jp#?#article > h1.article-option-title:contains(/^おススメ�
 ||news.2chblog.jp/headline1.htm
 ||news.2chblog.jp/headline2.htm
 giants-news.com##.top_rss_up_title
-ge-soku.com###custom_html-35
+mildch.com,amaebi.co,umamusume-umapyoi.com,incident-wo.com##.blogroll-wrapper
+ge-soku.com,incident-wo.com###custom_html-35
 ge-soku.com###custom_html-48
 ge-soku.com###custom_html-54
 ge-soku.com###custom_html-91
@@ -934,8 +935,6 @@ kidan-m.com,otakumix.doorblog.jp###rss1
 otakumix.doorblog.jp##iframe[src="http://otakumix.doorblog.jp/testrss.html"]
 openworldnews.net###headline
 huyosoku.com,kaigai-matome.net##.blogrolls
-mildch.com,amaebi.co,umamusume-umapyoi.com,incident-wo.com##.blogroll-wrapper
-incident-wo.com###custom_html-35
 pokemon-matome.net###header_rssbox
 pokemon-matome.net##div[class^="rssinline"]
 pokemon-matome.net##div[class^="rss_inner"]

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -332,7 +332,6 @@ sukattojapan.com##.section-rss1
 sukattojapan.com#?#.related-wrapper > div.rss-single:upward(1)
 sukattojapan.com#?#.plugin-memo > div.side > div.blogroll-saido:upward(2)
 ||vtubernews.jp/*link.js
-revuestarlightre.com###custom_html-4
 hiragana46matome.com,toriizaka46.jp##.sec-rss
 hiragana46matome.com,toriizaka46.jp##.sec-rss-article
 pazdra2ch.blog.jp##div[id^="rss-box"]
@@ -927,7 +926,7 @@ bottisoku.blog.2nt.com##.plugin3_body
 bottisoku.blog.2nt.com##div[style^="width:1200px;height:280px"]
 .sprss002.html$domain=moeero-library.com|eromanga-moeerolibrar.com
 ||eromanga-cafe.com^$subdocument,~third-party
-eromanga-cafe.com###custom_html-4
+eromanga-cafe.com,revuestarlightre.com###custom_html-4
 nandemoiiyoch.com,eromanga-cafe.com###custom_html-7
 eromanga-cafe.com##.loop-single-widget
 ero-doujinshiworld.com,bl-doujinsouko.com,bl-boyslove.com,eromanga-musou.com,erocomic-hunter.net,eromanga-moeerolibrar.com,eromanga-life.com,ero-mangacafe.com,dojin-pandemic.com,dojinwatch.com,eromanga-castle.com,doujincafe.com,ero-manga-platinum.net,ero-mangasokuhou.com,ero-comic-hunter.net,eromanga-cafe.com,eromanga-sevendays.net,moeero-library.com##.boxi800

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -551,7 +551,8 @@ pokemon-goh.doorblog.jp###more > div.t_h > b
 pokemon-goh.doorblog.jp##.rss_mid_parts
 ||usi32.com/inc/rss$subdocument,~third-party
 usi32.com##.rss-outer_bottom
-usi32.com##.top_rss_wrap
+usi32.com,world-fusigi.net##.top_rss_wrap
+world-fusigi.net##div[class^="articles_under_rss_"]
 oumaga-times.com##.popular-list
 oumaga-times.com##.popular-list-header
 burusoku-vip.com##.headline-body
@@ -875,8 +876,6 @@ mindhack2ch.com##.rss-article
 sonicch.com,drdinl.com###rss-box
 sonicch.com###tangan_box2
 newmofu.doorblog.jp###widget-blogroll
-world-fusigi.net##div[class^="articles_under_rss_"]
-world-fusigi.net##.top_rss_wrap
 moeclo.ldblog.jp##iframe
 moeclo.ldblog.jp##div[id^="RSS"]
 moeclo.ldblog.jp###TOPArea

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -386,7 +386,6 @@ dng65.com###center_outline > div[class^="mheadline"]
 dng65.com##.hdl_atb2_outer
 elog-ch.com##.l-wrapper.invisible_sp > main.l-main-wide
 jiwachan.net##.foot_rss
-moeasia.net###middlerss
 asianoneta.blog.jp##.headline_outline
 asianoneta.blog.jp#?#.ently_text > span:has(> span > span > b:contains(☆おすすめ記事☆))
 crx7601.com##.section2
@@ -679,7 +678,7 @@ bantyou.livedoor.biz##iframe[src="http://bantyou.livedoor.biz/frss.html"]
 wara2ch.com##iframe[src$="warakan_rsslink.html"]
 ||inutomo11.com/nanj$subdocument
 inutomo11.com##iframe[src^="http://inutomo11.com/nanj"]
-syurabahazard.com###middlerss
+moeasia.net,syurabahazard.com###middlerss
 syurabahazard.com##.middlersstitle
 ||syurabahazard.com/js/bottomlink.js
 ||syurabahazard.com/js/middlelink.js


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/175702
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
