### PR TITLE
Fix #186979 open.spotify.com

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -119,6 +119,7 @@ eztv.unblocked.sh,animeshow.tv,vidzi.tv##body > div[id][style*="position: fixed"
 !
 ! Spotify - https://github.com/AdguardTeam/AdguardFilters/issues/10050
 ! https://github.com/AdguardTeam/AdguardFilters/issues/186979
+!+ NOT_PLATFORM(ext_chromium, ext_ff)
 ||media-us.amillionads.com/*.mp3$media,redirect=noopmp4-1s,domain=spotify.com
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||media-us.amillionads.com/*.mp3$domain=open.spotify.com
@@ -126,7 +127,9 @@ eztv.unblocked.sh,animeshow.tv,vidzi.tv##body > div[id][style*="position: fixed"
 ||audio-*.scdn.co/audio/$media,redirect=noopmp4-1s,domain=spotify.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/171225
 ! https://github.com/AdguardTeam/AdguardFilters/issues/165079
+!+ NOT_PLATFORM(ext_chromium, ext_ff)
 ||creativeservice-production.scdn.co/mp3-ad/*.mp3$media,~xmlhttprequest,redirect=noopmp4-1s,domain=spotify.com
+!+ NOT_PLATFORM(ext_chromium, ext_ff)
 ||audio-ak*-spotify-com.akamaized.net/audio/$media,~xmlhttprequest,redirect=noopmp4-1s,domain=spotify.com
 ! https://github.com/AdguardTeam/AdguardForWindows/issues/3087
 ||audio-*.scdn.co/audio/$media,redirect=noopmp4-1s,app=Spotify.exe


### PR DESCRIPTION
*TODO*: after relase the version with fix of `$redirect` rules, remove `!+ NOT_PLATFORM(ext_chromium, ext_ff)` hints in Spotify rules group or revert PR.

https://github.com/AdguardTeam/AdguardBrowserExtension/issues/2913