### PR TITLE
Cleanup duplicate rules in CyrillicFilters (common-sections/adservers.txt)

### DIFF
--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -825,7 +825,6 @@
 ||windowmentaria.com^$third-party
 ||armi.media^$third-party
 ||pornogoogle.info^$third-party
-||zzznews.ru^$third-party
 ||7wwchtqe.ru^$third-party
 ||advmusic.net^$third-party
 ||metrika.traff.space^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -611,7 +611,6 @@
 ||iulftx.com^$third-party
 ||eqmx04n5s0.ru^$third-party
 ||qerusgreyt.com^$third-party
-||fast-hunter.com^$third-party
 ||bigbonga.com^$third-party
 ||fbcctf.com^$third-party
 ||kopterka.ru^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -2558,7 +2558,6 @@ http://w7.ru^$third-party
 ||wm-panel.com^$third-party
 ||wmcasher.ru^$third-party
 ||wmclickz.ru^$third-party
-||wmip.ru^$third-party
 ||wmirk.ru^$third-party
 ||wmkredit.ru/widget/$third-party
 ||wmlink.ru^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -1926,7 +1926,6 @@ http://w7.ru^$third-party
 ||octobird.com^$third-party
 ||octoclick.net^$third-party
 ||office.ad1.ru^$third-party
-||ogeri.ru^$third-party
 ||ognyvo.ru^$third-party
 ||oiya.ru^
 ||ojooo.com^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -651,7 +651,6 @@
 ||dzubavstal.com^$third-party
 ||passtechusa.com^$third-party
 ||vastroll.ru^$third-party
-||qlnomb.com^$third-party
 ||socgate.ru^$third-party
 ||mstngh.com^$third-party
 ||tr6rfgjix6tlr8bp.info^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -980,7 +980,6 @@ http://w7.ru^$third-party
 ||ad2.rambler.ru^
 ||ad3.rambler.ru^
 ||ad4sell.com^$third-party
-||adbean.ru^$third-party
 ||adbid.pl^$third-party
 ||adbmi.com^$third-party
 ||adbn.ru^

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -593,7 +593,6 @@
 ||kataprius.com^$third-party
 ||yxswtummev.info^$third-party
 ||quaruzon.com^$third-party
-||kataprius.com^$third-party
 ||sereendipit.com^$third-party
 ||sdmot.ru^$third-party
 ||qfhzki.com^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -465,7 +465,6 @@
 ||randiul.com^$third-party
 ||alli-ti-hunter.com^$third-party
 ||ogtz5yn2u1.ru^$third-party
-||ogtz5yn2u1.ru^$third-party
 ||69qa.club^$third-party
 ||fast-hunter.com^$third-party
 ||kkmacsqsbf.info^$third-party

--- a/CyrillicFilters/common-sections/adservers.txt
+++ b/CyrillicFilters/common-sections/adservers.txt
@@ -801,7 +801,6 @@
 ||fe4r7k22y68p.info^$third-party
 ||zfsfkp.com^$third-party
 ||ogeri.ru^$third-party
-||newrrb.bid^$third-party
 ||activepr.info^$third-party
 ||gqedxf.com^$third-party
 ||v1-c73e.kxcdn.com^$third-party


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/176283
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
