### PR TITLE
Try fix #176445 share.dmhy.org

### DIFF
--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -1343,7 +1343,7 @@ wnacg.org##a[href^="https://l.tyrantdb.com/"][target="_blank"] > img
 6park.com##img[width="980"][height="90"]
 teepr.com##div[class^="mid-post-ad-"]
 ||159i.com/sxxd.js
-share.dmhy.org##div[id$="adv"]:has(a > img)
+share.dmhy.org##div[align="center"][id] > a > img
 4399pk.com,downkr.com,cardu.com.tw,cw.com.tw,hk.on.cc,share.acgnx.se##.banner
 huya.com##.J_ad
 techbang.com##.ad_grey_floor

--- a/ChineseFilter/sections/specific.txt
+++ b/ChineseFilter/sections/specific.txt
@@ -1343,7 +1343,7 @@ wnacg.org##a[href^="https://l.tyrantdb.com/"][target="_blank"] > img
 6park.com##img[width="980"][height="90"]
 teepr.com##div[class^="mid-post-ad-"]
 ||159i.com/sxxd.js
-share.dmhy.org##div[align="center"] > a > img
+share.dmhy.org##div[id$="adv"]:has(a > img)
 4399pk.com,downkr.com,cardu.com.tw,cw.com.tw,hk.on.cc,share.acgnx.se##.banner
 huya.com##.J_ad
 techbang.com##.ad_grey_floor


### PR DESCRIPTION
#176445
Can't reproduce, because there is literaly the rule that hides this element.
Enabled filter does not contain any unblocking rules for dmhy.org.

Pr exists because hiding an element by its alignment seems very strange to me and may produce some unexpected behaviour.