### PR TITLE
Fix  #176394 - convertio.co ads

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -339,6 +339,7 @@ $xmlhttprequest,third-party,denyallow=linkvertise.com|fastly.net|statically.io|s
 !
 ! NOTE: Specific rules
 !
+convertio.co##.softobar-container
 vidsrc.*#%#//scriptlet('prevent-window-open')
 hogwarts.cafe#$#body[class*="adthrive-"]:not(.home) .site-footer-wrap { margin-bottom: 0 !important; }
 retromania.gg##.banner > *


### PR DESCRIPTION

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/176394



 


Removed the ads as stated in the issue #176394 using 
```css
convertio.co##.softobar-container
``` 
Those are ads because they lead to an external site.  




<details>

<summary>Screenshot 1:</summary>

Problem

![image](https://github.com/AdguardTeam/AdguardFilters/assets/73603712/e8ea183d-2afe-40eb-a811-d643aa248da7)


</details>

<details>

<summary>Screenshot 2:</summary>

Fixed

![image](https://github.com/AdguardTeam/AdguardFilters/assets/73603712/2dd4961e-ec31-4aaf-b2db-158a6c031551)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
