### PR TITLE
Fix #181507 www.patee.ru

### DIFF
--- a/CyrillicFilters/RussianFilter/sections/specific.txt
+++ b/CyrillicFilters/RussianFilter/sections/specific.txt
@@ -227,6 +227,8 @@ comandir.com#?##dle-content > noindex:has(> div.hblock > div[id*="ScriptRoot"])
 muz-tv.ru##.x-popup-ad-short
 marieclaire.ru##.article__block_type-productSet
 pc.ru##div[class^="advert_"]
+patee.ru##div:has(> .yandex-rtb)
+patee.ru##.yandex-rtb
 hen-tay.com#?#td > table:has(> tbody > tr > td:contains(/Реклама|Порно игра|Партнёры/))
 hen-tay.com#?#tbody > tr:has(> td > noindex > div[align="center"] > a > img[src^="/go/"])
 hen-tay.com#?#.news > div[align="center"]:has(> a[href*=".php"] > img)


### PR DESCRIPTION
Fix #181507

two rules for the desktop and mobile version
Desktop:
<img width="1031" alt="image" src="https://github.com/AdguardTeam/AdguardFilters/assets/108522804/ed1cf0a0-d2b0-422e-a726-dcff3d9cf559">
Mobile:
<img width="1031" alt="image" src="https://github.com/AdguardTeam/AdguardFilters/assets/108522804/7b34e2a5-eb88-40dd-8a9a-8684bb760c05">
