### PR TITLE
feat(tweakers.net): block two tracking requests

### DIFF
--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -96,13 +96,15 @@ security.nl##.banner_leaderboard
 iculture.nl##.ad-top-desktop
 iculture.nl##.feed-ad-wrapper
 ||tweakers.net/*/build/banners.*.js
+||tweakers.net/i^$xhr
+||tweakers.net/ajax/clicks/log^$xhr
+tweakers.net##body .top-banner
+tweakers.net##.video-container > iframe[src^="https://ads.pexi.nl/"]
 vandaaginside.nl##div[class^="a-bannerWrapper-"]
 vandaaginside.nl##div[class^="Component-bannerTopWrapper-"]
 itnijs.frl##.last.widget
 itnijs.frl##.widget-5 > div.banner
 ||itnijs.frl/wp-content/uploads/2017/10/bannerItNijs
-tweakers.net##body .top-banner
-tweakers.net##.video-container > iframe[src^="https://ads.pexi.nl/"]
 spiele.spiegel.de##div[id^="ad-gamepage"]
 kieskeurig.nl##.advertisement
 ad.nl##li[class^="tile tile tile--"]

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -96,8 +96,6 @@ security.nl##.banner_leaderboard
 iculture.nl##.ad-top-desktop
 iculture.nl##.feed-ad-wrapper
 ||tweakers.net/*/build/banners.*.js
-||tweakers.net/i^$xhr
-||tweakers.net/ajax/clicks/log^$xhr
 tweakers.net##body .top-banner
 tweakers.net##.video-container > iframe[src^="https://ads.pexi.nl/"]
 vandaaginside.nl##div[class^="a-bannerWrapper-"]

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1120,6 +1120,8 @@ washingtontimes.com##.piano-in-article-reco
 ||zendesk.com/embeddable_blip?type=analytics&data=
 ||scripts.swifteq.com/hc_events.js
 ||tweakers.nl/track/
+||tweakers.net/i^$xhr
+||tweakers.net/ajax/clicks/log^$xhr
 ||cba24n.com.ar/api/v*/analytics
 ||media-platform.com/common/js/lib/cxense/
 ||fireseo.ru/wp-content/*/jquery.iframetracker.js

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1120,8 +1120,8 @@ washingtontimes.com##.piano-in-article-reco
 ||zendesk.com/embeddable_blip?type=analytics&data=
 ||scripts.swifteq.com/hc_events.js
 ||tweakers.nl/track/
-||tweakers.net/i^$xhr
-||tweakers.net/ajax/clicks/log^$xhr
+||tweakers.net/i^$xmlhttprequest
+||tweakers.net/ajax/clicks/log^$xmlhttprequest
 ||cba24n.com.ar/api/v*/analytics
 ||media-platform.com/common/js/lib/cxense/
 ||fireseo.ru/wp-content/*/jquery.iframetracker.js


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.


### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located


Two changes:

1. Follow up of #198291, adding the rule `||tweakers.net/i^$xhr` blocks the xhr request mentioned in that pr
2. Blocks a click logger

Also grouped all the rules for tweakers.net together. The rule `||tweakers.net/*/build/banners.*.js` might be possible to delete, doesnt seem to be used anymore

<details>

<summary>Click logger request:</summary>

![image](https://github.com/user-attachments/assets/b8f6ef18-e73c-445c-b4b9-4b3955637cbc)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
