### PR TITLE
add adocean, nonli and aquaplatform ad trackers

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -1237,6 +1237,9 @@ serve.everydayporn.co^
 ! To fix the issue with the CNAME trackers, add problematic domains here:
 ! https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/exclusions.txt
 !
+! Adocean : adocean.pl disguised advertising networks
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/adocean.txt
+!
 ! AdSpyglass : 0i0i0i0.com disguised advertising networks
 ||dappaa.site^
 ||spinna.xyz^
@@ -1255,6 +1258,9 @@ serve.everydayporn.co^
 ||tjaard11.xyz^
 ||dappab.site^
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/adspyglass.txt
+!
+! Aquaplatform : aquaplatform.com disguised advertising networks
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/aquaplatform.txt
 !
 ! ahacdn.me : cdn18685953.ahacdn.me disguised advertising networks
 ||freshalldaynews.com^
@@ -1321,6 +1327,9 @@ serve.everydayporn.co^
 ||exoclick.com^
 ||bizonads-ssp.com^
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/namesilo.txt
+!
+! nonli.com : nonli.com disguised advertising networks
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/nonli_com.txt
 !
 ! PopCash : popcashjs.b-cdn.net disguised advertising networks
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/popcash.txt


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/cname-trackers/issues/98