### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (cookies_specific.txt) part 2-1

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1631,7 +1631,6 @@ mashnews.ru,pkge.net,lucasentertainment.com##.notification
 tracemyip.org###acTOSckBar
 volnamobile.ru###message-block-cookie
 nec.com##.func-cookie
-ukraine.com.ua##.c-gdpr-banner
 szkolnastrona.pl##.backdrop-cookies
 octoparse.jp##div[class^="cookies_cookies_"]
 fmdataba.com###coki61
@@ -7278,7 +7277,7 @@ swiatksiazki.pl##.cookies-section
 megogo.ru##div[class*="mobile-megogo-agreement-notify"]
 knuddels.de###root div[style^="position: relative; display: flex;"] > div[class^="Column_ColumnFluid__"] > div[class^="Column_ColumnFluid__"] > div[class^="Column_Column__"][style^="background-repeat: no-repeat; opacity:"]
 pollylingu.al###opt-form
-graef.de,sketchfab.com,twitchcon.com##.c-gdpr-banner
+ukraine.com.ua,graef.de,sketchfab.com,twitchcon.com##.c-gdpr-banner
 tiendeo.com.tr##.s·footer-gdpr
 fratelliguzzini.com###cookie-law-wrap
 getoutline.org##.cPeak_Announcements .notification-wrapper

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -569,7 +569,6 @@ loggi.com#%#//scriptlet('set-cookie', '_cookie_banner_showed', 'true')
 derimod.com.tr##.cc-window[aria-label="cookie bar"]
 vava.cars##vc-cookies-notification
 amway.it#%#//scriptlet('trusted-click-element', '.bottom_btn_wrapper > div#preferences_prompt_submit')
-kz.amway.com,amway.ua##.disclaimer-container
 bybit.com##div[class^="style_gdpr-cookie-notice"]
 itau.com.br,hipercard.com.br##.marco-civil-banner
 bigo.tv##.privacy-popup
@@ -8739,7 +8738,7 @@ paketda.de###PrivacyInformationConsent
 radio-canada.ca##.g-alert-cookie
 nikkei.com##kite-privacy-notification
 patreon.com##.reactWrapper div[aria-live="polite"][aria-describedby="BannerContent-0"]
-fakeemail.de,amway.ru,wizaz.pl##.disclaimer-container
+kz.amway.com,amway.ua,fakeemail.de,amway.ru,wizaz.pl##.disclaimer-container
 hallo-meinung.de##body > .uk-section-primary.uk-position-bottom
 joyn.de##div[data-test-id="CookieNotification"]
 get.adobe.com###adChoice_div

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1124,7 +1124,6 @@ web.magentatv.de#%#//scriptlet('trusted-click-element', '#OVERLAY-REJECT')
 blog.govoyagin.com#%#//scriptlet('set-cookie', 'cmplz_marketing', 'allow')
 stavka.tv##.CookiesInfo
 ya.*##.gdpr-popup-v3-main
-nrn.com##.gdpr-popup-border
 app.interviewme.pl#?##app > div[class] > div[class*=" "]:has(h3[style^="font-size:"] + p > a[href$="-cookie"])
 sky.it#%#//scriptlet('trusted-click-element', 'button[title="Continua senza accettare"]')
 hyperoptic.com#%#//scriptlet('trusted-set-cookie', 'ho_cookie_consent', 'essential_analytics_marketing')
@@ -10327,7 +10326,7 @@ trello.com##.gdpr-cookie-consent-banner
 tesco.hu,tesco.pl##.gdpr-cookies
 ivacy.com##.gdpr-hellobar
 highsnobiety.com##.gdpr-optin-view
-designnews.com,wealthmanagement.com,itprotoday.com##.gdpr-popup-border
+nrn.com,designnews.com,wealthmanagement.com,itprotoday.com##.gdpr-popup-border
 twitter.com##.gdpr-privacy-banner
 news.ro##.gdpr-section
 abcmouse.com,shopalike.nl,vimeo.com##.gdpr_banner

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1236,7 +1236,6 @@ ilmattino.it,leggo.it#$##richiesta_accettazione_abbonamento { display: none !imp
 marshall.com#$##CookieConsentDialog { display: none !important; }
 marshall.com#$#.modal-backdrop { display: none !important; }
 marshall.com#$#body { overflow: auto !important; padding-right: 0 !important; }
-shop.garten-bienen.at##.cookie-information
 pfr.gov.ru,sfr.gov.ru##.user-data-processing-wrapper
 ||ostsee24.de/consent/
 careerswales.gov.wales##.cw-cookies-policy-banner
@@ -10287,7 +10286,7 @@ libertylondon.com##.cookie-disclaimer-message
 finder.com##.cookie-footer-bar
 metabomb.net,nintendolife.com,usgamer.net,vg247.com##.cookie-gdpr
 ikea.com##.cookie-info__panel
-india-store.de,schaumstofflager.de,photowall.de,turkiyesigorta.com.tr,turkiyehayatemeklilik.com.tr,vakifemeklilik.com.tr,nofluffjobs.com##.cookie-information
+shop.garten-bienen.at,india-store.de,schaumstofflager.de,photowall.de,turkiyesigorta.com.tr,turkiyehayatemeklilik.com.tr,vakifemeklilik.com.tr,nofluffjobs.com##.cookie-information
 dmax.com.tr,gq.com.tr,tlctv.com.tr,vogue.com.tr##.cookie-item
 de-mail.info,gmx.net,web.de##.cookie-lasche
 iloft.it##.cookie-law-policy

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1851,7 +1851,6 @@ oz.by###c-dialog
 aluguefoco.com.br###warning
 advesphoto.hu###marketingConsent
 ||bankinform.ru/js/widgets/CookieAgreementWidget.js
-stm.com.tr##.cookie_modal
 gim-international.com,mein-zaunshop.de,gartengeraete-onlineshop.de##div[x-data*="cookieConsent"]
 1a-garten-ammer.de#$#div[class^="cookiemessage"] { display: none !important; }
 1a-garten-ammer.de#$#body[style] { overflow: auto !important; }
@@ -7411,7 +7410,7 @@ plshair.co.uk##.vtl-cb-main-widget
 speedof.me#$#.cc-dialog-pane { display: none !important; }
 speedof.me#$#.cc-window-banner { display: none !important; }
 speedof.me#$#.body-margin-top { margin-top: 0 !important; }
-myvitamins.com,myprotein.com,homebase.co.uk,zavvi.it,glossybox.de,lookfantastic.com##.cookie_modal
+stm.com.tr,myvitamins.com,myprotein.com,homebase.co.uk,zavvi.it,glossybox.de,lookfantastic.com##.cookie_modal
 quebarato.com.br##.floatingBarPrivacy
 heimgourmet.com##.gaCookieConsent
 heimgourmet.com#$#body.gaBarShown { margin-top: 0 !important; }


### PR DESCRIPTION

 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177982
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
