### PR TITLE
Fix boomstore.de rule

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -1673,7 +1673,7 @@ $removeparam=epi,domain=microsoft.com|xbox.com
 ||www.lidl.de^$removeparam=msktc
 ||www.pricezilla.de^$removeparam=bid
 !
-||boomstore.de*.html$removeparam=campaign
+||boomstore.de/*.html$removeparam=campaign
 ||www.alternate.de^$removeparam=campaign
 ||www.alternate.de^$removeparam=campaign
 !


### PR DESCRIPTION
I'm pretty sure it's not meant to match `boomstore.dexyz.html`.