### PR TITLE
Fix #176679 akku-maeser.at

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -11901,6 +11901,7 @@ premium-link.ninja##.cc_banner-wrapper
 !--- JS rules---
 ! SECTION: Cookies - Specific rules (JS)
 !
+akku-maeser.at#%#//scriptlet('set-cookie-reload', 'cookies_confirmed_1', '1')
 ! For cmp.quantcast.com unblocked and clicks are required
 wackojaco.com,gpblog.com#%#//scriptlet('trusted-click-element', 'button[mode="secondary"]')
 wackojaco.com,gpblog.com#%#//scriptlet('trusted-click-element', '.qc-cmp2-header-links > button[mode="link"]:first-child')


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/176679
The website utilises an inline script to load site components only after the policy has been accepted. As a result, elemhide will not be effective. 
I have used 'set-cookie-reload' as the inline script runs before the scriptlet and the modal window is displayed the first time the cookie is set.