### PR TITLE
Cleanup duplicate rules in MobileFilter (specific_web.txt) part 1

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -268,7 +268,6 @@ cruxnow.com##.grid > div.w-full > div[class^="flex"]:has(> div[class] > div[id^=
 2ch-c.net##.cdt_wrapper
 2ch-c.net##a[href="mgs/mgs.php"]
 baomoi.com###content-main > div[class] > div[class] > div[class]:has(> div[class] > a[href] div button[title="Báo lôi"])
-lefigaro.fr##.ccmcss_oas_top
 spite.cz##.sda-space--mobile
 geo.fr##.ads-introText
 wtmnews.net##.entry-content > p:has(> a[target="_blank"][rel="nofollow sponsored "] > img)
@@ -307,7 +306,7 @@ cyclesports.jp##[class^="banner"]
 soccer-king.jp##div[style]:has(> div > div[id^="div-gpt-ad"])
 gaming-city.com##.m-top-banner
 gaming-city.com##.mobile-footer-ad
-linternaute.com,journaldunet.com##.ccmcss_oas_top
+lefigaro.fr,linternaute.com,journaldunet.com##.ccmcss_oas_top
 www-news18-com.cdn.ampproject.org#?#.short_discription + div[style] > span:contains(advertisement):upward(1)
 komonews-com.cdn.ampproject.org##div[data-testid="story-body"] div[style]:has(> amp-ad)
 yespornpleasexxx.com##iframe[src^="//a.magsrv.com/"]

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -220,7 +220,7 @@ t-mall.tsite.jp###content_inr > p[style="font-weight: bold; font-size: 16px;"]:h
 quifinanza.it##.hp_320x1
 giga.de#$#body { padding-top: 9rem !important; }
 rtlnieuws.nl##.dfp-rectangle-mobilewrapper
-kutv.com##.displayAd
+kutv.com,wlos.com##.displayAd
 scribd.com##.page_wrapper > div[class] > div[class]:has(> #scribd_mobile_pushdown-pushdown-cls:only-child)
 scribd.com##.page_wrapper > div[class] > a[href^="https://www.scribd.com/oauth/signup?doc_id="][target="_blank"]
 leekduck.com###ad-event-page-mobile
@@ -290,7 +290,6 @@ kabutan.jp##footer > div.flex.justify-center
 tipranks.com##.displaynone > div[style="height:100px"]:empty
 voennoedelo.com##.mBanner
 news.mynavi.jp##.articleList_list > li.articleList_listNode:has(div[id^="div-gpt-ad"])
-wlos.com##.displayAd
 freehentaistream.com##.mbanner-wrapper
 minkou.jp##.mod-listReview-list__ad
 minkou.jp##.js-display-ad

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1442,7 +1442,6 @@ badspi.jp##.middle_ad_area
 telegraf.in.ua##.partner-img
 telegraf.in.ua###bottom_banner
 alba.co.jp##.topbnrArea
-kijyomatome-ch.com###article-1_5
 movie-rush.com##.container-fluid > div.mb-2
 movie-rush.com##.fs
 phileweb.com###banner-header
@@ -2993,7 +2992,7 @@ matometanews.com###category_ranking
 newsoku.blog##div[style="width:100%;height:500px; overflow: hidden;"]
 newsoku.blog##footer > div.widget_mobile_ad ~ div[class^="widget"]
 news4vip.livedoor.biz###f984a
-openworldnews.net,majikichi.com,majikichi.com,girlsvip-matome.com,sutekinakijo.com,onecall2ch.com,jin115.com,chaos2ch.com,bipblog.com,akb48matomemory.com,himasoku.com,blog.esuteru.com,kyousoku.net,vipsister23.com,blog.jp,2chblog.jp,doorblog.jp,livedoor.biz,blog.livedoor.jp###article-1_5
+kijyomatome-ch.com,openworldnews.net,majikichi.com,majikichi.com,girlsvip-matome.com,sutekinakijo.com,onecall2ch.com,jin115.com,chaos2ch.com,bipblog.com,akb48matomemory.com,himasoku.com,blog.esuteru.com,kyousoku.net,vipsister23.com,blog.jp,2chblog.jp,doorblog.jp,livedoor.biz,blog.livedoor.jp###article-1_5
 arstechnica-com.cdn.ampproject.org##.instream-wrap
 mobile.reuters.com##.mpu_ad
 mobile.reuters.com##.promo.editorial

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -339,12 +339,11 @@ mannenzaken.nl##.r89-mobile-rectangle-mid
 mannenzaken.nl##.r89-mobile-rectangle-infinite
 mannenzaken.nl##.wpb_wrapper:has(> div.td-fix-index > div.r89-mobile-billboard-top)
 cnbctv18.com##.below-summary-ad
-porngo.com##.center-spot
 telegraf.com.ua$$div[class="tgr-ads"]
 mytabs.ru##.dc-bt-mobile
 3movs.com##.spot_list
 3movs.com##.spot-after-header
-xxxfiles.tv##.center-spot
+porngo.com,xxxfiles.tv##.center-spot
 overclockers.ru##.container-block:has(> div[id^="yandex_rtb"])
 overclockers.ru##.container-block.woback:has(> div > ins[data-revive-zoneid])
 tupaki.com###roadblocker-wrapper

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -1387,7 +1387,7 @@ sexvid.*##.block_main ~ div.title_centered
 thestudentroom.co.uk###mobile-ad-floating
 sonicch.com###sumaho
 m.hellporno.com##.tabs
-news.jorudan.co.jp###ad-top-2
+eporner.com,news.jorudan.co.jp###ad-top-2
 news.jorudan.co.jp##div[id^="ad-bottom-"]
 paroles.net##div[style="min-height:250px;"]
 milffox.com##.mobile_top_ads
@@ -3395,7 +3395,6 @@ aydinlik.com.tr,insider.com,rookie.shonenjump.com,gmx.*,zeit.de,jp.ign.com,openc
 jp.ign.com,amp.theguardian.com,zeenews.india.com,amp.fakty.ua,indianexpress.com##amp-iframe
 rbc.ru##.banners__mobile-freeze
 lifo.gr##.ad_inside > .sticky-wrap
-eporner.com###ad-top-2
 outlook.live.com###topLevelItemsExceptFolderPane > main > div[class*=" "] > div[class^="_"]:not([role="group"])
 ck101.com###mobile_backgroundAD
 atlasobscura.com##.ad-background-intra-body

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -492,7 +492,6 @@ www-timesofisrael-com.cdn.ampproject.org##.banner-placeholder
 gptoday.net##.top-banner-leaderboard
 gptoday.net##.ad-placeholder-wrapper
 gptoday.net###gptoday_ros_bravo_mobile
-hellosehat.com##.article-mobile-ad
 tuttotech.net#?#.grid-start > .align-self-center:has(> .banner)
 gptoday.net###gptoday_ros_bravo_mobile
 0352.ua#?#.row > div.card-wrapper:has(> amp-ad)
@@ -3029,7 +3028,7 @@ mobil.krone.at##div[data-krn-click-id="startseite-mobil-jackpot"]
 sciencealert.com##.ad_div
 testkolik.com##.mobilreklam
 www-news18-com.cdn.ampproject.org,news18.com##.adv_wrp
-helloyishi.com.tw,greatergood.berkeley.edu##.article-mobile-ad
+hellosehat.com,helloyishi.com.tw,greatergood.berkeley.edu##.article-mobile-ad
 www-nytimes-com.cdn.ampproject.org##figure.margins-v.ad
 newsweekjapan.jp,m.sweclockers.com###topBanner
 expressen.se##body div.bam-ad-slot[data-slot-name]


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177287
 
### Add your comment and screenshots

Based on the issue, I removed the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
