### PR TITLE
snapinst.app

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -572,7 +572,7 @@ galwaybayfm.ie##.w-full.relative:has(> span:first-child + div[data-slot]:last-ch
 boyfriendtv.com#%#//scriptlet('prevent-addEventListener', 'click', 'interstitial')
 tradingview.com##div[class^="container-"]:has(> div[class^="ad-"])
 snapinst.app#$#body { overflow: auto !important; }
-snapinst.app###adOverlay
+snapinst.app#$##adOverlay { display: none !important; }
 newshuta.in###SoumyaHelp-Ads
 newshuta.in###BR-Footer-Ads
 westword.com##div[inline-content-billboard]

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -571,6 +571,7 @@ galwaybayfm.ie##div[data-dfp][data-slot][type="doubleclick"]
 galwaybayfm.ie##.w-full.relative:has(> span:first-child + div[data-slot]:last-child)
 boyfriendtv.com#%#//scriptlet('prevent-addEventListener', 'click', 'interstitial')
 tradingview.com##div[class^="container-"]:has(> div[class^="ad-"])
+snapinst.app#$#body { overflow: auto !important; }
 snapinst.app###adOverlay
 newshuta.in###SoumyaHelp-Ads
 newshuta.in###BR-Footer-Ads


### PR DESCRIPTION
Fix scrolling on snapinst.app download page

1. Switch to mobile view
2. Open https://snapinst.app/
3. Paste some link, e.g. https://www.instagram.com/p/DFyBQ4MRPvB (this post contains a lot of pictures)
4. Click on download button
5. Scroll should work on download page

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

none

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
