### PR TITLE
Fix #198435 nypost.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -495,6 +495,7 @@ reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion#@#.Sid
 !
 ! Add without $third-party, so apps are blocking them too
 !
+||curbminers.com^
 ||punyplant.com^
 ||jubilanttempest.com^
 ||hospitablehat.com^


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/198435

I can't reproduce, so I just added the admiral domain here.