### PR TITLE
Remove block on User Generated Content on modrinth.com (reverts d804900)

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -352,8 +352,6 @@ clickndownload.*##html > div[style^="position: fixed;"]
 redd.tube##.banner-juicy-desktop
 growdiaries.com##.header_add
 growdiaries.com##.cpm_item > .adv-visibility + a[target="_blank"] > img
-modrinth.com##.markdown-body > p:last-of-type > a > img
-||wsrv.nl/?url=https%3A%2F%2Ftr7zw.dev%2Fimg%2Fshockbyte_black.png$domain=modrinth.com
 kingstreamz.lol,mylivestream.pro###openLinks
 namify.tech##.suggestion-rows .suggestion__namify-partner
 namify.tech##[class*="gtm-banner-"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Add your comment and screenshots

Adguard's job isn't to block user-generated content in ways that affect far too much content. [d804900](https://github.com/AdguardTeam/AdguardFilters/commit/d80490047b571045015a62b26eb57c722f9a621c) was reverted upstream as of [44f2e0e](https://github.com/uBlockOrigin/uAssets/commit/44f2e0eeb3480d0eff468668d8bf287f34d17df2).

This change was made far too hastily, without any testing prior to the change being committed. Further testing is needed for changes like these to actually be implemented, as breaking pages mainly consisting of UGC like this is generally not a great idea.

Alongside this, I expect some sort of extra testing to be done going forward. Testing this change on a few mod pages would've been good enough to see that it breaks far too much.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
