### PR TITLE
Fix #197556 ozlosleep.com

### DIFF
--- a/SpywareFilter/sections/cookies_general.txt
+++ b/SpywareFilter/sections/cookies_general.txt
@@ -6,6 +6,9 @@
 ! Bad:  ||example.com^$cookie=flat_r_mb (should be in cookies_specific.txt)
 !
 !
+! Shopify
+! https://www.shopify.com/legal/cookies
+$cookie=_shopify_y
 ! Cox Media Group.
 $cookie=uniqueCMGVisitor
 ! blueconic

--- a/SpywareFilter/sections/general_url.txt
+++ b/SpywareFilter/sections/general_url.txt
@@ -145,6 +145,8 @@
 ! Cloudflare permormance monitoring
 /cdn-cgi/rum?
 !
+/wpm@*/web-pixel-
+/shopifycloud/media-analytics/v*/analytics.js
 /shopifycloud/shopify/assets/shop_events_listener-*.js
 /wp-content/plugins/pixelyoursite/*
 /xhr/api/v2/collector

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -67,6 +67,8 @@
 !
 !
 !
+||identitypxl.app^
+||identitypxl.com^
 ||geotags.refinery89.com^
 ||logg9r.io^
 ||api.statsig.com^


### PR DESCRIPTION
## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/197556

### Add your comment and screenshots

I'm not sure if `/wpm@*/web-pixel-` is too generic?

`identitypxl` is used in some other sites: https://publicwww.com/websites/%22identitypxl%22/

I can't reproduce any `audiencelab` connections.

Cookie `_shopify_y` is used for analytics: https://www.shopify.com/legal/cookies