### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 2-2

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2637,7 +2637,6 @@ starsandstripesfc.com,polygon.com##div[class^="adblock-whitelist-messaging__"]
 starsandstripesfc.com,polygon.com#%#//scriptlet("set-constant", "ConcertAds", "true")
 starve.io###trevda
 steamid.io##.noads-inner
-stol.it###block-message
 strangermeetup.com#%#//scriptlet("set-constant", "window.adsEnabled", "true")
 streamonsport.to##.events img[alt="adblock"]
 studopedia.info,infopedia.su,studopedia.net,studopedia.su,studopedia.org,studopedia.ru,studopedia.com.ua,lektsii.org,mydocx.ru#%#//scriptlet("set-constant", "adsbygoogle.loaded", "true")
@@ -2649,7 +2648,7 @@ svgrepo.com##.showSidebar > div.side
 swatchseries.to##.centeres > #rotating-item-wrapper > .notify
 symbolab.com#$#.adsbygoogle { position: absolute!important; left: -3000px!important; }
 sythe.org#$#a[href^="https://www.sythe.org/redir.php?"] > img[src^="//img.sythe.org/$"] { display: block !important; }
-t-hsn.com###block-message
+stol.it,t-hsn.com###block-message
 t-hsn.com#$##kokoku-area { display: block !important; min-height: 30px !important; margin: 10px 0 10px !important; opacity: 0 !important; }
 t-online.de#%#window.IM = [1,2,3];
 t3n.de##.ab-notice

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2448,7 +2448,6 @@ offcost.ru###alertBlock
 oglaszamy24.pl###abp_box
 oglaszamy24.pl#%#//scriptlet("abort-current-inline-script", "onload", "ad.offsetWidth")
 ogznet.com#%#//scriptlet("prevent-setTimeout", "appendMessage")
-okkazeo.com###ads
 old-games.ru###adb
 olegon.ru#%#AG_onLoad(function() { window.deta = function() {}; });
 olkino.com##.alert-block
@@ -2543,7 +2542,7 @@ queer.pl##.box-info-1234
 quermania.de###getyourguide2
 quest.nl##.message-quest
 r3owners.net#%#//scriptlet("set-constant", "XenForo.rellect.AdBlockDetector", "noopFunc")
-radarbox.com###ads
+okkazeo.com,radarbox.com###ads
 radarbox.com##.map-ad
 radio.de#%#AG_onLoad(function() { setTimeout(function() {parent.postMessage('AdBlockInactive', '*'); }, 300); });
 radiopotok.ru$$script[tag-content="ga('send', 'event', 'AdBlock',"][max-length="1650"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1821,12 +1821,11 @@ savevideo.me##div[id^="ads_notice_"]
 savevideo.me##td.max_bl_right > div[style*="background-color:"][style*="13px;"]
 usatoday.com#%#//scriptlet("set-constant", "ads.adBlockDetected", "false")
 autosport.com#$#.ms-hapb { position: absolute!important; left: -3000px!important; }
-moddroid.com###ad_block_reminder_dialog
 fulltime-predict.com#$#.modal { display: none !important; }
 fulltime-predict.com#$#.modal-backdrop { display: none !important; }
 fulltime-predict.com#$#body.modal-open { overflow: auto !important; }
 dubznetwork.com#$?##vidorev_post_extensions-2 > .widget-item-wrap:has(> div > p:contains(Please consider to turn off your adblock or whitelist)) { visibility: hidden !important; }
-jojoy.io###ad_block_reminder_dialog
+jojoy.io,moddroid.com###ad_block_reminder_dialog
 @@||ads.twitcasting.tv/js/env_test/ads.js
 timeanddate.com#%#//scriptlet('prevent-addEventListener', 'load', 'Dislike intrusive ads')
 fosslinux.com#%#//scriptlet('set-constant', 'penci_adlbock', 'undefined')

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2097,7 +2097,6 @@ cyberpedia.su###divtext > p[style="color:red;"]
 cyberpedia.su#%#//scriptlet('set-constant', 'adsbygoogle.loaded', 'true')
 dallasobserver.com#%#//scriptlet("set-constant", "VMG.Components.Adblock", "false")
 damngeeky.com##.google-trending
-dasoertliche.de###banner-right
 daz3d.ru#%#//scriptlet("prevent-setTimeout", "/function\(\)\{var.[a-z]\=[a-z]\.getElementById/", "3000")
 deco-cool.com##.wrapper > div[id][class][style*="z-index: 9999"]
 deco-cool.com##.wrapper > div[id][class][style*="z-index: 9999"] + div[class][style*="z-index: 9999"]
@@ -2124,7 +2123,6 @@ diymag.com##.block--ad-blocker-message
 dn.se###pwOverlay
 dniwolne.eu#%#//scriptlet("set-constant", "google_jobrunner", "noopFunc")
 docs.paloaltonetworks.com##.ad-block-notification
-docs.pyrogram.org###banner
 doodlr.io#%#//scriptlet("set-constant", "isAdBlockActive", "false")
 downflixs.com##.entry-content h3[style^="text-align:"]:not(:last-child)
 download3k.com###google_top
@@ -2749,7 +2747,7 @@ vaa.jp,yonelabo.com###nankafix
 vanar.io#$#div[id^="div-gpt-ad"].advertisement { display: block!important; }
 vc.ru##.layout__right-column > div[class*=" "][style="--offset-top:16px;"]
 vek-noviy.ru##body > div.leftbar-wrap > div[style="width: 300px; height: 250px;"]
-venea.net###banner
+dasoertliche.de,docs.pyrogram.org,venea.net###banner
 venea.net#%#//scriptlet("set-constant", "ab.isTrig", "false")
 venge.io/905193.json$replace=/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":true\,/"name":"Support"\,"tags":\["DesktopOnly"]\,"enabled":false\,/,domain=venge.io
 video.komarovskiy.net##.rmp-ad-block-container

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2139,7 +2139,6 @@ drakoric.com##.mh-header > p[style="text-align: center;"]
 drawnstories.ru###mdl_adb
 dressupmix.com###adblock_popup
 drnasserelbatal.com#%#//scriptlet("set-constant", "canRunAds", "true")
-drtuber.com###abmessage
 dumpert.nl#%#//scriptlet('prevent-setTimeout', 'AdBlockerCheck')
 dzone.com,amgreatness.com###adtoniq-msgr-bar
 ebookbb.com##.special-message-wrapper
@@ -2268,7 +2267,6 @@ html.de##.noticeContainer
 huawei.mobzon.ru###main-content > div.user3
 hw4.ru##noindex > center > div[style="width: 680px; height: 280px;"]
 hypebeast.com###ad-blocker-popups
-iceporn.com###abmessage
 icy-veins.com###premium_information
 icy-veins.com#%#//scriptlet('set-constant', 'icy_veins_blocked', 'false')
 imagebam.com##.box_wait#hideifpossible
@@ -2442,7 +2440,7 @@ nu.nl#%#//scriptlet("set-constant", "isAdBlockEnabled", "false")
 numberempire.com###toplink
 numberempire.com##.perm_ad
 nusantararom.org##.elementor-popup-modal
-nuvid.*###abmessage
+proporn.com,tubeon.com,yeptube.com,drtuber.com,iceporn.com,nuvid.*###abmessage
 nw10.ru###ipsLayout_header
 od-news.com###text-25
 od-news.com##body > div[id][class][style*="z-index: 9999"]
@@ -2525,7 +2523,6 @@ progarchives.com##div[id^="banner-"]
 pronetblog.by##.adsensepost
 propolski.com##body > div[id][class][style*="z-index: 9999"]
 propolski.com##body > div[id][class][style*="z-index: 9999"] + div[class][style*="z-index: 9999"]
-proporn.com###abmessage
 prosieben.de##a[href^="http://www.prosieben.de/service/warum-werbung"]
 prozoro.net.ua##.install-app
 ps4.in.ua##.adblockDetectedMessage
@@ -2720,7 +2717,6 @@ trustedreviews.com#%#window.blockAdBlock = function() {};
 tsn.ua##.c-aside--60x35
 tt1069.com#%#//scriptlet("abort-current-inline-script", "document.getElementById", "ad blocker")
 tube8.*###adBlockAlertWrap
-tubeon.com###abmessage
 tuchkatv.ru##.adb_m
 tulengua.es###Main_Content_divLabelAbuso
 tunefind.com##div[class^="BlockedAd__blockedAd"]
@@ -2801,7 +2797,6 @@ yellowbridge.com#$?##pgFooterM { remove: true; }
 yellowbridge.com#$?##pgHeaderM { remove: true; }
 yellowbridge.com#$?##pgSkyM { remove: true; }
 yenigolcuk.com,hedefgazetesi.com.tr,eldedemokrasi.com,afyonhaberturk.com,nehaberankara.com,mansetburdur.com,bolgesellig.com,telgrafgazetesi.com,burokratika.com,balikesirartihaber.com,ajansbalikligol.com,karar67.com,gazetemalatya.com,vansesigazetesi.com,kocaelisabah.com,antalyadanhaberler.com,aydinyeniufuk.com.tr,yerelvanhaber.com,a2teker.com,kibrishakikat.com,izmirtime35.com,sancakplus.com,marasfisilti.com,burdurgazetesi.com,zeytinburnuhaber.org,denizli20haber.com,akdenizdeyeniyuzyil.net,ulakci.com,egegundem.com.tr,isdunyasindakadin.com,haberimizvar.net#%#//scriptlet('abort-on-property-read', 'isAdBlockActive')
-yeptube.com###abmessage
 ynet.co.il,infobae.com,abcnyheter.no,sme.sk,yourdictionary.com,foxnews.com#%#//scriptlet("prevent-addEventListener", "/load|error/", ".head.removeChild(")
 yorumbudur.com#%#//scriptlet("set-constant", "ads", "true")
 you-porn.com,youporngay.com###adblock_tooltip


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 https://github.com/AdguardTeam/AdguardFilters/issues/176717 
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
