### PR TITLE
Fix for httpstatus.io

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -267,7 +267,6 @@ nanjpride.blog.jp##div[class^="article-outer"] > div.recommend:has(> div.ninja-r
 ||microsoft.com/etc.clientlibs/microsoft/clientlibs/exp-analytics/
 ||cdn.mrkhub.com/sks/js/sks_track.js
 ||edit-document.com/click-event/
-||httpstatus.io/analytics/script.js
 ||memonotepad.com/js/modules/google-analytics-bundle.js
 ||support.microsoft.com/*/ms.analytics-web-*.min.js
 ||affine.pro/*/track-link.*.js


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

The script being blocked makes the site (https://httpstatus.io/) unable to function - specifically "Check status" on home page. The problematic filter is removed in this pull request.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
