### PR TITLE
Fix #200739 1tamilmv.ms

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -296,6 +296,7 @@ _ad_content.
 !+ NOT_PLATFORM(ext_safari, ios)
 /tghr.js$script
 !
+/aclib.js^$script
 /embed-1/ajax/e-1/banners|$xmlhttprequest
 /in/show/?tag_ab=*&site_id=
 .com/in/multy|$xmlhttprequest,third-party


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/200739

I can't exactly reproduce user's screenshot, but I saw an unblocked Adcash request. As far as I see, this rule works on uBO for a while without false positives.