### PR TITLE
Cleanup duplicate rules on some filters part 2-1

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -125,7 +125,6 @@
 ||patakaendymal.top^$all
 ||noopapnoeic.digital^$all
 ||showoffmanifer.guru^$all
-||noopapnoeic.digital^$all
 ||meniscigox.digital^$all
 ||vlkxsrhi.com^
 ||lxvluwda.com^

--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -125,7 +125,6 @@
 ||patakaendymal.top^$all
 ||noopapnoeic.digital^$all
 ||showoffmanifer.guru^$all
-||meniscigox.digital^$all
 ||vlkxsrhi.com^
 ||lxvluwda.com^
 ||afeerdah.net^

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -24,7 +24,6 @@ afkortingen.nu###banner_right
 afkortingen.nu###banner_top
 agconnect.nl##div[class$="_ad-slot"]
 alblasserdamsnieuws.nl##.albla-adlabel
-alblasserdamsnieuws.nl##.albla-adlabel
 alblasserdamsnieuws.nl##div[id^="albla-"]
 alle-tests.nl,bloovi.be###advertising
 cinenews.be,handbal.nl,webmastersunited.com,wegdamnieuws.nl##.ads

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -166,7 +166,6 @@ autoweek.nl##.page-banner
 marktplaats.nl###banner-aanbieding
 marktplaats.nl###banner-bottom
 marktplaats.nl###banner-viptop
-afkortingen.nu###banner_right
 afkortingen.nu###banner_top
 iphoned.nl###featured-header
 tvgids.nl###ligatus_under_content

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -166,7 +166,6 @@ autoweek.nl##.page-banner
 marktplaats.nl###banner-aanbieding
 marktplaats.nl###banner-bottom
 marktplaats.nl###banner-viptop
-afkortingen.nu###banner_top
 iphoned.nl###featured-header
 tvgids.nl###ligatus_under_content
 afkortingen.nu###link_unit


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/176728
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
