### PR TITLE
Fix 181428 www.uol.com.br

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -635,8 +635,10 @@ prepp.in#%#//scriptlet('trusted-set-cookie', 'ldCookie', 'closed')
 gocomics.com##.amu-container-alert
 uol.com.br,elperiodicoextremadura.com,laopiniondemalaga.es#$?#body > div.tp-modal:has(> div.tp-iframe-wrapper > iframe[id^="offer_"]) { display: none !important; }
 uol.com.br,elperiodicoextremadura.com,laopiniondemalaga.es#$#.tp-backdrop { display: none !important; }
-uol.com.br,elperiodicoextremadura.com,laopiniondemalaga.es#$#html > body[class] { overflow: auto !important; touch-action: auto !important; height: auto !important; }
 uol.com.br,elperiodicoextremadura.com,laopiniondemalaga.es#$#html { overflow: auto !important; touch-action: auto !important; }
+uol.com.br#$#html > body[class]:not([class^="amp-"]) { overflow: auto !important; touch-action: auto !important; height: auto !important; }
+uol.com.br#$#html > body[class^="amp-"] { overflow: auto !important; touch-action: auto !important; }
+elperiodicoextremadura.com,laopiniondemalaga.es#$#html > body[class] { overflow: auto !important; touch-action: auto !important; height: auto !important; }
 laopiniondemalaga.es###fmegaPiano
 ytv.co.jp##.delivery_bnr
 browserling.com##.welcome-back


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/181428

The problem was `height: auto;` style in the rule: `uol.com.br,elperiodicoextremadura.com,laopiniondemalaga.es#$#html > body[class] { overflow: auto !important; touch-action: auto !important; height: auto !important; }`

<img width="1277" alt="image" src="https://github.com/AdguardTeam/AdguardFilters/assets/108522804/04dc0527-8cb4-415d-aba2-bc763b0c3580">
