### PR TITLE
Add greylabeldelivery.com, Stape and WeCanTrack

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -4092,6 +4092,7 @@
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/trackers/commanders-act.txt
 !
 ! Content Ignite : greylabeldelivery.com disguised trackers
+||tccd.douglas.
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/refs/heads/master/data/trackers/content-ignite.txt
 !
 ! Criteo : dnsdelegation.io disguised trackers

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -4091,6 +4091,9 @@
 ||commandersact.com^$third-party
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/trackers/commanders-act.txt
 !
+! Content Ignite : greylabeldelivery.com disguised trackers
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/refs/heads/master/data/trackers/content-ignite.txt
+!
 ! Criteo : dnsdelegation.io disguised trackers
 ||storetail.io^
 ||dnsdelegation.io^
@@ -4210,6 +4213,11 @@
 ||trekkww.fun^
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/trackers/redtrack.txt
 !
+! Stape : stape.net disguised trackers
+.stape.net
+||load.gtm.
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/refs/heads/master/data/trackers/stape.txt
+!
 ! TraceDock : *.eu-central-1.elb.amazonaws.com disguised trackers
 ! not included
 !
@@ -4225,13 +4233,15 @@
 ||webtrekk.net^$third-party
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/trackers/webtrekk.txt
 !
+! Wecantrack : wecantrack.com disguised trackers
+!#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/refs/heads/master/data/trackers/wecantrack.txt
+!
 ! Wizaly : wizaly.com disguised trackers
 ||wizaly.com^
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/trackers/wizaly.txt
 !
 ! Rule for detecting hidden trackers when the main domain cannot be blocked.
 ||d1udjti6mtxz9q.cloudfront.net^$third-party
-.stape.net
 !
 ! NOTE: CNAME disguised tracking networks end ⬆️
 ! !SECTION: CNAME disguised tracking networks

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -4216,7 +4216,11 @@
 !
 ! Stape : stape.net disguised trackers
 .stape.net
-||load.gtm.
+|load.gtm.
+|load.sgtm.
+|load.ss.
+|load.sst.
+||thegreatesthits.
 !#include https://raw.githubusercontent.com/AdguardTeam/cname-trackers/refs/heads/master/data/trackers/stape.txt
 !
 ! TraceDock : *.eu-central-1.elb.amazonaws.com disguised trackers


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/cname-trackers/issues/105
