### PR TITLE
Block AS CNAME servers

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -19,6 +19,10 @@
 ! /asset/jquery/slim-3.2.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 !
 !
+! AS CNAME ex. https://www.47206262.xyz/script/jmty.jp.js
+/^https:\/\/www\.\d{8}\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-]{2,}\.js$/$script,third-party
+!+ PLATFORM(ios, ext_safari)
+/^https:\/\/www\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-][A-Za-z-]+\.js$/$script,third-party
 ! Used on porn sites in players with `flashvars`
 /player/html.php?aid=*&video_id=*&referer=
 ! Scum

--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -19,10 +19,6 @@
 ! /asset/jquery/slim-3.2.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 !
 !
-! AS CNAME ex. https://www.47206262.xyz/script/jmty.jp.js
-/^https:\/\/www\.\d{8}\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-]{2,}\.js$/$script,third-party
-!+ PLATFORM(ios, ext_safari)
-/^https:\/\/www\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-][A-Za-z-]+\.js$/$script,third-party
 ! Used on porn sites in players with `flashvars`
 /player/html.php?aid=*&video_id=*&referer=
 ! Scum

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -38,6 +38,10 @@ triblive.com###storyContent > div[data-type="float"][data-stn-player]
 !##################
 !
 ! START: Ad-Shield ad reinsertion
+! ad-shield.cc CNAME ex. https://www.47206262.xyz/script/jmty.jp.js
+/^https:\/\/www\.\d{8}\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-]{2,}\.js$/$script,third-party
+!+ PLATFORM(ios, ext_safari)
+/^https:\/\/www\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]\.xyz\/script\/[0-9A-Za-z.-]+\.[A-Za-z-][A-Za-z-]+\.js$/$script,third-party
 ! For all platforms including iOS
 ||html-load.com/loader.min.js$domain=nikkansports.com|j-cast.com|picksandparlays.net|ranking.net
 ||ad-shield.cc^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://github.com/AdguardTeam/AdguardFilters/issues/197087

### Add your comment and screenshots


**Warning:** Please remove personal information before uploading screenshots!

1. Your comment

Unfortunately, `https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/ads/ad-shield.txt` is not catching up their changes. uBO has been using a regex for a while ([initial commit](https://github.com/uBlockOrigin/uAssets/commit/a2de6614f0aa68eb6bfb62037bfd5245185d61e1)) which successfully blocked them on `bbs.animanch.com` (mobile-only) yesterday, but at the time AG failed ([fixed](https://github.com/AdguardTeam/AdguardFilters/commit/224db4f958c47fba75e18603e44683ce40302242) already). I think in practice the form in this PR is enough which is safer and thus can omit `$header` in the uBO rule.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
