### PR TITLE
Cleanup duplicate rules in MobileFilter (specific_web.txt) part 2

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -481,7 +481,7 @@ txxx.com,txxx.tube##.index-page > .wrapper > .row + div[class]
 in-porn.com,inporn.com##.video__wrapper > section[class]:first-child
 aqa.ru##span[style="height: 300px; padding: 0; width: 100%; display: block;"]
 news-sky-com.cdn.ampproject.org##.sdc-site-au
-metro-co-uk.cdn.ampproject.org##.metro-amp-ad
+metro.co.uk,metro-co-uk.cdn.ampproject.org##.metro-amp-ad
 www-manchestereveningnews-co-uk.cdn.ampproject.org,www-mirror-co-uk.cdn.ampproject.org##.mod-video
 hi-tech.mail.ru#?#div[data-logger-parent="top"] > div[style*="height"][style*="40px"]:has(> div[data-rb-slot])
 nikkansports.com##li[id^="adUnit"]
@@ -1301,7 +1301,6 @@ businessinsider-com-pl.cdn.ampproject.org##.bottomLayerBar
 businessinsider-com-pl.cdn.ampproject.org##div[style="margin:auto;width:300px;"]
 game8.jp###g8-ad-placement-sp_under_archive_ab
 game8.jp##.ad-skyflag-wrapper
-metro.co.uk##.metro-amp-ad
 trashbox.ru##.div_aj_top4_as
 hentaihaven.xxx##.adb
 brow2ing.com##.free-area

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -988,7 +988,6 @@ m.economictimes.com###int_overlay
 gendai.media###first-rectangle
 m.wcostream.tv,m.wcostream.net###rmds
 s.tabelog.com##.ad-rstdtl-wrap
-webcg.net##.infeed
 onepiece-akumanomi.com##.adsbygoogle
 imtest.de##div[class^="contentAd"]
 detail.chiebukuro.yahoo.co.jp##aside[class^="Detail_chie-Pages__AdNM_"]
@@ -2246,7 +2245,7 @@ dic.nicovideo.jp###ad01
 dic.nicovideo.jp##.st-Header_Ad
 dic.nicovideo.jp##.st-Ad:not(#sdad)
 diamond.jp###gpt-dol-infeed-ranking
-saga-s.co.jp,diamond.jp##.infeed
+webcg.net,saga-s.co.jp,diamond.jp##.infeed
 producthunt.com##div[class*="styles_mobilePopoutAd_"]
 tofight.ru###cf-bg
 thetimes.co.uk##div[class*="NativeAd-"]

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -663,7 +663,6 @@ eromanga-fantasy.com,erodoujinshi-world.com##iframe[height="270px"][width="320px
 masrawy.com##.featuredSCMob
 ||eromanga-musou.com/fammusou1.html
 eromanga-musou.com##iframe[src*="//eromanga-musou.com/fammusou1.html"]
-jeremyfoodie.tw##.header-fixed-area
 cleantechnica.com##.zox-post-body > center > a[target="_blank"] > span.mrf-detailsMedia
 cleantechnica.com##.zox-post-body > p > span > a[rel*="sponsored"] > span.mrf-detailsMedia
 engadget.com##div[data-ad-mn]
@@ -3351,7 +3350,7 @@ newgrodno.by##.main-nav-below > nav#top-nav > div.container > div.topbar-wrapper
 m.tvtoday.de##.tv-program > .component > ul > li.js-table-row:not(.time-listing):not([data-start-time])
 txxx.com##.rek-item
 txxx.com##div[class^="rek-"]
-fox-saying.com,maxfoodfun.com,pixnet.net##.header-fixed-area
+jeremyfoodie.tw,fox-saying.com,maxfoodfun.com,pixnet.net##.header-fixed-area
 pixnet.net##.octopus
 pluggedin.ru##a[target="_blank"][href^="https://ads.adfox.ru"] > img
 community.spiceworks.com##.ad-content-slot

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -513,7 +513,6 @@ m.airporthaber.com##.Banner
 poginfo.ddo.jp#?#.mx-0.mx-auto:has(> div[style="height: 250px"])
 poginfo.ddo.jp##.footer-menu-bar
 lepoint.fr###WRAP_TOP_POS
-jmcomic1.me##.div_sticky2
 crx4chrome.com##div[style="min-height:336px;"]
 mine-3m.com##.gtm-affiliate-button-3
 erologz.com##div[class^="cls-"]
@@ -527,7 +526,7 @@ times.abema.tv##div[style="min-height: 100px;margin-bottom: 2vh; text-align: cen
 times.abema.tv##.article-banner
 upworthy.com##.mobile_ads
 cumhuriyet.com.tr#?#.container > div.row > div.row.mb20:has(> #sticky-player)
-18comic.org##.div_sticky2
+18comic.org,jmcomic1.me##.div_sticky2
 ehow.co.uk##.mobile-display-ad
 pcgames.de,gamesworld.de##.sdgSlotContainer
 pussyspace.com,pussyspace.net#?##main-area-box div[id]:has(> iframe[src*="/lazyload"])


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177287
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
