### PR TITLE
Fix #180517 www.wetter.com

### DIFF
--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -4257,6 +4257,13 @@ popularmechanics.com#?#section > div[class*=" "]:has(> div[class]:first-child + 
 veranda.com,wetter.com#?#div[class^="sc-"]:has(> div.ad-container)
 wetter.com#?#.som-wrapper:has(> div[data-slotname])
 wetter.com#?#.clickperformance-wrapper:has(> .ad-flex)
+wetter.com#?#.mbanner-fixed:remove()
+wetter.com#$#.mbanner-is-fixed { top: 0px !important; padding-top: 0px !important; }
+wetter.com#$##main-header-fixable { top: 0px !important; }
+wetter.com#?#div.ad-container:remove()
+wetter.com#?#div:has(> div#div-gpt-ad-wetter_direct_toolbar):remove()
+wetter.com#$#body > header > div { padding-top: 0px !important }
+wetter.com#$#body > header > div > div { top: 0px !important; padding-top: 0px !important }
 housebeautiful.com#?#section > div[class*="css-"]:has(> div#gpt-ad-vertical-bottom)
 express.co.uk#$?##taboola-mid-article-thumbnails-outstream { remove: true; }
 express.co.uk#$?#div[data-type="article-body"] .text-description > div { remove: true; }

--- a/MobileFilter/sections/specific_web.txt
+++ b/MobileFilter/sections/specific_web.txt
@@ -4255,13 +4255,12 @@ elle.com,elledecor.com,runnersworld.com#?#div[class*="css-"]:has(> div.ad-contai
 tmailweb.com#?#.row > div[class^="col-"]:has(> div.d-none > ins.adsbygoogle)
 popularmechanics.com#?#section > div[class*=" "]:has(> div[class]:first-child + .ad-container:last-child)
 veranda.com,wetter.com#?#div[class^="sc-"]:has(> div.ad-container)
-wetter.com#?#.som-wrapper:has(> div[data-slotname])
-wetter.com#?#.clickperformance-wrapper:has(> .ad-flex)
-wetter.com#?#.mbanner-fixed:remove()
+wetter.com##.som-wrapper
+wetter.com##.clickperformance-wrapper
+wetter.com##.mbanner-fixed
 wetter.com#$#.mbanner-is-fixed { top: 0px !important; padding-top: 0px !important; }
 wetter.com#$##main-header-fixable { top: 0px !important; }
-wetter.com#?#div.ad-container:remove()
-wetter.com#?#div:has(> div#div-gpt-ad-wetter_direct_toolbar):remove()
+wetter.com##div:has(> div#div-gpt-ad-wetter_direct_toolbar)
 wetter.com#$#body > header > div { padding-top: 0px !important }
 wetter.com#$#body > header > div > div { top: 0px !important; padding-top: 0px !important }
 housebeautiful.com#?#section > div[class*="css-"]:has(> div#gpt-ad-vertical-bottom)


### PR DESCRIPTION
#180517

1. Could not reproduce empty spaces from the original bug report: they seem to be fixed already by:
```
MobileFilter/sections/specific_web.txt:4258:wetter.com#?#.som-wrapper:has(> div[data-slotname])
MobileFilter/sections/specific_web.txt:4259:wetter.com#?#.clickperformance-wrapper:has(> .ad-flex)
```
2. Removed the banners from the page header and fixed the shifted layout after removing them.
