### PR TITLE
Fix #176383 lite.liiingo.com detects an adblocker

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2900,7 +2900,7 @@ zumvo.so##.top-message
 ||jps.evolok.net/acd/$xmlhttprequest,domain=wakefieldexpress.co.uk
 ||kriminalukraine.com.ua/sites/default/files/please.jpg
 ||lifebel.com/wp-content/uploads/*^*.js?ver=
-||lite.liiingo.com#%#//scriptlet('prevent-setTimeout', 'ad_blocker_detector_modal')
+lite.liiingo.com#%#//scriptlet('prevent-setTimeout', 'ad_blocker_detector_modal')
 ||lugasat.org.ua/media/js/abDetector.min.js
 ||massivemark.com^$third-party
 ||media.news.com.au/cs/nca/latest/public/js/p/*/promo-display^

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2900,7 +2900,6 @@ zumvo.so##.top-message
 ||jps.evolok.net/acd/$xmlhttprequest,domain=wakefieldexpress.co.uk
 ||kriminalukraine.com.ua/sites/default/files/please.jpg
 ||lifebel.com/wp-content/uploads/*^*.js?ver=
-lite.liiingo.com#%#//scriptlet('prevent-setTimeout', 'ad_blocker_detector_modal')
 ||lugasat.org.ua/media/js/abDetector.min.js
 ||massivemark.com^$third-party
 ||media.news.com.au/cs/nca/latest/public/js/p/*/promo-display^
@@ -3105,6 +3104,7 @@ animenewsnetwork.com#@##Adbanner
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=strategium.ru
 @@||yandex.ru/ads/system/context.js$xmlhttprequest,domain=sdamgia.ru
 timeanddate.com#@##ad-wrap2
+lite.liiingo.com#%#//scriptlet('prevent-setTimeout', 'ad_blocker_detector_modal')
 fastfoodmenupreise.de#@#.banner_ads
 fastfoodmenupreise.de#@#.banner-ads
 fastfoodmenupreise.de#@#.ad-zone
@@ -3756,6 +3756,8 @@ guided.news#@#.ad-250
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=t3n.de
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||a.realsrv.com/ad-provider.js$domain=buondua.com
+!+ PLATFORM(ios, ext_android_cb)
+@@||lite.liiingo.com^$generichide
 !+ NOT_OPTIMIZED
 @@||d1q4kshf6f0axi.cloudfront.net/js/_ads/adtech.js$domain=spanishdict.com
 !+ NOT_OPTIMIZED

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2900,6 +2900,7 @@ zumvo.so##.top-message
 ||jps.evolok.net/acd/$xmlhttprequest,domain=wakefieldexpress.co.uk
 ||kriminalukraine.com.ua/sites/default/files/please.jpg
 ||lifebel.com/wp-content/uploads/*^*.js?ver=
+||lite.liiingo.com#%#//scriptlet('prevent-setTimeout', 'ad_blocker_detector_modal')
 ||lugasat.org.ua/media/js/abDetector.min.js
 ||massivemark.com^$third-party
 ||media.news.com.au/cs/nca/latest/public/js/p/*/promo-display^


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/176383

# Creating the pull request

Fixed #176383 by preventing a timeout
https://github.com/AdguardTeam/AdguardFilters/issues/176383#issuecomment-2040012679
This Method is best because it does not interfere with Bootstrap Modals and stops the anti-adblock component before it can show up


### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

<details>

![68747470733a2f2f63646e2e616467756172642e696e666f2f736974657265706f7274732f6667776f6d77793539673863677773636b386367776f3863676b3867776738367379386a7632677973382e706e673f6e633d31](https://github.com/AdguardTeam/AdguardFilters/assets/73603712/53c73c07-5b1b-4663-91b8-b75172e380bd)
</details>

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.



- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
