### PR TITLE
Cleanup duplicate rules on some filters part 2-2

### DIFF
--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -1760,8 +1760,6 @@ blick.ch##a[href^="https://jackpot.onelink.me"]
 magdeburger-news.de##.element-container > a[href*="redirect"]
 cosmopolitan.de##.amazon-bundle-product
 vogue.de##div[data-test-id="AdBannerWrapper"]
-brigitte.de##section[data-name*="Veeseo"]
-brigitte.de##.vergleichsinfo
 bunte.de##.fe-channel-item--promo
 elle.de,instyle.de,freundin.de##.item-paragraph--advertising-products-paragraph
 elle.de,instyle.de##.ecommerce-slider
@@ -1943,7 +1941,8 @@ netdoktor.ch,netdoktor.de###header-ad-slot
 waz.de##.block-header--banner > a:not([href*="waz.de"])
 ||compact-online.de/wp-content/uploads/*/-anzeige-300x250
 wiwo.de##.c-teasergallery--ressort
-stern.de##.vergleichsinfo
+brigitte.de##section[data-name*="Veeseo"]
+brigitte.de,stern.de##.vergleichsinfo
 stern.de##section[data-name^="Vermarktung"]
 stern.de##section[data-name^="Homepage_3er-Kachel-Reisewelten"]
 welt.de##section[data-tb-region="sponsored"]

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -1450,8 +1450,6 @@ golem.de##a[href^="https://www.golem.de/news/anzeige-"]
 golem.de##a[href^="https://www.golem.de/news/anzeige-"] + .cluster-header
 golem.de##a[href^="https://www.golem.de/news/anzeige-"] + .cluster-header + p
 tff-forum.de###subheader-inner > div[id^="banner-"]
-mtb-news.de##div[class^="mtbnews-ad-"]
-mtb-news.de##.mtbnewsAdBillboardContainer
 ga.de##div[data-host="general-anzeiger-bonn.weekli.de"]
 ga.de##.park-portal-marker::before
 unsere-helden.com,forum.golem.de##img[referrerpolicy="unsafe-url"]
@@ -1461,7 +1459,8 @@ administrator.de##.ads-300x600-wrapper
 administrator.de##.snhb-ads
 willhaben.at##.apn-leaderboard-wrapper
 golem.de##.kpomubeaetv
-emtb-news.de,rennrad-news.de##.mtbnewsAdBillboardContainer
+mtb-news.de##div[class^="mtbnews-ad-"]
+emtb-news.de,mtb-news.de,rennrad-news.de##.mtbnewsAdBillboardContainer
 emtb-news.de,rennrad-news.de##div[class^="mtbnews-ad-container"]
 emtb-news.de##.message[data-author="eMTB-News.de"]
 rennrad-news.de##.message[data-author="Rennrad-News.de"]

--- a/SocialFilter/sections/popups.txt
+++ b/SocialFilter/sections/popups.txt
@@ -22,7 +22,7 @@ lesite24.com###button-contact-vr
 awbi.in##body > a[href^="https://whatsapp.com/channel/"]
 rosario3.com##.popup-redes
 vw-passat.pl#%#//scriptlet('set-cookie', 'fblb', '1')
-ukrainart.com.ua###bg_popup
+ukrainart.com.ua,timeallnews.ru###bg_popup
 chizhik.club#?#div[class] > div[class]:has(> div.box > a[href="https://vk.com/chizhik.club"])
 hitdiscount.by,groshyk.by##.banners
 wilsonamplifiers.com##.promotion-banner-sticky
@@ -361,7 +361,6 @@ beyazgazete.com,bogazgazetesi.com.tr###myModal
 bogazgazetesi.com.tr##.modal-backdrop
 eadaily.com###like_box
 analizmerkezi.com###cm-facetwit
-timeallnews.ru###bg_popup
 colorlib.com,cydiageeks.com###conversions-box
 diziizle.net###facebook-takipet
 eleman.net###facebox

--- a/SocialFilter/sections/popups.txt
+++ b/SocialFilter/sections/popups.txt
@@ -263,7 +263,7 @@ cofe.ru###fb_popup
 povar.ru##.soc-banner
 interpress.az###interpresspop
 choiz.me##.socialblock
-wotsite.net,choiz.me###overlay
+haberkibris.com,lubernet.ru,wotsite.net,choiz.me###overlay
 materikelas.com###sidebar > #text-7 #box-message
 crazymailing.com##.fb_block
 bestofthelist.com###cboxOverlay
@@ -353,7 +353,6 @@ takprosto.cc##.jquery-modal.blocker
 ||kibrissondakika.com/wp-content/plugins/popup-maker/
 kibrissondakika.com##.popmake
 haberkibris.com##.boxfb
-haberkibris.com###overlay
 utro.ru##.mask
 utro.ru##.facebook__box
 ren.tv###banner_ss_all
@@ -374,7 +373,6 @@ coco01.net###fbCover
 kredivepara.com###ffbp
 kredivepara.com###ffbp-bg
 palo.com.tr###like-popup
-lubernet.ru###overlay
 vinbazar.com###parent-popup
 lubernet.ru###popup-block
 ulyanovskcity.ru###popup_contact


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/176728
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
