### PR TITLE
nicovideo.jp track parameter

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -1554,12 +1554,18 @@ $removeparam=igshid,domain=instagram.com|threads.net
 ! NicoNico (nicovideo.jp)
 ! Keep subdomain
 $removeparam=from,domain=anime.nicovideo.jp|dic.nicovideo.jp
-||commons.nicovideo.jp^$removeparam=transit_from
+||nicovideo.jp^$removeparam=transit_from
+||nicovideo.jp^$removeparam=transit_type
+||nicovideo.jp^$removeparam=rf
+||nicovideo.jp^$removeparam=rp
+||nicovideo.jp^$removeparam=ra
+||nicovideo.jp^$removeparam=rd
 ||live.nicovideo.jp^$removeparam=ch_anime_ref
-||seiga.nicovideo.jp^$removeparam=track
+||manga.nicovideo.jp^$removeparam=track
 ||sp.nicovideo.jp^$removeparam=ss_id
 ||sp.nicovideo.jp^$removeparam=ss_pos
 ||sp.nicovideo.jp^$removeparam=cp_in
+||sp.nicovideo.jp^$removeparam=cnt_transit
 ||nicovideo.jp^$removeparam=news_ref
 ||nicovideo.jp^$removeparam=cmnhd_ref
 ||nicovideo.jp^$removeparam=ref


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

N/A

### Add your comment and screenshots

**Changes due to this pull request** 

1. Add tracking parameters after site renewal.

2. Add the missing tracking parameters for sp.nicovideo.jp.

the First:

transition_type,transition_id,rp,rf,ra,rd
Reproduction procedures:
1. Access `https://www.nicovideo.jp/watch/sm37943946` 
2. Mouse over the blue band with ▶.
3. Get the following link.
`https://www.nicovideo.jp/watch/sm43160347?playlist=eyJ0eXBlIjoic2VyaWVzIiwiY29udGV4dCI6eyJzZXJpZXNJZCI6MTg1NzIxfX0&transition_type=series&transition_id=185721&rf=nvpc&rp=watch&ra=series&rd=first`

track
domain changed. seiga.nicovideo.jp -> manga.nicovideo.jp.

the Second:

cnt_transit
Reproduction procedures:
1. Access `https://x.com/ducedayo/status/1820440208590225870`
2. Get the following link.
`https://sp.nicovideo.jp/watch/sm30916712?ss_id=8dd66c51-163b-4b9a-b867-459fd92bebbe&ss_pos=9&cp_in=wt_srch&cnt_transit=suggest`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
