### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 2-1

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3514,8 +3514,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||p*.drtst.com/templates/drtuber/js/advertisement.js
 @@||pagead2.googlesyndication.com/favicon.ico$domain=maxedtech.com|primetechieforum.com
 @@||pagead2.googlesyndication.com/page/js/adsbygoogle.js?_=$domain=thehouseofportable.com
-@@||pagead2.googlesyndication.com/pagead/js/*/show_ads_impl.js$domain=epicbundle.com
-@@||pagead2.googlesyndication.com/pagead/js/*/show_ads_impl.js$domain=malekal.com
+@@||pagead2.googlesyndication.com/pagead/js/*/show_ads_impl.js$domain=epicbundle.com|malekal.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=3dnews.ru
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=battlestick2.net
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=bdcraft.net

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3135,7 +3135,6 @@ ghxi.com#@#.wpcom_ad_wrap
 @@||demonoid.is/awe2.js
 @@||powvibeo.me/js/dfp-pop.js
 @@||andrialive.it/*/app/assets/js/prebid-ads.js
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=shellshock.io
 @@||js.wpadmngr.com/static/adManager.js$domain=luscious.net
 @@||winiso.pl/sailthru.js
 101.ru#@#.advert-1
@@ -3426,8 +3425,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||htlbid.com/*/motherjones.com/htlbid.js$domain=motherjones.com
 @@||im.haberturk.com/assets/js/adblock.js
 @@||imagebam.com/JS/site_ads.js
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=anidub.com
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=gamereactor.de|gamereactor.dk|gamereactor.fr|gamereactor.es
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=gamereactor.de|gamereactor.dk|gamereactor.fr|gamereactor.es|shellshock.io|anidub.com
 @@||imgbox.com/site_ads.js
 @@||imgonline.com.ua/*advert*.js
 @@||imleagues.com/spa/ads/show_ads.js

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3613,8 +3613,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||static.adziff.com/ab/ads.js
 @@||static.ak.crunchyroll.com/versioned_assets/js/components/ads_enabled.ac6fa3aa.js
 @@||static.baik.ru/static/js/apps-js/adv/google_advert.*.js$domain=irk.ru
-@@||static.criteo.net/images/pixel.gif$domain=diariodenavarra.es
-@@||static.criteo.net/images/pixel.gif$domain=gmx.net
+@@||static.criteo.net/images/pixel.gif$domain=diariodenavarra.es|gmx.net
 @@||static.criteo.net/js/px.js^$domain=lequipe.fr
 @@||static.diep.io/*.js$~third-party
 @@||static.doubleclick.net/instream/ad_status.js$domain=malaysiastock.biz

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3100,7 +3100,6 @@ golf-live.at#@#.ad_unit
 animenewsnetwork.com#@##Adbanner
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=mysb555.com
 @@||imasdk.googleapis.com^$xmlhttprequest,domain=cc-fan.tv|cn-fan.tv|fox-fan.tv|nf-fan.tv
-@@||static.doubleclick.net/instream/ad_status.js$domain=dailyvoice.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=strategium.ru
 @@||yandex.ru/ads/system/context.js$xmlhttprequest,domain=sdamgia.ru
 timeanddate.com#@##ad-wrap2
@@ -3612,7 +3611,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||static.criteo.net/images/pixel.gif$domain=diariodenavarra.es|gmx.net
 @@||static.criteo.net/js/px.js^$domain=lequipe.fr
 @@||static.diep.io/*.js$~third-party
-@@||static.doubleclick.net/instream/ad_status.js$domain=malaysiastock.biz
+@@||static.doubleclick.net/instream/ad_status.js$domain=dailyvoice.com|malaysiastock.biz
 @@||static.fore.4pcdn.de/premium/ads/delivery/ajs.php?$domain=4players.de
 @@||static.game-state.com/js/adblock.js
 @@||static.icy-veins.com/javascript/*adsense

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3289,8 +3289,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||appsgames.ru/wp-content/cache/min/1/wp-content/plugins/angwp/assets/dev/js/advertising-
 @@||appsgames.ru/wp-content/plugins/angwp/assets/dev/js/advertising.js
 @@||asset.pagefair.com/adimages/$domain=adn.com
-@@||asset.pagefair.com/adimages/textlink-ads.jpg$domain=eastbaytimes.com
-@@||asset.pagefair.com/adimages/textlink-ads.jpg$domain=ocregister.com
+@@||asset.pagefair.com/adimages/textlink-ads.jpg$domain=eastbaytimes.com|ocregister.com
 @@||assets.247sports.com/Scripts/SkyNet/Shared/ads.js
 @@||assets.portfolio.hu/js/ad_300x250.js
 @@||assets.purch.com/ramp/js/Advertisement/advertisement.js

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3295,8 +3295,7 @@ wvgazettemail.com,ceogelisim.com#@#.adSense
 @@||automeme.io/assets/html/ad1.html
 @@||automeme.io/assets/html/ad2.html
 @@||avforme.com/templates/default/js/advertising.js
-@@||b.adbox.lv/bxlib/js/loader.js$domain=inbox.lt
-@@||b.adbox.lv/bxlib/js/loader.js$domain=inbox.lv
+@@||b.adbox.lv/bxlib/js/loader.js$domain=inbox.lt|inbox.lv
 @@||battlestick2.net/ads.js
 @@||bazonline.ch/scripts/advertisement.js
 @@||bcrams.com/common/templates/dfp/


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 https://github.com/AdguardTeam/AdguardFilters/issues/176717 
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
