### PR TITLE
Fix #198856 diariovasco.com

### DIFF
--- a/SpanishFilter/sections/specific.txt
+++ b/SpanishFilter/sections/specific.txt
@@ -861,7 +861,7 @@ lanacion.com.ar##.lay-container > aside.ln-aside
 ||abola.pt/Scripts/videojs.ads.min.js
 sapo.pt##.fugly-ads
 sapo.pt##.spnsr
-ideal.es,leonoticias.com,eldiariomontanes.es,lasprovincias.es,laverdad.es,elcomercio.es,diariosur.es,elcorreo.com,hoy.es##.v-adv
+diariovasco.com,ideal.es,leonoticias.com,eldiariomontanes.es,lasprovincias.es,laverdad.es,elcomercio.es,diariosur.es,elcorreo.com,hoy.es##.v-adv
 brothersdoaz.com.br##.chw-widget
 elperiodico.cat##.following-ad-parent
 elperiodico.cat##body .following-ad-container

--- a/SpywareFilter/sections/cookies_specific.txt
+++ b/SpywareFilter/sections/cookies_specific.txt
@@ -501,7 +501,8 @@ $cookie=tint-anonymous-uid,domain=leichtathletik.de
 ||lemurov.net^$cookie=flat_r_mb
 ||21buttons.com^$cookie=21b.user.generated.id
 $cookie=vocuser_uuid,domain=ideal.es|elcorreo.com
-$cookie=ev_sid,domain=ideal.es|elcorreo.com
+$cookie=ev_sid,domain=ideal.es|elcorreo.com|diariovasco.com
+$cookie=ev_did,domain=diariovasco.com
 ||joyn.de^$cookie=trackingSessionId
 ||tf1.fr^$cookie=atidvisitor
 ||tf1.fr^$cookie=ABTastySession


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/198856

There are also tracking cookies `ev_sid` and `ev_did`