### PR TITLE
Updated `$permissions` rules

### DIFF
--- a/SpywareFilter/sections/general_extensions.txt
+++ b/SpywareFilter/sections/general_extensions.txt
@@ -403,17 +403,25 @@ accountkiller.com#%#window.ga = function(){var a = arguments[5];a&&a.hitCallback
 !
 ! Suppressing Google's "Protected" Audience API:
 ! https://wicg.github.io/turtledove/
-! TODO: Add a scriptlet: https://github.com/AdguardTeam/Scriptlets/issues/395
+! https://github.com/AdguardTeam/Scriptlets/issues/395
+#%#//scriptlet('no-protected-audience')
 !
+!#if (!ext_ublock)
 ! Suppressing both Google's Topics API and Topics API using Permissions policy
-! Works in CoreLibs-based AdGuard versions, the browser extension waits for https://github.com/AdguardTeam/tsurlfilter/issues/66
-! Part with "://*.*" before "$permissions=" is required, otherwise it will be marked as too wide rule
 ! AGLint temporarily disabled for this rule due to https://github.com/AdguardTeam/AGLint/issues/191
 ! TODO: Enable it back when AGLint is fixed.
-! TODO: remove $document modifier after versions with Corelibs 1.14.38+ will be released
-!#if (!ext_ublock)
 ! aglint-disable-next-line
-://*.*$document,permissions=join-ad-interest-group=()\,run-ad-auction=()\,browsing-topics=()
+*$permissions=join-ad-interest-group=()
+! aglint-disable-next-line
+*$permissions=run-ad-auction=()
+! aglint-disable-next-line
+*$permissions=browsing-topics=()
+!
+! Suppressing Private State Token API
+! aglint-disable-next-line
+*$permissions=private-state-token-issuance=()
+! aglint-disable-next-line
+*$permissions=private-state-token-redemption=()
 !#endif
 !
 ! End: Rules for Google "Privacy" Sandbox

--- a/SpywareFilter/sections/general_extensions.txt
+++ b/SpywareFilter/sections/general_extensions.txt
@@ -411,17 +411,17 @@ accountkiller.com#%#window.ga = function(){var a = arguments[5];a&&a.hitCallback
 ! AGLint temporarily disabled for this rule due to https://github.com/AdguardTeam/AGLint/issues/191
 ! TODO: Enable it back when AGLint is fixed.
 ! aglint-disable-next-line
-*$permissions=join-ad-interest-group=()
+/*/$permissions=join-ad-interest-group=()
 ! aglint-disable-next-line
-*$permissions=run-ad-auction=()
+/*/$permissions=run-ad-auction=()
 ! aglint-disable-next-line
-*$permissions=browsing-topics=()
+/*/$permissions=browsing-topics=()
 !
 ! Suppressing Private State Token API
 ! aglint-disable-next-line
-*$permissions=private-state-token-issuance=()
+/*/$permissions=private-state-token-issuance=()
 ! aglint-disable-next-line
-*$permissions=private-state-token-redemption=()
+/*/$permissions=private-state-token-redemption=()
 !#endif
 !
 ! End: Rules for Google "Privacy" Sandbox


### PR DESCRIPTION
- added `Suppressing Google's "Protected" Audience API` https://github.com/AdguardTeam/Scriptlets/issues/395
- added `Suppressing Private State Token API` https://github.com/AdguardTeam/AdguardFilters/issues/175725
- changed `Suppressing both Google's Topics API and Topics API using Permissions policy` (related to `TODO: remove $document modifier after versions with Corelibs 1.14.38+ will be released`)
