### PR TITLE
Fix #185821 novayagazeta.ru

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -54,6 +54,7 @@ armidaleexpress.com.au,bendigoadvertiser.com.au,canberratimes.com.au,centralwest
 !
 ! SECTION: Subscriptions - Regular rules
 !
+novayagazeta.ru###mainNode > div:has(> a[href="/landing/email"])
 journal.tinkoff.ru##div[class^="_container_"]:has(> div[data-is-fullsize="true"] input[type="email"])
 hdmotori.it###modal
 deadlock.one##div[id="block-b5subtheme-social"]

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -2172,6 +2172,9 @@ subbota.ua##aside.sidebar > div[id^="custom_html-"]
 !   NOTE: Donation widgets
 !   Really annoying only
 !
+novayagazeta.ru###mainNode > div[style="padding-top: 5px;"]:has(> a[href^="https://supportnovaya.club/"])
+novayagazeta.ru###article-body div[style="height: 100px;"]:has(> div[style="left: 15px; width: 400px; height: 100px;"])
+novayagazeta.ru###article-body div:has(> div > p > span > a[href="mailto:donate@novayagazeta.ru"])
 motherjones.com##section[id^="mj-article-bottom-membership"]
 gigazine.net##div[id^="donate"]
 spokesman.com##article > aside[class]:has(div.give-butter iframe[title="Give Butter Donations"])


### PR DESCRIPTION
Fix #185821 novayagazeta.ru

1. Попап внизу страницы, на красном фоне с текстом «Давайте оставаться на связи». Появляется секунд через 30, наверное ещё надо в конец страницы промотать. Ведёт на страницу с предложением подписаться на email-рассылку.
```adblock
novayagazeta.ru###mainNode > div:has(> a[href="/landing/email"])
```
2. При промотке вниз, вверху страницы, sticky попап с текстом «Стать соучастником».
```adblock
novayagazeta.ru###mainNode > div[style="padding-top: 5px;"]:has(> a[href^="https://supportnovaya.club/"])
```
3. В середине статьи блок на всю высотку экрана с просьбой о донате.
```adblock
novayagazeta.ru###article-body div[style="height: 100px;"]:has(> div[style="left: 15px; width: 400px; height: 100px;"])
```
4. В конце статьи блок на всю высотку экрана с просьбой о донате.
```adblock
novayagazeta.ru###article-body div:has(> div > p > span > a[href="mailto:donate@novayagazeta.ru"])
```