### PR TITLE
Cleanup duplicate rules in SpywareFilter

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -211,7 +211,6 @@ inapps.appsflyersdk.com^
 ||event-collector.moviesanywhere.com^
 ||us-east-1.paa-reporting-advertising.amazon^
 ||analytics.nianticlabs.com^
-||sg.log.ulivetv.net^
 ||tracker.ulivetv.net^
 ||trackernew.ulivetv.net^
 ||gamestats.easybrain.com^

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -2126,7 +2126,6 @@
 ||track.tproger.ru^
 ||track.ugamezone.com^
 ||track.ultimate-guitar.com^
-||track.wattpad.com^
 ||track.websiteceo.com^
 ||track.wildblue.com^
 ||track.zalando.

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -1301,7 +1301,6 @@
 ||gscounters.gigya.com^
 ||gtm.beiersdorf.com^
 ||gtm.udemy.com^
-||gtm.vanmoof.com^
 ||gtmdev.jabra.
 ||guq9.vente-unique.it^
 ||harvester.hbpl.co.uk^

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -456,7 +456,6 @@
 ||sgtm.fashionunited.
 ||mercury.coupang.com^
 ||client-telemetry.roblox.com^
-||ecsv2.roblox.com^
 ||tracing.roblox.com^
 ||treatment.grammarly.com^
 ||rac.ruutu.fi^


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 https://github.com/AdguardTeam/AdguardFilters/issues/176343
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
