### PR TITLE
VK track params

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -237,9 +237,9 @@
 ||gillian-guide.github.io^$removeparam=ref
 ! https://github.com/AdguardTeam/AdguardFilters/issues/166436
 ||pcmag.com^$removeparam=taid
-! VKontakte trackers. There are multiple domains like vk.com and vk.ru
-||vk.*$removeparam=trackcode
-||vk.*$removeparam=recom
+! VKontakte
+$removeparam=trackcode,domain=vk.com|vk.ru
+$removeparam=recom,domain=vk.com|vk.ru
 ! https://github.com/AdguardTeam/AdguardFilters/issues/166382
 ||vkplay.ru$removeparam=_1ld
 ||vkplay.ru$removeparam=_1lp

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -237,6 +237,9 @@
 ||gillian-guide.github.io^$removeparam=ref
 ! https://github.com/AdguardTeam/AdguardFilters/issues/166436
 ||pcmag.com^$removeparam=taid
+! VKontakte trackers. There are multiple domains like vk.com and vk.ru
+||vk.*$removeparam=trackcode
+||vk.*$removeparam=recom
 ! https://github.com/AdguardTeam/AdguardFilters/issues/166382
 ||vkplay.ru$removeparam=_1ld
 ||vkplay.ru$removeparam=_1lp


### PR DESCRIPTION
# VK track params

Adds VK track params removal: `trackcode` and `recom`. 
There are multiple VK domains, like `vk.com` and `vk.ru`. 
These trackers appear in links like at `https://vk.com/groups`  
Tested by myself.

## Prerequisites

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [X] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
