### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 2-3

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2136,7 +2136,7 @@ dragcave.net#%#(function(){var b=window.setTimeout;window.setTimeout=function(a,
 dragcave.net#%#//scriptlet("prevent-setTimeout", "google_ads_frame")
 dragcave.net#?##middle > div[class]:has(> ins.adsbygoogle)
 drakoric.com##.mh-header > p[style="text-align: center;"]
-drawnstories.ru###mdl_adb
+drawnstories.ru,info-kibersant.ru,kinda.media,tiver.ru###mdl_adb
 dressupmix.com###adblock_popup
 drnasserelbatal.com#%#//scriptlet("set-constant", "canRunAds", "true")
 drtuber.com###abmessage
@@ -2280,7 +2280,6 @@ imtranslator.net#%#//scriptlet("prevent-setTimeout", "test.offsetHeight")
 inbox.lv#%#//scriptlet("set-constant", "inxBX.failed", "false")
 independent.co.uk##.adblock-modal
 indiatimes.com#$#body .adBanner { display: block!important; }
-info-kibersant.ru###mdl_adb
 init.engineer##.alert-dismissible
 inoreader.com#%#//scriptlet("set-constant", "cr", "0")
 inoreader.com#%#//scriptlet("set-constant", "gn", "true")
@@ -2312,7 +2311,6 @@ keezmovies.com##.attentionMsg
 kemono.party##.jumbo-link
 keybr.com#%#//scriptlet("prevent-setTimeout", "()=>", "5000")
 kimcartoon.*##.adbWarnContainer
-kinda.media###mdl_adb
 kontrolkalemi.com###XGT-AdBlock-etkin
 kontrolnaya-rabota.ru###toast-container
 korsars.pro##div[style="width: 468px; height: 60px;"]
@@ -2709,7 +2707,6 @@ timvision.it#$#.pub_300x250.pub_300x250m.adBanner { display: block !important; }
 titlovi.com##.header > header + [id*="-"]:not([class]) > a[href*="adblock"]
 titulky.com#%#//scriptlet("set-constant", "foolish_script_is_here", "noopFunc")
 titulky.com#%#//scriptlet("set-constant", "showBanner600", "true")
-tiver.ru###mdl_adb
 tiz-cycling.live###msg-sticky-wrapper
 tool.liumingye.cn###pop-container
 topbestalternatives.com#%#//scriptlet("abort-current-inline-script", "EventTarget.prototype.addEventListener", "window.getComputedStyle")

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2060,7 +2060,6 @@ cams.xnxx.com##.dad-vlac-notice
 canyoublockit.com#$##wrapfabtest { height: 1px !important; }
 capfriendly.com##.g_flbrd_ad
 capfriendly.com##.g_lbrd_top_cont
-carbu.com#%#window.canRunAds = true;
 cartoonbrew.com#%#//scriptlet("abort-on-property-read", "ad_block_test")
 cbr.com###js-popup-blocker
 cda.pl#%#//scriptlet("set-constant", "adblockV1", "true")
@@ -2410,7 +2409,6 @@ multifilemirror.com##.jbanner
 multifilemirror.com##.noticeContainer
 multiup.org##.alert.alert-success
 multiup.io,multiup.org#$#.mfp-ready { display: none !important; }
-mydramalist.com#%#window.canRunAds = true;
 myshows.me##.likewiki
 mysmsbox.ru##div[ng-if="status.adBlockerActive"]
 nachrichten.at###iab_overlay
@@ -2469,7 +2467,7 @@ otempo.com.br##.adblock-info
 otomobilgunluklerim.com#$#.adblockalert { display: none !important; }
 otomobilgunluklerim.com#$#body.ad_block_detected { overflow: auto !important; }
 eater.com,outsports.com,polygon.com,vox.com##div[class^="adblock-allowlist-messaging"]
-pgfire.net,vaingloryfire.com,heroesfire.com,smitefire.com,dotafire.com,elophant.com,mobafire.com#%#window.canRunAds = true;
+carbu.com,mydramalist.com,pgfire.net,vaingloryfire.com,heroesfire.com,smitefire.com,dotafire.com,elophant.com,mobafire.com#%#window.canRunAds = true;
 oyungezer.com.tr###blocker
 parasportontario.ca#%#//scriptlet("abort-on-property-read", "closeBlockerModal")
 pastebin.com###abrpm

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2497,7 +2497,7 @@ pixiz.com#%#//scriptlet('abort-current-inline-script', 'document.getElementById'
 playonlinux.com##.login > div[style*="background-color:#666;"][style*="color:#FFF"]
 playshake.ru#%#fuckAdBlock = function() {};
 pleinevie.fr,science-et-vie.com###detection-block
-pleinevie.fr###detection-block-overlay
+pleinevie.fr,science-et-vie.com###detection-block-overlay
 pln-pskov.ru###check_ad_block
 png.is#$#ins.adsbygoogle[data-ad-slot] { height: 1px!important; }
 poeaffix.net###ADBAR
@@ -2599,7 +2599,6 @@ satelliteguys.us#%#//scriptlet("set-constant", "adBlockDetected", "false")
 savevideo.me#%#//scriptlet("prevent-setTimeout", "function() { if ((($('.y_banner #b0').length < 1", "2000")
 savevideo.me#%#//scriptlet('abort-current-inline-script', '$', 'Please disable "ad blocker"')
 schwaebische.de##.goodies
-science-et-vie.com###detection-block-overlay
 scrolller.com##.notification[style^="height: 189px;"]
 sd-company.su###dom_adblock
 seo-visit.com#%#//scriptlet("abort-on-property-read", "adsbygoogle")

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2496,7 +2496,7 @@ pikabu.ru##section[data-role="adb-warning"]
 pixiz.com#%#//scriptlet('abort-current-inline-script', 'document.getElementById', 'flex')
 playonlinux.com##.login > div[style*="background-color:#666;"][style*="color:#FFF"]
 playshake.ru#%#fuckAdBlock = function() {};
-pleinevie.fr###detection-block
+pleinevie.fr,science-et-vie.com###detection-block
 pleinevie.fr###detection-block-overlay
 pln-pskov.ru###check_ad_block
 png.is#$#ins.adsbygoogle[data-ad-slot] { height: 1px!important; }
@@ -2599,7 +2599,6 @@ satelliteguys.us#%#//scriptlet("set-constant", "adBlockDetected", "false")
 savevideo.me#%#//scriptlet("prevent-setTimeout", "function() { if ((($('.y_banner #b0').length < 1", "2000")
 savevideo.me#%#//scriptlet('abort-current-inline-script', '$', 'Please disable "ad blocker"')
 schwaebische.de##.goodies
-science-et-vie.com###detection-block
 science-et-vie.com###detection-block-overlay
 scrolller.com##.notification[style^="height: 189px;"]
 sd-company.su###dom_adblock

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2370,7 +2370,6 @@ maxedtech.com###ablock-top-fixed
 maxedtech.com###ablock-widget
 maxpark.com##body > div[id][style="display: block;"]:first-child
 mc-at.org#%#//scriptlet("prevent-setTimeout", "showads", "7000")
-medicalxpress.com#%#window.blockAdBlock = function() {};
 megagames.com#$##ad-banner { display: block!important; }
 megagames.com#%#//scriptlet("set-constant", "jQuery.adblock", "false")
 megogo.net##.specialBlock_v1
@@ -2486,7 +2485,6 @@ phillymag.com###blocker-text
 phonearena.com##.adblock_awareness
 phonescoop.com###topstripalert
 phoronix.com###content > script[type="text/javascript"] + strong
-phys.org#%#window.blockAdBlock = function() {};
 pic5you.ru###bb
 macapp.org.cn,picmix.com#%#//scriptlet("abort-on-property-read", "adBlockDetected")
 picmix.com#%#//scriptlet('abort-current-inline-script', 'document.getElementById', '.style.display')
@@ -2673,7 +2671,6 @@ techobest.com$$script[tag-content="adback_configuration"][min-length="100000"][m
 techonthenet.com##.adsblocked
 techsolutiontips.com#%#window.google_jobrunner = function() { };
 techtobo.com##.notices--block
-techxplore.com#%#window.blockAdBlock = function() {};
 telestar.fr##.dfp-slot-megaban
 telestar.fr##body > div[id^="detection-block"]
 temperatur.nu###infobar
@@ -2711,7 +2708,7 @@ tiz-cycling.live###msg-sticky-wrapper
 tool.liumingye.cn###pop-container
 topbestalternatives.com#%#//scriptlet("abort-current-inline-script", "EventTarget.prototype.addEventListener", "window.getComputedStyle")
 tracker.network##.trn-upsell-premium
-trustedreviews.com#%#window.blockAdBlock = function() {};
+medicalxpress.com,phys.org,techxplore.com,trustedreviews.com#%#window.blockAdBlock = function() {};
 tsn.ua##.c-aside--60x35
 tt1069.com#%#//scriptlet("abort-current-inline-script", "document.getElementById", "ad blocker")
 tube8.*###adBlockAlertWrap


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 https://github.com/AdguardTeam/AdguardFilters/issues/176717 
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
