### PR TITLE
fix seznam.cz #176766

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -647,7 +647,6 @@
 ||client-metrics.chess.com^
 ||stat.kwikmotion.com^
 ||analytics.vpplayer.tech^
-||h.seznam.cz^
 ||stat.cncenter.cz^
 ||metrics.roblox.com^
 ||t.xoom.com^


### PR DESCRIPTION
[#176766](https://github.com/AdguardTeam/AdguardFilters/issues/176766)
Removed the rule that prevented the page from being displayed
This task is related to [#126495](https://github.com/AdguardTeam/AdguardFilters/issues/126495) 
I checked, if you disable the rule on this site, then cookies are not shown