### PR TITLE
block another pattern of server-side GTM

### DIFF
--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -9,7 +9,7 @@
 !+ NOT_PLATFORM(ios, ext_safari)
 /\/\/([0-9a-z]+\.){1,}[0-9a-z]+\.[a-z]{2,}\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
 !+ PLATFORM(ios, ext_safari)
-/\/\/([0-9a-z]+\.)?[0-9a-z]+\.[0-9a-z]+\.[a-z][a-z]+\/[a-z]{8}\.js\?st=[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]+$/$~third-party,match-case
+/\/\/([0-9a-z]+\.)?([0-9a-z]+\.)?[0-9a-z]+\.[0-9a-z]+\.[a-z][a-z]+\/[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]\.js\?st=[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]+$/$~third-party,match-case
 ! https://github.com/uBlockOrigin/uAssets/issues/9932
 ! ex. https://bitdomain.biz/n06eaqkwkq2d/T6wYzHxHWWzfs/6OWki/4i2D4u/ZIQb2nQkaXSF/cVkUc+zmqKYvfudx/SGqzLxv38jdl/yltwxPN+erfWRFS/LQUKf1hC7dE/t3YI on bitdomain.biz
 /\/[a-z0-9]{12}\/[a-zA-Z0-9\/\+\-]{97,106}$/$match-case,script,~third-party

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -9,7 +9,7 @@
 !+ NOT_PLATFORM(ios, ext_safari)
 /\/\/([0-9a-z]+\.){1,}[0-9a-z]+\.[a-z]{2,}\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
 !+ PLATFORM(ios, ext_safari)
-/\/\/([0-9a-z]+\.)?[0-9a-z]+\.[0-9a-z]+\.[a-z][a-z]+\/[a-z]{8}\.js\?st=[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]$/$script,~third-party,match-case
+/\/\/([0-9a-z]+\.)?[0-9a-z]+\.[0-9a-z]+\.[a-z][a-z]+\/[a-z]{8}\.js\?st=[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]+$/$~third-party,match-case
 ! https://github.com/uBlockOrigin/uAssets/issues/9932
 ! ex. https://bitdomain.biz/n06eaqkwkq2d/T6wYzHxHWWzfs/6OWki/4i2D4u/ZIQb2nQkaXSF/cVkUc+zmqKYvfudx/SGqzLxv38jdl/yltwxPN+erfWRFS/LQUKf1hC7dE/t3YI on bitdomain.biz
 /\/[a-z0-9]{12}\/[a-zA-Z0-9\/\+\-]{97,106}$/$match-case,script,~third-party

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -6,7 +6,10 @@
 !
 !
 ! server-side GTM pattern B ex. https://sgtm.tagmanageritalia.it/kxacofiy.js?st=MK7842
-/\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
+!+ NOT_PLATFORM(ios, ext_safari)
+/\/\/([0-9a-z]+\.){1,}[0-9a-z]+\.[a-z]{2,}\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
+!+ PLATFORM(ios, ext_safari)
+/\/\/([0-9a-z]+\.)?[0-9a-z]+\.[0-9a-z]+\.[a-z][a-z]+\/[a-z]{8}\.js\?st=[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]$/$script,~third-party,match-case
 ! https://github.com/uBlockOrigin/uAssets/issues/9932
 ! ex. https://bitdomain.biz/n06eaqkwkq2d/T6wYzHxHWWzfs/6OWki/4i2D4u/ZIQb2nQkaXSF/cVkUc+zmqKYvfudx/SGqzLxv38jdl/yltwxPN+erfWRFS/LQUKf1hC7dE/t3YI on bitdomain.biz
 /\/[a-z0-9]{12}\/[a-zA-Z0-9\/\+\-]{97,106}$/$match-case,script,~third-party

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -6,7 +6,7 @@
 !
 !
 ! server-side GTM pattern B ex. https://sgtm.tagmanageritalia.it/kxacofiy.js?st=MK7842
-/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
+/\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
 ! https://github.com/uBlockOrigin/uAssets/issues/9932
 ! ex. https://bitdomain.biz/n06eaqkwkq2d/T6wYzHxHWWzfs/6OWki/4i2D4u/ZIQb2nQkaXSF/cVkUc+zmqKYvfudx/SGqzLxv38jdl/yltwxPN+erfWRFS/LQUKf1hC7dE/t3YI on bitdomain.biz
 /\/[a-z0-9]{12}\/[a-zA-Z0-9\/\+\-]{97,106}$/$match-case,script,~third-party

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -5,7 +5,7 @@
 ! Bad: .org/ads/$domain=example.org (for instance, should be in speficic.txt)
 !
 !
-! server-side GTM pattern B ex. https://sgtm.tagmanageritalia.it/kxacofiy.js?st=MK7842
+! server-side GTM pattern B ex. https://load.ss.esade.edu/ykpgwaiz.js?st=5V4W3ZR
 !+ NOT_PLATFORM(ios, ext_safari)
 /\/\/([0-9a-z]+\.){1,}[0-9a-z]+\.[a-z]{2,}\/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
 !+ PLATFORM(ios, ext_safari)

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -5,6 +5,8 @@
 ! Bad: .org/ads/$domain=example.org (for instance, should be in speficic.txt)
 !
 !
+! server-side GTM pattern B ex. https://sgtm.tagmanageritalia.it/kxacofiy.js?st=MK7842
+/[a-z]{8}\.js\?st=[0-9A-Z]{6,8}$/$script,~third-party,match-case
 ! https://github.com/uBlockOrigin/uAssets/issues/9932
 ! ex. https://bitdomain.biz/n06eaqkwkq2d/T6wYzHxHWWzfs/6OWki/4i2D4u/ZIQb2nQkaXSF/cVkUc+zmqKYvfudx/SGqzLxv38jdl/yltwxPN+erfWRFS/LQUKf1hC7dE/t3YI on bitdomain.biz
 /\/[a-z0-9]{12}\/[a-zA-Z0-9\/\+\-]{97,106}$/$match-case,script,~third-party


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/commit/6f2058b21f0363d91bb0bab7e52378d2632f4fe6

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

0. **DO NOT** upload screenshots with sexually explicit material on GitHub directly.\
 Instead, upload it to a third-party image hosting and post the link to it without preview (!) here.\
 Also, mention if the link leads to NSFW content;

1. Your comment

Other than `?id=GTM-`, `.js?st=` is used. Ofc we can't add such a generic rule (false positive example `https://www.languefrancaise.net/dev6/pub/pmwiki-utils.js?st=1723143120`) and unfortunately, there seems to be no common subdomain like `://gtm`. We have to use regex to block them.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
