### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 2-4

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1841,7 +1841,7 @@ filmix.ac#?##player pjsdiv[style^="position: absolute;"] > pjsdiv[style^="positi
 turk5series.com##div[style*="background-color"][style*="position: fixed;"][style*="z-index: 2147483650;"]
 designalive.pl###cover
 femmeactuelle.fr###bt-softwall
-steamcollector.com##.adblock-detected
+greenville.com,steamcollector.com##.adblock-detected
 steamcollector.com#%#//scriptlet('abort-current-inline-script', 'getComputedStyle', 'adsbygoogle')
 techymedies.com###SpiderBlogginAdblocker
 libgen.rocks###maintable > tbody > tr > td[valign="top"] + td > #message
@@ -2248,7 +2248,6 @@ good-football.org###player_block
 goodfon.ru##.js-adb
 gp.se##.adblock-checker
 gputracker.eu#%#//scriptlet("abort-current-inline-script", "$", "can_show_ads")
-greenville.com##.adblock-detected
 hard-tm.ru##.baseHtml.noticeContent
 hardware.info##.sitearea > div:not([class]):not([id])
 hdkino.biz#?#.full-news td[bgcolor] > center > p:last-child

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -3211,7 +3211,7 @@ pietsmiet.de#@#.googleads
 poelab.com#@##influads_block
 poelab.com#@##SponsoredLinks
 pr-cy.ru,pr-cy.io#@##adframe:not(frameset)
-preis24.de#@##bottomAd
+preis24.de,whatfontis.com#@##bottomAd
 psychic.de#@#.ad-new
 puhekupla.com#@#.googlead
 quizlet.com#@#.ad-placement
@@ -3228,7 +3228,6 @@ vice.com#@#.ad-placement
 washingtonpost.com#@#.AD_area
 washingtonpost.com#@#.ADBox
 wg-gesucht.de#@#a[href^="https://pubads.g.doubleclick.net/"]
-whatfontis.com#@##bottomAd
 wholicab.com#@##adContent
 wp.pl#@#.ad_container
 wp.pl#@#.pub_300x250

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2003,7 +2003,7 @@ anisearch.com###top_outside
 anison.fm##.rightb_in
 astar.bz,anistar.org,online-star.org,online-stars.org##.a-message
 anitokyo.tv##div[style="width: 240px; height: 400px;"]
-anitokyo.tv##div[style="width: 300px; height: 250px;"]
+anitokyo.tv,batzbatz.ru,скачатьофис.рф##div[style="width: 300px; height: 250px;"]
 antutu.pw###ai-adb-message
 antutu.pw###ai-adb-overlay
 applesfera.com##.ad-cen
@@ -2027,7 +2027,6 @@ babycenter.com###mediumRectangleAd1Container
 babycenter.com#%#//scriptlet('prevent-setTimeout', 'white-list us')
 balticlivecam.com###ad_block_off
 basicweb.ru#%#//scriptlet("set-constant", "popUpInfo", "noopFunc")
-batzbatz.ru##div[style="width: 300px; height: 250px;"]
 baumarkt-tracker.de###runa-notif
 beckershospitalreview.com#$#.olyticsblocker { display: none !important; }
 beckershospitalreview.com#$#body { overflow: auto !important; }
@@ -3009,7 +3008,6 @@ zumvo.so##.top-message
 ||yourdictionary.com/scripts/googleFundingChoices.js
 ||ytmp3.eu/*/pagead/js/adsbygoogle.js$script,xmlhttprequest,redirect=googlesyndication-adsbygoogle,important,domain=ytmp3.eu
 ||zeelandnet.nl/static/js/footer.*.js$replace=/(=new Request\(")https:\/\/pagead2\.googlesyndication\.com\/pagead\/js\/adsbygoogle\.js(")/\$1\$2/
-скачатьофис.рф##div[style="width: 300px; height: 250px;"]
 ||i2.esmas.com/wp/assets/js/adblock/kw-pqr.min.js
 socialblade.com##div[style="width: 340px; float: left;"] > div[style="width: 300px; height: 250px; padding: 20px; background: #fff; margin-bottom: 20px;"]
 socialblade.com##div[style="width: 860px; float: left; font-size: 8pt;"] > div[style^="width: 860px; height: 90px; padding: 20px; background: #fff; float: left;"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2507,7 +2507,6 @@ poedb.tw#$##wrapfabtest { height: 1px!important; }
 poedb.tw#%#//scriptlet("abort-on-property-read", "adBlockDetected")
 poedb.tw#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 pogdesign.co.uk###data > .replace
-politonline.ru##div[data-type="anti-abp"]
 poncy.ru###hide-adblock
 pornorips.com#?#h1 > span:contains(AddBlocker)
 portableapps.com###block-block-39
@@ -2583,7 +2582,7 @@ rufilmtv.org##.attention
 rufilmtv.org##.attentions
 rulu.co##cf-div
 rutab.net#%#//scriptlet("abort-current-inline-script", "$", "ad")
-rutvet.ru##div[data-type="anti-abp"]
+politonline.ru,rutvet.ru##div[data-type="anti-abp"]
 s0urce.io###window-msg2
 s0urce.io#$##messageTester { height: 1px!important; }
 s0urce.io#?#.login-window > .login-element:has(>#messageTester)


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
 https://github.com/AdguardTeam/AdguardFilters/issues/176717 
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
