### PR TITLE
Fix #198205 giornaledibrescia.it

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -1181,9 +1181,8 @@ sexkbj.top#%#//scriptlet('set-constant', 'cRAds', 'true')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/196894#event-16047513542
 ||tripstraveltips.com/wp-content/uploads/ccdfea/aabacb.
 @@||static.doubleclick.net/instream/ad_status.js$domain=thesciencetoday.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/198205
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197118
-giornaledibrescia.it,moovitapp.com#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
+moovitapp.com#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/196992
 1xanimes.in#$##pbt { display: none !important; }
 1xanimes.in#$#body { overflow: auto !important; }

--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -1181,8 +1181,9 @@ sexkbj.top#%#//scriptlet('set-constant', 'cRAds', 'true')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/196894#event-16047513542
 ||tripstraveltips.com/wp-content/uploads/ccdfea/aabacb.
 @@||static.doubleclick.net/instream/ad_status.js$domain=thesciencetoday.com
+! https://github.com/AdguardTeam/AdguardFilters/issues/198205
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197118
-moovitapp.com#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
+giornaledibrescia.it,moovitapp.com#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/196992
 1xanimes.in#$##pbt { display: none !important; }
 1xanimes.in#$#body { overflow: auto !important; }

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -4747,6 +4747,8 @@ smellyfisher.com##.providers
 bestmovie.it,treccani.it##.gmp
 forum.fibra.click##.FibraClickAds-fake-poststream-item
 open.online##a[rel="sponsored"]
+! https://github.com/AdguardTeam/AdguardFilters/issues/198205
+giornaledibrescia.it#%#//scriptlet('prevent-fetch', 'www3.doubleclick.net')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/198176
 nerdevil.it##.afxshop
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197648


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/198205

Caused by DNS blocking.