### PR TITLE
Cleanup duplicate rules in AnnoyancesFilter (cookies_specific.txt) part 2-3

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1804,7 +1804,7 @@ snob.ru##.footer-cookie-notice
 lueur.org#?#body > div#modal:has(> div#modal-dialog > div#modalcontent > p > button[onclick^="cookieManagement"])
 c6bank.com.br#?#.MuiBox-root > div.MuiBox-root:has(> div.MuiBox-root > p > a[href="https://www.c6bank.com.br/termos-de-uso"])
 egoe-nest.eu##.s2022-cookie-bar__veil
-doz.pl##.popup-cookies
+netia.pl,vitalia.pl,makeup.ru,skin.ru,doz.pl##.popup-cookies
 ||doz.pl/skin/assets/bundle/default/js/elements/cookie-wall.js
 ||mywellness.de/wp-admin/admin-ajax.php?action=get_eprivacy_data
 die-mitte.ch###ampsandConsentElement
@@ -9909,7 +9909,6 @@ create.vista.com,shephardmedia.com,roosterteeth.com##.policy-banner
 hotellook.com,kongregate.com##.policy-bar
 pdftoexcel.com,netart-registrar.com,nazwa.pl##.policy-box
 lesmobiles.com##.popin-cnil
-netia.pl,vitalia.pl,makeup.ru,skin.ru##.popup-cookies
 forum.fok.nl##.popup_1TXMW
 leguide.com##.popup_policies
 muse.mu##.pp-footer

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1627,7 +1627,6 @@ alpi-software.com##div[class^="m-cookie-"]
 whoisxmlapi.com##.cookie-message-block
 revistacromos.com.co##.Cookies-containerGeneral
 today.it#$#.o-wrapper.iub--active { filter: none !important; user-select: auto !important; pointer-events: auto !important; cursor: auto !important; }
-mashnews.ru,pkge.net,lucasentertainment.com##.notification
 tracemyip.org###acTOSckBar
 volnamobile.ru###message-block-cookie
 nec.com##.func-cookie
@@ -10363,7 +10362,7 @@ ft.com##.n-messaging-slot--cookieConsentB
 vanharen.nl,deichmann.com,roland-schuhe.de##.newsflash
 elderscrollsportal.de,macuser.de,mangahelpers.com##.noticeContent
 bauexpertenforum.de##.noticeCookiesContent
-mindbodyonline.com,friendhosting.net,ad-maven.com,wmeagency.com,lesara.de,megawrzuta.pl,postnauka.ru##.notification
+mashnews.ru,pkge.net,lucasentertainment.com,mindbodyonline.com,friendhosting.net,ad-maven.com,wmeagency.com,lesara.de,megawrzuta.pl,postnauka.ru##.notification
 tvnet.lv,postimees.ee##.notification--cookie
 mercedes-benz.de##.notificationbox__base
 culture.ru,seat.dk##.notify-bar

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -1438,7 +1438,7 @@ sugi-net.jp#$#div[style="position: fixed; left: 0px; top: 0px; width: 100%; heig
 sugi-net.jp#$#body[style="overflow: hidden;"] { overflow: auto !important; }
 ||assets.poool.fr^$domain=larousse.fr
 ||assets.poool-subscribe.fr^$domain=larousse.fr
-russia-tv.online##.page-footer__popup-cookie
+litehd.tv,russia-tv.online##.page-footer__popup-cookie
 shop.asfinag.at#$##modalCookieInfo { display: none !important; }
 shop.asfinag.at#$#.modal-backdrop { display: none !important; }
 asfinag.at#$##cookieOverlayModal { display: none !important; }
@@ -2054,7 +2054,6 @@ fstec.ru##body > div.eb-bottom-center[data-options*='backdrop_color":"rgba(0, 0,
 supraphonline.cz##body > div[style^="text-align:left; padding: 10px 20px; background-color:"]
 simpleimageresizer.com###consent-popup-id
 gedik.com#%#//scriptlet('set-session-storage-item', 'acceptCookies', 'false')
-litehd.tv##.page-footer__popup-cookie
 daddylive.link##.gdpr-cm-wrap
 wtmobile.com###cbox-container
 info-car.pl##app-accept-cookies

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -572,7 +572,7 @@ amway.it#%#//scriptlet('trusted-click-element', '.bottom_btn_wrapper > div#prefe
 kz.amway.com,amway.ua##.disclaimer-container
 bybit.com##div[class^="style_gdpr-cookie-notice"]
 itau.com.br,hipercard.com.br##.marco-civil-banner
-bigo.tv##.privacy-popup
+totalizator.pl,traseo.pl,wakanim.tv,novavax.com,serumshop.ru,kartoteka.by,bigo.tv##.privacy-popup
 bigo.tv##.bottom_loadapp
 zdf.de#%#//scriptlet('trusted-click-element', 'button[data-testid="cmp-revoke-all"]')
 copilot.microsoft.com#%#//scriptlet('trusted-set-cookie', 'BCP', 'AD=0&AL=0&SM=0')
@@ -7876,7 +7876,6 @@ tevapharm.com##.vi-alert-CookieBlock
 softline.ru##div[class$="_content_cookie"]
 store.softline.ru###stripe_permission_use_cookie
 radio.net##div[data-testid="cookienotice-container"]
-totalizator.pl,traseo.pl,wakanim.tv,novavax.com,serumshop.ru,kartoteka.by##.privacy-popup
 picnic.app###modal
 serverschmiede.com###cookieCheck
 textpro.me,ephoto360.com,gamez.de,wallpapershome.com,wallpapershome.ru##.cc-dialog


### PR DESCRIPTION

 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?
https://github.com/AdguardTeam/AdguardFilters/issues/177982
 
### Add your comment and screenshots

Based on the issue, I have cleaned up the duplicate rules.



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
