### PR TITLE
Add regex for revolving adservers

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -21,6 +21,8 @@
 ! /asset/angular.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 ! /asset/jquery/slim-3.2.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 !
+! ex. https://gutazngipaf.com/en/olrod?id=2013574
+/^https:\/\/[a-z]{10,12}\.com\/[a-z\/]{2,}\?id=[12]\d{6}$/$script,third-party,match-case
 ! ex. https://fiveyardlab.com/z-7131650
 /^https:\/\/[0-9a-z]{5,}\.[a-z]{2,3}\/z-[5-7]\d{6}$/$script,~third-party
 ! https://github.com/AdguardTeam/AdguardFilters/pull/175819


### PR DESCRIPTION

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/179465

### Add your comment and screenshots

1. Your comment

A family of revolving adservers like `https://gutazngipaf.com/en/olrod?id=2013574` has been common for a while. The rule here was added to uAssets by https://github.com/uBlockOrigin/uAssets/commit/9597e167987c094f814e236c62a3968af8d2871f and subsequently adjusted by https://github.com/uBlockOrigin/uAssets/commit/783d732c84557ca42a8492c3f01be3e172acd5d8 , no problem has been reported. We already have a specific rule for CB added by https://github.com/AdguardTeam/AdguardFilters/pull/157595 but this can be generic if `{n,m}` is supported.

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

![logs](https://github.com/AdguardTeam/AdguardFilters/assets/58900598/94b6313d-1d59-4f45-bdbb-b493fa98b652)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
