### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 3-2

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2171,7 +2171,7 @@ exabytetv.info##.deadblocker-header-bar
 exame.com###ad-blocker-warning
 nwdb.info,explorecams.com,tiermaker.com#%#//scriptlet("prevent-addEventListener", "np.detect")
 extreme-down.tv##div[style="display:block;position:relative"] > p.lastpost-header + p[style="color:green;"] > b
-extremetube.com##.attentionMsg
+extremetube.com,keezmovies.com##.attentionMsg
 ezcoin.it###zwerghonigbienen
 dailyadvertiser.com.au,canberratimes.com.au,thecourier.com.au,portnews.com.au,illawarramercury.com.au,dailyliberal.com.au,centralwesterndaily.com.au,newcastleherald.com.au,examiner.com.au,bendigoadvertiser.com.au#%#//scriptlet('set-cookie', 'dismissCheck', '1')
 fanart.tv###generic > .container > .inset_box
@@ -2308,7 +2308,6 @@ jsfiddle.net###keep-us-running
 jungle.world###block-adblocker
 kamudanhaber.net,habervakti.com,medya28.com,milliirade.com,kanalmaras.com#$#div[data-advert=temedya][id]:not(#style_important) { display: block !important; }
 kanzenshuu.com##.advert
-keezmovies.com##.attentionMsg
 kemono.party##.jumbo-link
 keybr.com#%#//scriptlet("prevent-setTimeout", "()=>", "5000")
 kimcartoon.*##.adbWarnContainer

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1735,7 +1735,6 @@ myshows.me##.DetectAdBlock__modal
 elitepvpers.com#%#//scriptlet('prevent-setTimeout', '.first().height()')
 bypass.city#%#//scriptlet('prevent-fetch', '/googlesyndication\.com|googletagmanager\.com/')
 ||googletagmanager.com/gtm.js$xmlhttprequest,redirect=nooptext,domain=bypass.city
-new-123movies.live##.hhotnews
 posti.mail.ee#%#//scriptlet('set-constant', 'inxBX.failed', 'false')
 ||b.adbox.lv/bxlib/js/loader.js$script,redirect=noopjs,domain=posti.mail.ee
 smarthomebeginner.com##.boxAdBlock
@@ -2244,7 +2243,7 @@ goduke.com##div[aria-label="Ad Blocker Detected"]
 gofile.io###adsPlaywire
 gol.ru##.material-content-adblock
 goldesel.to#?#body > div[class] > ul[class]:has(> li > a[href^="apps/windows/"] > img)
-gomovies-online.cam,new-gomovies.online##.hhotnews
+gomovies-online.cam,new-gomovies.online,new-123movies.live##.hhotnews
 good-football.org###player_block
 goodfon.ru##.js-adb
 gp.se##.adblock-checker

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2404,7 +2404,7 @@ moving2canada.com##.header_advertisement_container
 mrexcel.com#%#//scriptlet("set-constant", "adblockDetector", "noopFunc")
 ms-devices.com#$#.footer_ad { height: 1px!important; }
 msfn.org##.cAnnouncements
-multifilemirror.com##.blockContainer
+multifilemirror.com,smplace.com##.blockContainer
 multifilemirror.com##.jbanner
 multifilemirror.com##.noticeContainer
 multiup.org##.alert.alert-success
@@ -2608,7 +2608,6 @@ simply-hentai.com##.detect-message
 slain.io##.ablocked
 sm.ms##.wwads_abp
 sme.sk#%#//scriptlet("abort-on-property-read", "GoogleContributor")
-smplace.com##.blockContainer
 snbforums.com##.adblock_floating_message
 soccer.ru##.disabled-block
 sokakyemekleri.com##.blocker-notice

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1903,7 +1903,6 @@ siracusanews.it#$#html { overflow: auto !important; }
 silverspoon.site##.jconfirm
 behindthesteelcurtain.com##.adblock-allowlist-messaging__article-wrapper
 enit.in###orquidea-slideup
-photoresizer.com##.banner
 phoenixliteos.com#?#.wb_cont_inner > div[id^="wb_element_instance"][data-plugin="TextArea"]:has(> p[style] > span:contains(ad blockers))
 phoenixliteos.com#?#div[data-plugin="GoogleAdSense"] + div[id^="wb_element_instance"][data-plugin="Shape"]:has(> div.wb_shp)
 ||phoenixliteos.com/gallery_gen/0b56e3d97ab2d305e30f9175a74078d2.png
@@ -2077,7 +2076,7 @@ chip.de#%#//scriptlet("set-constant", "TfmediaExtFolEngineLoaded", "true")
 cikavosti.com,beetlestop.ru,sait-pro-dachu.ru,pcportal.org##.adb-def
 civicx.com##.adblock_detector
 civicx.com#%#//scriptlet("set-constant", "Object.prototype.rellect_adblock_detector", "false")
-client.googiehost.com##.banner
+client.googiehost.com,photoresizer.com##.banner
 cmacked.com,macdrop.net##.adp-popup
 coh2.org###top_stripe > div.img2_box.box
 coh2.org##div[id^="portal_ad"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2014,7 +2014,7 @@ anitokyo.tv##div[style="width: 300px; height: 250px;"]
 antutu.pw###ai-adb-message
 antutu.pw###ai-adb-overlay
 applesfera.com##.ad-cen
-faselhd.*,apteka.ua##.alert-danger
+apteka.ua,cablegratis.online,faselhd.*##.alert-danger
 artage.io##.spb-block.b300x250
 artsgtu.ru##table[style^="height: 200px;"][width="900"]
 as.com,foxnews.com,foxbusiness.com#%#//scriptlet("prevent-setTimeout", "/offsetHeight[\s\S]*?offsetWidth[\s\S]*?\.parentNode\.removeChild/")
@@ -2062,7 +2062,6 @@ bronydom.net###AltBlocked
 buondua.com#$#.noblock-modal { display: none !important; }
 buondua.com#$#body.tingle-enabled { position: static!important;overflow: auto!important; }
 bwitter.me#?##side > ins.adsbygoogle:upward(1)
-cablegratis.online##.alert-danger
 cams.xnxx.com##.dad-vlac-notice
 canyoublockit.com#$##wrapfabtest { height: 1px !important; }
 capfriendly.com##.g_flbrd_ad


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177022
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
