### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (Popup/antiadblock.txt) part 3-4

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2139,7 +2139,7 @@ dragcave.net#?##middle > div[class]:has(> ins.adsbygoogle)
 drakoric.com##.mh-header > p[style="text-align: center;"]
 drawnstories.ru,info-kibersant.ru,kinda.media,tiver.ru###mdl_adb
 dressupmix.com###adblock_popup
-drnasserelbatal.com#%#//scriptlet("set-constant", "canRunAds", "true")
+drnasserelbatal.com,file.fm,files.fm,gamehag.com,onlinehashcrack.com,timebucks.com,uderent.com#%#//scriptlet("set-constant", "canRunAds", "true")
 dumpert.nl#%#//scriptlet('prevent-setTimeout', 'AdBlockerCheck')
 dzone.com,amgreatness.com###adtoniq-msgr-bar
 ebookbb.com##.special-message-wrapper
@@ -2180,7 +2180,6 @@ farming-simulator15.ru##div[id^="advertur"] + div[style="width: 160px; height: 6
 farming-simulator15.ru##div[id^="advertur"] + div[style="width: 300px; height: 250px;"]
 feber.se##div.overlayBox[id^="202"]
 festyy.com##.information-container
-file.fm,files.fm#%#//scriptlet("set-constant", "canRunAds", "true")
 filezipa.com##div[style*="height: 100%;"][style*="opacity: .7"][style*="z-index:"]
 firebit.biz##div[align="center"][style^="background-color:#0088CC; font-size:12px; min-height: 70px;"]
 firebit.net#$#.adsense { width: 10px!important; height: 10px!important; }
@@ -2218,7 +2217,6 @@ gallerix.ru###adbw
 gameblog.fr##img[id^="ablock_"]
 gameblog.fr#%#//scriptlet("set-constant", "adblock", "false")
 gamedev.net###gd
-gamehag.com#%#//scriptlet("set-constant", "canRunAds", "true")
 gamekings.tv##.addblocker-detected
 gamemag.ru#%#//scriptlet("abort-on-property-read", "window.adblockDiv")
 gamer.com.tw##body > div[style^="position: fixed; left: 20px; right: 20px; bottom: 20px; z-index:"]
@@ -2451,7 +2449,6 @@ omaweetraad.nl##.banner-block
 how-to-pc.info,easy-learn-tech.info,one-click-tutorials.info,solvetube.site,getintopc.com#%#//scriptlet('set-constant', 'pqdxwidthqt', 'false')
 onehack.us##center.abb_parent
 oneman.gr#%#//scriptlet("abort-current-inline-script", "atob", "-10000px")
-onlinehashcrack.com#%#//scriptlet("set-constant", "canRunAds", "true")
 onlinethreatalerts.com###adblockermsg
 open2ch.net##.onegai
 opengapps.org##.advertisement > #donatebox
@@ -2690,7 +2687,6 @@ tigernet.com###adblockBox
 tigernet.com###adblockSky
 tigernet.com###topAdBlock
 tileman.io#$#.adbanner#adt { display: block!important; }
-timebucks.com#%#//scriptlet("set-constant", "canRunAds", "true")
 timvision.it#$#.pub_300x250.pub_300x250m.adBanner { display: block !important; }
 titlovi.com##.header > header + [id*="-"]:not([class]) > a[href*="adblock"]
 titulky.com#%#//scriptlet("set-constant", "foolish_script_is_here", "noopFunc")
@@ -2719,7 +2715,6 @@ tweaking4all.com##.t4a_helpus
 twitchquotes.com##.ad-parent
 txxx.com##.header-blocked-ad
 ucoin.net#%#//scriptlet("set-constant", "window.canRunAds", "true")
-uderent.com#%#//scriptlet("set-constant", "canRunAds", "true")
 ui.memoryhackers.org##.show.fade.alert-dismissible.dont-block-this-info-message.alert
 unknowncheats.me##div[id^="ab_notice"]
 unknowncheats.me##div[style="text-align:center;"] > div[style="display:inline-block;"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -2157,7 +2157,7 @@ epidemia-koronawirus.pl###sgpb-popup-dialog-main-div-wrapper
 epidemia-koronawirus.pl##.sgpb-popup-overlay
 equestriadaily.com##.top-banner-section
 era-igr.ru#$##adsense2.adsense { display: block!important; }
-erfahrungen.com#%#//scriptlet("prevent-setTimeout", "adsbygoogle")
+erfahrungen.com,howjsay.com,reviewmeta.com#%#//scriptlet("prevent-setTimeout", "adsbygoogle")
 esoligorsk.by###stopAdBlock
 eu4cn.com###bluedeck_ding > div[onclick]
 eurabota.com##.abtop
@@ -2263,7 +2263,6 @@ homebank.free.fr###asheader.ads
 homebank.free.fr###disablemessage
 horriblesubs.info##.message-blk
 hotvideo.fr###disclaimerId
-howjsay.com#%#//scriptlet("prevent-setTimeout", "adsbygoogle")
 html.de##.noticeContainer
 huawei.mobzon.ru###main-content > div.user3
 hw4.ru##noindex > center > div[style="width: 680px; height: 280px;"]
@@ -2560,7 +2559,6 @@ remont-aud.net#%#//scriptlet("set-constant", "ab", "false")
 renklikodlar.net##.header_adblock
 residentadvisor.net##body > div[style*="height: 152px;"]
 respekt.cz##.adblocker
-reviewmeta.com#%#//scriptlet("prevent-setTimeout", "adsbygoogle")
 ridble.com###adblock-wrapper
 rmz.cr###latest_episodes_fuck_adblock
 rocket-league.com#%#//scriptlet("abort-current-inline-script", "document.getElementById", ".style.display=")

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1804,7 +1804,7 @@ casper.tw##.container > div.row > div.rounded-top + div.d-lg-block
 boylove.cc##.blocked_hint_msg_pc
 videoaktiv.de###_su1
 videoaktiv.de###sp-rect
-strategium.ru#%#//scriptlet('prevent-setTimeout', 'adblock')
+penize.cz,strategium.ru#%#//scriptlet('prevent-setTimeout', 'adblock')
 android.com.pl#%#//scriptlet('set-constant', 'hasAdblock', 'false')
 101soundboards.com,android.com.pl#$#body > div:not([class], [id]) > #AdHeader { display: block !important; }
 101soundboards.com,android.com.pl#$#body > div:not([class], [id]) > #AdHeader ~ * { display: block !important; }
@@ -2475,7 +2475,6 @@ pastedownload.com##.ad
 pastenow.ru###google-block
 pcinvasion.com##.execphpwidget > div[style="min-height: 250px;"]
 peacocktv.com##.playback-ad-blocker-notice
-penize.cz#%#//scriptlet('prevent-setTimeout', 'adblock')
 free-reseau.fr,penize.cz,smartcockpit.com###adblocker
 petanikode.com##div[data-id="antiadblock"]
 petrimazepa.com##div[role="dialog"][style^="position: fixed; height: auto; width: 415px;"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1710,8 +1710,7 @@ spletnik.ru##.z-adblock-message
 forx.mazen-ve3.com#%#//scriptlet('prevent-addEventListener', 'load', 'theModal')
 xanimu.com,familyporner.com,darknessporn.com,freepublicporn.com,pisshamster.com,punishworld.com#%#//scriptlet('remove-node-text', 'script', 'advert')
 crackwatcher.com#%#//scriptlet('set-constant', 'google_ad_modifications', 'emptyObj')
-automoto.it,moto.it#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
-calcmaps.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
+automoto.it,calcmaps.com,moto.it,insidermonkey.com,udocz.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 megogo.net##.adBlock_banner
 mifirm.net#%#//scriptlet('prevent-element-src-loading', 'script', 'pagead2.googlesyndication.com')
 hlavnespravy.sk#?#div[id^="text-"]:has(> div.textwidget > div[id^="admin-"] > a.adblock-warning)
@@ -2285,7 +2284,6 @@ indiatimes.com#$#body .adBanner { display: block!important; }
 init.engineer##.alert-dismissible
 inoreader.com#%#//scriptlet("set-constant", "cr", "0")
 inoreader.com#%#//scriptlet("set-constant", "gn", "true")
-insidermonkey.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 internet-law.ru###fab-enabled
 tuttoandroid.net,psy.pl,koty.pl,intibia.com#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
 investing.com#%#//scriptlet("set-constant", "window.google_ad_status", "1")
@@ -2727,7 +2725,6 @@ twitchquotes.com##.ad-parent
 txxx.com##.header-blocked-ad
 ucoin.net#%#//scriptlet("set-constant", "window.canRunAds", "true")
 uderent.com#%#//scriptlet("set-constant", "canRunAds", "true")
-udocz.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 ui.memoryhackers.org##.show.fade.alert-dismissible.dont-block-this-info-message.alert
 unknowncheats.me##div[id^="ab_notice"]
 unknowncheats.me##div[style="text-align:center;"] > div[style="display:inline-block;"]

--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -1712,7 +1712,7 @@ xanimu.com,familyporner.com,darknessporn.com,freepublicporn.com,pisshamster.com,
 crackwatcher.com#%#//scriptlet('set-constant', 'google_ad_modifications', 'emptyObj')
 automoto.it,calcmaps.com,moto.it,insidermonkey.com,udocz.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 megogo.net##.adBlock_banner
-mifirm.net#%#//scriptlet('prevent-element-src-loading', 'script', 'pagead2.googlesyndication.com')
+abcya.com,mifirm.net,vsthemes.org#%#//scriptlet('prevent-element-src-loading', 'script', 'pagead2.googlesyndication.com')
 hlavnespravy.sk#?#div[id^="text-"]:has(> div.textwidget > div[id^="admin-"] > a.adblock-warning)
 hlavnespravy.sk#?#.article-content > div[id^="admin-"]:has(> a.adblock-warning)
 animenewsnetwork.com#$#body #Adbanner { display: block !important; height: 1px !important; }
@@ -1794,7 +1794,6 @@ maxedtech.com#%#//scriptlet('prevent-fetch', 'pagead2.googlesyndication.com')
 marieclaire.fr#$?#.qiota_onboard:has(> div.AdBlockModal) { display: none !important; }
 marieclaire.fr#$##overlay { display: none !important; }
 marieclaire.fr#$#body { overflow: auto !important; }
-vsthemes.org#%#//scriptlet('prevent-element-src-loading', 'script', 'pagead2.googlesyndication.com')
 chat.g4f.ai,chat.chatbot.sex##.adsbox
 vnexpress.net##.wrap-hd-adblock
 pallabmobile.in,woowebtools.com,wooseotools.com##div[style^="position: fixed; width: 100vw;"][style$="z-index: 999999;"]
@@ -1819,7 +1818,6 @@ gamebrew.org#%#//scriptlet('prevent-fetch', 'nitropay.com')
 @@||nitropay.com/ads-*.js$xmlhttprequest,domain=gamebrew.org
 @@||gamebrew.org/images/misc/yzfdmoan23.js
 darksoftware.net#?#.notices .notice--primary:contains(Adblocker)
-abcya.com#%#//scriptlet('prevent-element-src-loading', 'script', 'pagead2.googlesyndication.com')
 chatreplay.stream##div[style^="height:"].container
 reddit.com#$##acceptabletest { display: block !important; }
 reddit.com#$##adblocktest { display: block !important; }


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177022
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
