### PR TITLE
Update AGLint to v2.0.10

### DIFF
--- a/.aglintrc.yaml
+++ b/.aglintrc.yaml
@@ -4,3 +4,9 @@ extends:
   - aglint:recommended
 syntax:
   - AdGuard
+rules:
+  no-excluded-rules:
+    - error
+    - regexp-patterns:
+        # Do not forget to escape special regex characters
+        - staff-start\.com\/js\/track\/

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -48,6 +48,7 @@ $cookie=_awl;maxAge=30,domain=nypost.com|al.com|9news.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/152328
 ||securepubads.g.doubleclick.net/tag/js/gpt.js$script,redirect=googletagservices-gpt,domain=~golf.com|~today.line.me|~inmuebles24.com|~inside.com.tw|~investing.com|~olx.com.eg|~eksisozluk.com|~heycar.co.uk|~gizmodo.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/152079
+! aglint-disable-next-line no-excluded-rules
 !||staff-start.com/js/track/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/187274
 ! Breaks search on shopping.yahoo.co.jp

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "*.md": "markdownlint"
     },
     "devDependencies": {
-        "@adguard/aglint": "^2.0.9",
+        "@adguard/aglint": "2.0.10",
         "husky": "^9.1.5",
         "lint-staged": "^15.2.10",
         "markdownlint": "^0.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adguard/aglint@^2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@adguard/aglint/-/aglint-2.0.9.tgz#2082b12107dd2090102a72d64d8397a09f5e98d0"
-  integrity sha512-1xnQdGNwk6xb9m8YyxbaMLbSTQ59tehlwv7P92O7MqIMFLoLJy70HPrx3JOTj+GRrSNQOuJFHJnl7LVvF7pyUw==
+"@adguard/aglint@2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@adguard/aglint/-/aglint-2.0.10.tgz#5d1ef8c3934eed896ef32dcbb385d27f5fd292ce"
+  integrity sha512-gv04PUw0M9sPYbdiN5HIc4paBNvPbKpOEKmXJplcU0F5/k2vYREVwrtKS8YvezbSOGR4cUL/AjVsqiY4O8SjfQ==
   dependencies:
     "@adguard/agtree" "^1.1.8"
     "@inquirer/checkbox" "^1.3.7"
@@ -918,16 +918,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -954,14 +945,7 @@ string-width@^7.0.0:
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This update allows you to ban certain rules based on regex, for more details please refer to https://github.com/AdguardTeam/AGLint?tab=readme-ov-file#no-excluded-rules

Exclude also works for comments. I added an example requested by Yuki in the AGLint issue: https://github.com/AdguardTeam/AGLint/issues/214

If you want to ban some patterns, just edit `.aglintrc.yaml` accordingly.