### PR TITLE
Fix #198189 zoechip.cc

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -290,6 +290,9 @@ _ad_content.
 !+ NOT_PLATFORM(ext_safari, ios)
 /tghr.js$script
 !
+/ajax/banners?page=$xmlhttprequest,~third-party
+/ajax/banner/vpn|$xmlhttprequest,~third-party
+/ajax/embed-4/banners|$xmlhttprequest,~third-party
 /in/show/?tag_ab=*&site_id=
 .com/in/multy|$xmlhttprequest,third-party
 &stamat=*&chmob=


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/198189

### Add your comment and screenshots

These banners are used with the same patterns in a lot of streaming sites, for example:

```yml
https://arc018.to/watch-tv/watch-chicago-med-free-39424.10718764
```

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
