### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Widgets) part 2

### DIFF
--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -328,7 +328,8 @@ aatyu.livedoor.blog##.article-body > div.logbox4
 kitizawa.com##.article-body-more > div[style="border:1px solid #F90;padding:10px;border-radius:10px;background:#f9f9d4;"]
 ||matomeantena.com^$domain=japohan.net|aaieba.livedoor.biz
 ||nullpoantenna.com^$domain=japohan.net|aaieba.livedoor.biz
-sukattojapan.com##.section-rss1
+kijomatomelog.com##.rss-single
+kijomatomelog.com,sukattojapan.com##.section-rss1
 sukattojapan.com#?#.related-wrapper > div.rss-single:upward(1)
 sukattojapan.com#?#.plugin-memo > div.side > div.blogroll-saido:upward(2)
 ||vtubernews.jp/*link.js
@@ -820,8 +821,6 @@ celery-marine.net,otoko-honne.com,ske48matoeme.com,kijolifehack.com##div[id^="rs
 kijomatomelog.com#?#.sub_right > .sidewrapper:has(> .sidetitlebody > .sidetitle:contains(人気記事))
 manpukunews.blog.jp##div[align="center"] > table[width="700"]
 manpukunews.blog.jp##table[rules="None"]
-kijomatomelog.com##.rss-single
-kijomatomelog.com##.section-rss1
 ||kurumachannel.com/*-Rss.html
 kurumachannel.com##iframe[src*="-Rss.html"]
 kurumachannel.com##.article-body-inner > .bottom-link

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -226,7 +226,7 @@ crx7601.com#?#.article-body-inner .twitter-tweet ~ b:has(+ .ninja-recommend-bloc
 yokohama-sports.com##.antenna-midashi
 yokohama-sports.com##.text-rss-list
 hmangamatome.net##.rssbox_midashi
-hmangamatome.net###toprss
+hmangamatome.net,sexytvcap.com,erodoujinjohoukan.com###toprss
 /wp-content/plugins/chaty/*$domain=canadaglobalinfo.com
 ||vippers.jp/2ch-c_iframe_
 gameinn.jp##.wp-rss-template-container
@@ -440,7 +440,6 @@ kijomatomelog.com##div[style="margin-bottom:30px;"] > b > span[style="font-size:
 ||baiku-sokuho.info/top-rss.html
 carp-matome.blog.jp##.bw_outbox
 anihatsu.com##.rss-blogroll-kobetu
-sexytvcap.com,erodoujinjohoukan.com###toprss
 news30over.com##div[class^="topbox"]
 erodaizensyu.com##p > a[href] > iframe[src^="//blog-rss.com"]
 ||mudainodocument.com/headline9.html

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -536,7 +536,6 @@ mojokosan.doorblog.jp,animalch.net##.osusume
 crx7601.com##.box14
 matometanews.com###container > div[style^="width:1218px;"]
 mindhack2ch.com##.article__footer > p.section-title
-scienceplus2ch.com###rss-roll-01
 vsnp.net###link_area
 vsnp.net###link_etc2
 negisoku.com###main > div.column-inner > div.column-inner-2 > div[style^="overflow: auto;"]
@@ -780,7 +779,7 @@ mona-news.com##div[id^="rss_"]
 gamestlike.com,vtubersokuhou.com##.maintop-widget
 vtubersokuhou.com###block-11
 vtubersokuhou.com###block-15
-revuestarlightre.com###rss-roll-01
+revuestarlightre.com,scienceplus2ch.com###rss-roll-01
 revuestarlightre.com##div[class^="kiji-sita-rss"]
 revuestarlightre.com#?#article > div > .article-sub-category > h3:contains(Vtuberピックアップ)
 ||tsubamesoku.blog.jp/new.html

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -420,8 +420,6 @@ pachinkolist.com##div[style^="height:130px;overflow:auto;"]
 pachinkas.net##.border_bold
 oppainorakuen.com###more > a[target="_blank"]
 digital-thread.com##.article-headline
-sonicch.com##div[style="overflow:auto;height:550px;"]
-sonicch.com##.rss
 ||blog.livedoor.jp/kokopyon1/rss/$subdocument
 f1jouhou2.com##.rankings
 ||fc2.com/i/2/c/i2chmeijin/i2chmeijintoprss11.html
@@ -651,7 +649,8 @@ sundaymatome2channel.blog.fc2.com###header-rss-wrap
 2chblog.jp##.kiji-ue-rss
 2chmatome.net,elephant.2chblog.jp,vippers.jp###topRss
 kitizawa.com###headerRSS
-kijomatomelog.com,okkisokuho.com,no-one-no.net,ertk.net,uwakitaiken.com,blog.esuteru.com,kidan-m.com,onihimechan.com,kijonotakuhaibin.com,okusama-kijyo.com,otakomu.jp,exawarosu.net,mindhack2ch.com,duellinks.doorblog.jp,dragonquestwalk.blog.jp,netamesi.com,sk2ch.net,kijyomita.com,tanu-soku.com,akb48matomemory.com##.rss
+sonicch.com##div[style="overflow:auto;height:550px;"]
+sonicch.com,kijomatomelog.com,okkisokuho.com,no-one-no.net,ertk.net,uwakitaiken.com,blog.esuteru.com,kidan-m.com,onihimechan.com,kijonotakuhaibin.com,okusama-kijyo.com,otakomu.jp,exawarosu.net,mindhack2ch.com,duellinks.doorblog.jp,dragonquestwalk.blog.jp,netamesi.com,sk2ch.net,kijyomita.com,tanu-soku.com,akb48matomemory.com##.rss
 akb48matomemory.com##.rss2
 ||blogmaterial.nicoblomaga.jp/material/279/js/rss/alfa_article_bottom2.js
 ||blogmaterial.nicoblomaga.jp/material/279/js/rss/alfa_article_bottom4.js

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -855,7 +855,7 @@ daretoku-eromanga.info#?#.widget-title:contains(おすすめ新着リスト)
 daretoku-eromanga.info##.sidewinder
 daretoku-eromanga.info##.sidewinder-2
 brow2ing.com###newRelease
-f1jouhou2.com,ryusoku.com,fgo.news,kanasoku.info,brow2ing.com,animanch.com,news4vip.livedoor.biz,hosyusokuhou.jp###headline
+openworldnews.net,lifehack2ch.livedoor.biz,football-2ch.com,f1jouhou2.com,ryusoku.com,fgo.news,kanasoku.info,brow2ing.com,animanch.com,news4vip.livedoor.biz,hosyusokuhou.jp###headline
 katuru2ch.blog12.fc2.com##.saishin
 katuru2ch.blog12.fc2.com##.sougo_rss_div
 katuru2ch.blog12.fc2.com##div[id^="more"] > p > b > a[href^="http://katuru.com/rss/"]
@@ -933,7 +933,6 @@ eromanga-cafe.com##.loop-single-widget
 ero-doujinshiworld.com,bl-doujinsouko.com,bl-boyslove.com,eromanga-musou.com,erocomic-hunter.net,eromanga-moeerolibrar.com,eromanga-life.com,ero-mangacafe.com,dojin-pandemic.com,dojinwatch.com,eromanga-castle.com,doujincafe.com,ero-manga-platinum.net,ero-mangasokuhou.com,ero-comic-hunter.net,eromanga-cafe.com,eromanga-sevendays.net,moeero-library.com##.boxi800
 kidan-m.com,otakumix.doorblog.jp###rss1
 otakumix.doorblog.jp##iframe[src="http://otakumix.doorblog.jp/testrss.html"]
-openworldnews.net###headline
 huyosoku.com,kaigai-matome.net##.blogrolls
 mildch.com,amaebi.co,umamusume-umapyoi.com,incident-wo.com##.blogroll-wrapper
 incident-wo.com###custom_html-35
@@ -1048,7 +1047,6 @@ hosyusokuhou.jp###top
 blog.domesoccer.jp##.article-header-rss
 blog.domesoccer.jp#?#.main-post-list > div.blogrss:upward(1)
 minigob-matome.blog.jp,honsoku.com,samuraisoccer.doorblog.jp##.bt-rss
-lifehack2ch.livedoor.biz,football-2ch.com###headline
 tarosoku.com##div[class^="kijishita_rss"]
 psneolog.com##.rss_wrap
 psneolog.com##.rss_box-sp


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/175702
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
