### PR TITLE
Fix #198137 unas.hu

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_general.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_general.txt
@@ -11,6 +11,7 @@
 !#######################################################
 ! SECTION: Cookies - General element hiding
 !
+##.cookie-alert ~ #exposeMaskOverlay
 ##.idxrcookies-block-user-nav::before
 ##.we-use-cookies
 ##.l-footer-cookie


### PR DESCRIPTION
## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/198137

### Add your comment and screenshots

Looks like the overlay appears in multiple sites (I see many in specific list as well). Should we make it generic and remove duplicated in specific list or should we still make the rule per-site?
