### PR TITLE
Fix #199880 meistertask.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -2853,7 +2853,7 @@ noicompriamoauto.it#%#//scriptlet('trusted-click-element', 'button[data-qa-selec
 campbellsci.com#$#.modal-backdrop { display: none !important; }
 campbellsci.com#$#.modal[aria-labelledby="cookieSettingsModalLabel"] { display: none !important; }
 campbellsci.com#$#body { overflow: auto !important; padding-right: 0 !important; }
-meisterlabs.com###cb-wrapper
+meistertask.com,meisterlabs.com###cb-wrapper
 [$path=/app/consent]volksfreund.de#%#//scriptlet('trusted-click-element', '#consentAccept', '', '500')
 langeek.co#%#//scriptlet('set-cookie', 'accepted-cookie-consent', '1')
 cbom.atozmath.com###consentframe


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/199880

There's a script which I'm not sure if it's tracker or not:

```yml
https://cdn.mida.so/js/optimize.js?key=7ZnlPekbRGXmQBXVD180j3&v=20250226
```

which creates the cookie `optimize_uuid`.

This service is used in other sites too: https://publicwww.com/websites/%22mida.so%2Fjs%2Foptimize.js%22/ . Looks like it's an A/B testing platform service so I don't know if we should address it in ATP or not. If yes, may be we can add these rules?

```adb
||cdn.mida.so/js/optimize.js
$cookie=optimize_uuid
```