### PR TITLE
Fix #200389 koloshop.cz

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_general.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_general.txt
@@ -1672,6 +1672,7 @@
 !
 ! SECTION: Cookies - General URL
 !
+||cookies.pro-idea.cz^
 ||cookies.praguebest.cz^
 /gd-cookie.js
 ||consenttool.haendlerbund.de^


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/200389

It's also used in other sites: https://publicwww.com/websites/%22cookies.pro-idea.cz%22/