### PR TITLE
Remove filter for "useful" content at ebay.*

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -388,7 +388,6 @@ $xmlhttprequest,third-party,denyallow=fastlycdn.com|doodcdn.co|intensedebate.com
 !
 ! NOTE: Specific rules
 !
-ebay.*##.x-rx-slot
 sunderlandecho.com###first-sticky-group
 sunderlandecho.com##.taboola-bottomfeed
 sunderlandecho.com##div[id^="leaderboard"]

--- a/UsefulAdsFilter/sections/usefulads.txt
+++ b/UsefulAdsFilter/sections/usefulads.txt
@@ -226,7 +226,6 @@ ebay.co.uk,ebay.com,ebay.com.au#@?#.mfe-lex:-abp-has(h2:-abp-contains(sponsored)
 ebay.de#@?#.srp-list > .s-item:has(> div > .s-item__info > a > div[style="display:flex;"] span[role="text"] > span:contains(A) ~ span:contains(N) ~ span:contains(Z))
 ebay.com,ebay.co.uk,ebay.com.au#@?#div[itemtype="https://schema.org/Product"] div[id^="merch_html_"]:has(> div[id] .mfe-header > h2.mfe-pull-left:contains(Sponsored))
 ebay.com,ebay.co.uk,ebay.com.au#@?#div[itemtype="https://schema.org/Product"] div[id^="merch_html_"]:has(> div[id] h2.mfe-card-group-title:contains(sponsored))
-ebay.*#@#.x-rx-slot
 !
 ! aliexpress.com
 aliexpress.com#@#.search-item-card-wrapper-list:has( > div:only-child > div:only-child > a + div[class*="multi"])


### PR DESCRIPTION
Issue #192475 was addressed by @BlazDT in https://github.com/AdguardTeam/AdguardFilters/commit/167a7b0f6659ee9500d9fa53c23963d09bf1e472. That commit:

- adds anti-adblock entries (thank you!!)

but also

- adds a filter for the unwanted content that I was targeting
- adds a "usefulads" exclusion for the same content

Since many users probably enjoy using the "similar items" and "you may also like..." sections, this should NOT be the default behaviour.

For that reason, this PR removes the filter rule and its "usefulads" counterpart. The anti-adblock component was all that was required to solve the original issue.