### PR TITLE
Upd #175819

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -28,10 +28,14 @@
 ! https://github.com/AdguardTeam/AdguardFilters/pull/175819
 /^https:\/\/www\.[a-z]{8,16}\.com\/(?:[A-Za-z]+\/)*(?:[_0-9A-Za-z]{1,20}[-.])*[_0-9A-Za-z]{1,20}\.js$/$script,third-party,match-case,header=popads-node
 /^https:\/\/www\.[a-z]{8,16}\.com\/(?:[A-Za-z]+\/)*(?:[_0-9A-Za-z]{1,20}[-.])*[_0-9A-Za-z]{1,20}\.js$/$script,third-party,match-case,header=link:/adsco\.re\/>;rel=preconnect/
-://www.*.com/*.css|$script,third-party,header=link:/\/>;rel=preconnect/
-://www.*.com*/images/*.min.js|$script,third-party,header=link:/\/>;rel=preconnect/
-://www.*.com/css/$script,third-party,header=link:/\/>;rel=preconnect/
-://www.*.com/js/css/$script,third-party,header=link:/\/>;rel=preconnect/
+://www.*.com/*.css|$script,third-party,header=popads-node
+://www.*.com*/images/*.min.js|$script,third-party,header=popads-node
+://www.*.com/css/$script,third-party,header=popads-node
+://www.*.com/js/css/$script,third-party,header=popads-node
+://www.*.com/*.css|$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
+://www.*.com*/images/*.min.js|$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
+://www.*.com/css/$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
+://www.*.com/js/css/$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
 ! https://github.com/uBlockOrigin/uAssets/issues/9139#issuecomment-1945860142
 /tds/ae?*&clickid=$document
 .com/api/users?token=*&uuid=&pii=&in=false^$document

--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -26,11 +26,12 @@
 ! ex. https://fiveyardlab.com/z-7131650
 /^https:\/\/[0-9a-z]{5,}\.[a-z]{2,3}\/z-[5-7]\d{6}$/$script,~third-party
 ! https://github.com/AdguardTeam/AdguardFilters/pull/175819
+/^https:\/\/www\.[a-z]{8,16}\.com\/(?:[A-Za-z]+\/)*(?:[_0-9A-Za-z]{1,20}[-.])*[_0-9A-Za-z]{1,20}\.js$/$script,third-party,match-case,header=popads-node
 /^https:\/\/www\.[a-z]{8,16}\.com\/(?:[A-Za-z]+\/)*(?:[_0-9A-Za-z]{1,20}[-.])*[_0-9A-Za-z]{1,20}\.js$/$script,third-party,match-case,header=link:/adsco\.re\/>;rel=preconnect/
-://www.*.com/*.css|$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
-://www.*.com*/images/*.min.js|$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
-://www.*.com/css/$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
-://www.*.com/js/css/$script,third-party,header=link:/adsco\.re\/>;rel=preconnect/
+://www.*.com/*.css|$script,third-party,header=link:/\/>;rel=preconnect/
+://www.*.com*/images/*.min.js|$script,third-party,header=link:/\/>;rel=preconnect/
+://www.*.com/css/$script,third-party,header=link:/\/>;rel=preconnect/
+://www.*.com/js/css/$script,third-party,header=link:/\/>;rel=preconnect/
 ! https://github.com/uBlockOrigin/uAssets/issues/9139#issuecomment-1945860142
 /tds/ae?*&clickid=$document
 .com/api/users?token=*&uuid=&pii=&in=false^$document


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/pull/175819

1. Your comment

A new pattern of PopAds uncaught by the current rules found on `https://dlhd.so/stream/stream-51.php` I used unique `popads-node` for the regex, but simply generalized the rest of rules as they are relatively safe even without `$header`.  Add `dlhd.so#@%#//scriptlet('abort-current-inline-script', 'atob', '/popundersPerIP[\s\S]*?Date[\s\S]*?getElementsByTagName[\s\S]*?insertBefore/')` to reproduce.

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

![pa](https://github.com/AdguardTeam/AdguardFilters/assets/58900598/9dc35953-2b1b-43e7-82d9-1c6051932de3)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
