### PR TITLE
Cleanup duplicate rules in MobileFilter (specific_web.txt) part 4

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -494,7 +494,6 @@ gptoday.net##.ad-placeholder-wrapper
 gptoday.net###gptoday_ros_bravo_mobile
 hellosehat.com##.article-mobile-ad
 tuttotech.net#?#.grid-start > .align-self-center:has(> .banner)
-gptoday.net###gptoday_ros_bravo_mobile
 0352.ua#?#.row > div.card-wrapper:has(> amp-ad)
 root-nation.com###tdi_3
 root-nation.com###tdi_95

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -3080,7 +3080,6 @@ focus.ua##.no-pad-top > div.clearfix > aside.content-block__col > div.f-block:la
 hockeybuzz.com##body .adFooterDFPMobile
 hockeybuzz.com##body > div[style^="position:fixed; bottom:"][style*="z-index:"]
 ||m.sporx.com/_js/postitial_check.php
-4gamers.com.tw##.mobile-bottom-ads
 4gamers.com.tw##.scroller-ads-wrapper
 4gamers.com.tw##.news-detail-bg a[href][target="_blank"] > img[src*="/ads-media/"]
 hdblog.it##.news-list-item.banner_list_container

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -4123,7 +4123,6 @@ sn-jp.com#?#.content > div[style*="height"]:has(> center:only-child > div[id^="d
 sn-jp.com#?#.content > div[style*="height"]:has(> .parent:only-child > div[class^="child-"]:only-child > center > div[id^="div-gpt-"])
 sn-jp.com#?#main > div[style*="height"]:has(> .parent:only-child > div[class^="child-"]:only-child > div[id^="div-gpt-"])
 nicomanga.com#?#.row > div.col-md-4:has(> center > iframe[height="300px"])
-m.winfuture.de#?##articleBody > div:has(> div[id^="div-gpt-ad"])
 rtl.de#?#.article-body > div[class] > div[class]:has(> span:contains(/^Anzeige:$/))
 ibradome.com#?#body > center:has(> iframe[src^="//hhbypdoecp.com/"])
 delo-vcusa.ru#?#aside:has(> div.aligncenter > ins.adsbygoogle)

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -2468,7 +2468,6 @@ m.formel1.de##.b-top-container
 computerbild.de##.mrecContainer
 gsminfo.com.ua###custom_html-12
 gsminfo.com.ua###custom_html-10
-4gamers.com.tw##.interstitial-ads
 manager-magazin.de##amp-layout[width="300"][height="266"]
 2chan.net##div[style="width:670px;height:100px;margin:2px auto"]
 2chan.net##iframe[src*=".net/bin/ad"] + hr


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177287
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
