### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 3-1

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2091,7 +2091,7 @@ corneey.com##.information-container
 corriere.it#%#//scriptlet("set-constant", "isAdblockEnable", "false")
 cpu-world.com##div[class="ab_w9"]
 crackberry.com##.swal-overlay
-cracking.org##.adblock_floating_message
+cracking.org,snbforums.com##.adblock_floating_message
 creatur.io#%#//scriptlet("set-constant", "canRunAds", "true")
 criticecho.com,javadecompilers.com###babasbmsgx
 cscontrol.ru##.hbanka
@@ -2610,7 +2610,6 @@ slain.io##.ablocked
 sm.ms##.wwads_abp
 sme.sk#%#//scriptlet("abort-on-property-read", "GoogleContributor")
 smplace.com##.blockContainer
-snbforums.com##.adblock_floating_message
 soccer.ru##.disabled-block
 sokakyemekleri.com##.blocker-notice
 sovetromantica.com###popup_elem

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2117,7 +2117,7 @@ derivative-calculator.net##.support-me
 derivative-calculator.net#%#//scriptlet("abort-current-inline-script", "document.write", "ag_adBlockerDetected")
 lostineu.eu,designtagebuch.de##body div#steady-adblock-overlay-container
 desktophut.com###loading-ad
-desktophut.com##.ads
+desktophut.com,gamesresources.forumfree.it##.ads
 desu.me##.xyz_wrapper_inner
 deviantart.com##body > div#block-notice
 diep.io#%#AG_onLoad(function(){var c=document.querySelector("#ac1"),a=document.createElement("div"),b=document.createElement("iframe");b.style="width: 0px !important; border: none !important;";b.setAttribute("id","google_ads_iframe_");c&&c.appendChild(a);a&&a.appendChild(b)});
@@ -2225,7 +2225,6 @@ gamehag.com#%#//scriptlet("set-constant", "canRunAds", "true")
 gamekings.tv##.addblocker-detected
 gamemag.ru#%#//scriptlet("abort-on-property-read", "window.adblockDiv")
 gamer.com.tw##body > div[style^="position: fixed; left: 20px; right: 20px; bottom: 20px; z-index:"]
-gamesresources.forumfree.it##.ads
 gamesubject.com##.headb
 garrysmods.org#$#.jquery-modal.blocker { display: none !important; }
 garrysmods.org#$#body { overflow: auto !important; }

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2075,7 +2075,7 @@ chefkoch.de#%#//scriptlet("set-constant", "adblocker_is_off", "true")
 chefkoch.de$@$script[tag-content="Flags.networkListener"][min-length="20000"][max-length="150000"]
 chess.com##adblocker-check
 chip.de#%#//scriptlet("set-constant", "TfmediaExtFolEngineLoaded", "true")
-cikavosti.com,beetlestop.ru,sait-pro-dachu.ru,pcportal.org##.adb-def
+cikavosti.com,beetlestop.ru,sait-pro-dachu.ru,pcportal.org,zarplata-es.com##.adb-def
 civicx.com##.adblock_detector
 civicx.com#%#//scriptlet("set-constant", "Object.prototype.rellect_adblock_detector", "false")
 client.googiehost.com##.banner
@@ -2796,7 +2796,6 @@ youporngay.com###adblock_1
 yourhowto.net#$#.advert { height: 301px !important; position: absolute !important; top: -99999px !important; }
 yusepjaelani.blogspot.com#%#//scriptlet("set-constant", "AdBlockSELECTOR", "undefined")
 zakon.kz##.adblock_alert
-zarplata-es.com##.adb-def
 zelka.org##.blocker-form
 zelka.org##div[onclick^="$('.blocker-form')"]
 zerohedge.com###abd-banner

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2563,7 +2563,6 @@ redtube.com,redtube.net###ab_banner
 remont-aud.net#%#//scriptlet("set-constant", "ab", "false")
 renklikodlar.net##.header_adblock
 residentadvisor.net##body > div[style*="height: 152px;"]
-respekt.cz##.adblocker
 reviewmeta.com#%#//scriptlet("prevent-setTimeout", "adsbygoogle")
 ridble.com###adblock-wrapper
 rmz.cr###latest_episodes_fuck_adblock
@@ -2772,7 +2771,7 @@ wikihow.com#%#//scriptlet("set-constant", "_ads", "true")
 winhelp.us###pleasehelp
 wochenanzeiger-muenchen.de##.alert-danger.alert
 wortwuchs.net##.gridlove-ad
-wowjp.net##.adblocker-notification
+wowjp.net,respekt.cz##.adblocker-notification
 wvgazettemail.com,trib.com,sonyliv.com#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }
 wvnews.com###notification-area > #blox-message-incompatible
 wvnews.com#%#//scriptlet("set-constant", "__tnt.advertisements", "noopFunc")

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2040,7 +2040,7 @@ beckershospitalreview.com#$#.olyticsblocker { display: none !important; }
 beckershospitalreview.com#$#body { overflow: auto !important; }
 beckershospitalreview.com#$#html { overflow: auto !important; }
 beforeitsnews.com###ad-message
-bestradio.fm##.adb
+bestradio.fm,wotspeak.ru,rarcoin.ru##.adb
 betaprofiles.com,csdn.net,forum.qrz.ru,tvfeed.in,mastergrad.com,subtitlefix.com##.adblock
 bf4stats.com###sidebar > .sidebox:nth-child(4)
 bingotingo.com##.g1-sidebar > div > div.g1-sticky-widget > aside#text-5
@@ -2550,7 +2550,6 @@ radsport-news.com##.LayoutPromotionAds
 rallye-magazin.de###banner_billboard
 rallye-magazin.de###billboardattention
 randomlists.com##.layout-top > .adsbygoogle--top ~ aside.whine
-rarcoin.ru##.adb
 ratebeer.com##div[class^="AdBlockDetector_"]
 ratebeer.com#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads { display: block!important; }
 rbkgames.com##div#norris-detector
@@ -2773,7 +2772,6 @@ wikihow.com#%#//scriptlet("set-constant", "_ads", "true")
 winhelp.us###pleasehelp
 wochenanzeiger-muenchen.de##.alert-danger.alert
 wortwuchs.net##.gridlove-ad
-wotspeak.ru##.adb
 wowjp.net##.adblocker-notification
 wvgazettemail.com,trib.com,sonyliv.com#$#.pub_300x250.pub_300x250m.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }
 wvnews.com###notification-area > #blox-message-incompatible


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177022
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
