### PR TITLE
Update AGLint to v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "*.md": "markdownlint"
     },
     "devDependencies": {
-        "@adguard/aglint": "2.1.0",
+        "@adguard/aglint": "2.1.1",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "markdownlint": "^0.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adguard/aglint@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@adguard/aglint/-/aglint-2.1.0.tgz#ecbc7067fecabd49586e630e242d1116f1c0515a"
-  integrity sha512-SjXAlufcen/Mp10X/UtFMeGBjJQEP5IPgAjVTGffhyAbii87yXiz98EBjCUbQ4h8TlO6VCzAgw9PPd+xX94Wkw==
+"@adguard/aglint@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@adguard/aglint/-/aglint-2.1.1.tgz#f5b582e0f0048ebeff864cf3a01d23eb4ea97087"
+  integrity sha512-Q7c7A9obUcIhmxG7b1iWHahAZ/rhdg/G+1AWDy3wzKrWfWLdnMSLj1Zd26cOAjmNMwsblldWw2HuDc+Kbvt66Q==
   dependencies:
     "@adguard/agtree" "^2.0.2"
     "@adguard/ecss-tree" "^1.1.0"
@@ -903,16 +903,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -939,14 +930,7 @@ string-width@^7.0.0:
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Added support of `ext_chromium_mv3` as a known platform for `PLATFORM` and `NOT_PLATFORM` hints  - https://github.com/AdguardTeam/AGLint/issues/220