### PR TITLE
fix: tweakers.net image exception rule too greedy

### DIFF
--- a/DutchFilter/sections/antiadblock.txt
+++ b/DutchFilter/sections/antiadblock.txt
@@ -9,7 +9,7 @@
 !
 ! Prevent AdFender detection
 @@/ad_pics/*$image,domain=computerworld.nl|webwereld.nl
-@@||tweakers.net/i^
+@@||tweakers.net/i^$image
 @@||content.hwigroup.net/images^$domain=hardware.info
 hardware.info,tweakers.net#@#.AdBar
 !


### PR DESCRIPTION
### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

n.a.

### Add your comment and screenshots

1. Your comment

Tweakers is using a fake image url to submit an XHR request, with which they track which 3rd party domains were blocked on the client. This change limits the exception rule for `tweakers.net/i` to image requests only

The fake image url is dynamic and often changes (maybe even on every reload), in the screenshot the image starts with the dictionary name `schools_` but this can also be `material_` or an other dictionary word.

2. Screenshots

<details>

<summary>Request to /i that shows its a xml request not an image:</summary>

![image](https://github.com/user-attachments/assets/f66969b3-6abe-43cc-9e4f-4de8e50584e5)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
