### PR TITLE
Fix #200830 dontpad.com

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -656,7 +656,6 @@ anime4i.vip##div[class^="container-ads-"]
 economist.com##.adComponent
 independent.co.uk###main > div[class]:has(> div > div > a[href^="https://tv.apple.com/"])
 samplette.io##div[id^="pw-"][id$="-leaderboard"]
-||dontpad.com/scripts/ads.js
 linkedin.com##iframe[componentkey="MynetworkDesktopNav_mynetwork_desktop_nav_ad"]
 rule34video.com##.columns > div.panel_header:has(> a[href="https://theporndude.com/"])
 dorsetecho.co.uk##.mar-leaderboard--top


### PR DESCRIPTION
Reproduced with only base filter.
I've deleted a rule ||dontpad.com/scripts/ads.js
Left a cookie notice rule dontpad.com,myownconference.pl##.cookie-body looks like now should work fine
