### PR TITLE
fix #176460 www.sciencedirect.com

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -439,7 +439,7 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157532 [Stealth Mode - User-agent]
 @@||sciencedirect.com^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/176460 [Stealth Mode - User-agent]
-@@||sciencedirectassets.com^$stealth,domain=sciencedirect.com
+@@||sciencedirectassets.com^$stealth=useragent,domain=sciencedirect.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157167
 @@||vip.sp-flv.com^*/?url=age_$subdocument,stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157370 [Stealth Mode - Referrer]

--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -438,6 +438,8 @@
 @@||static.hentai.direct^$stealth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157532 [Stealth Mode - User-agent]
 @@||sciencedirect.com^$stealth
+! https://github.com/AdguardTeam/AdguardFilters/issues/176460 [Stealth Mode - User-agent]
+@@||sciencedirectassets.com^$stealth,domain=sciencedirect.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157167
 @@||vip.sp-flv.com^*/?url=age_$subdocument,stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/157370 [Stealth Mode - Referrer]


### PR DESCRIPTION
#176710
Apparently, there is a request to Blob Storage, Token+Signed URL returns, then there is a redirect at https://www.sciencedirect.com/science/article/pii/s2376060523001621?ref=PDF_DOWNLOAD&FR-9&
 RR=*signed_url*, that redirects to pdf.sciencedirectassets.com to download PDF, and when we break there with another UA, something from the Token+Signed url pair is apparently not valid.
 
 basically, that means that we **must** disable stealth mode for such requests if it is disabled on sciencedirect.com by default