### PR TITLE
Fixes 176727 sinnerclownceviri.com

### DIFF
--- a/TurkishFilter/sections/antiadblock.txt
+++ b/TurkishFilter/sections/antiadblock.txt
@@ -49,6 +49,7 @@ beceriksizler.net#%#//scriptlet('set-constant', 'adblock.check', 'noopFunc')
 ! https://github.com/uBlockOrigin/uAssets/issues/20860
 sinnerclownceviri.com#@#.reklam
 sinnerclownceviri.com#%#//scriptlet('prevent-setTimeout', 'AdBlock')
+sinnerclownceviri.com#%#//scriptlet('prevent-setTimeout', 'offsetParent')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/165648
 dizifon.com#@#.reklam
 dizifon.com#@#.advertisement:not(body)


### PR DESCRIPTION
Fixes #176727 sinnerclownceviri.com

This rule i took from the issue https://github.com/uBlockOrigin/uAssets/issues/20860

But I'm curious why not using something like `!sinnerclownceviri.com#%#//scriptlet('abort-current-inline-script', 'document.getElementById', 'x43f')`
