### PR TITLE
Fix #200920 baku.ws 

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -9,6 +9,7 @@
 !
 !
 !
+||newmedia.az^$third-party
 ||glum-mortgage.com^
 ||shocking-honey.com^
 ||ogaku.site^

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -1027,6 +1027,9 @@ avtosfer.az##.bnr0
 ||avtosfer.az/upload/banner/
 valyuta.com###bannerInvest
 ||baku.ws/banners
+||baku.ws/images/banners/
+baku.ws#$#.main-container > div.main-left:has(> div.main-slider) { width: 100% !important; }
+baku.ws##.main-container > div.main-right:has(> div.right-bnr:only-child)
 az.baku.ws##.main_top_banners
 az.baku.ws##.bottom_banner
 baku.ws##.ban_mac

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -710,7 +710,6 @@ auto.am##.azd-top
 ##.ainsyndication
 az##.makerekframe
 !
-||newmedia.az
 xeberle.com##.momizat-ads
 xeberle.com##.header-right a[target="_blank"]
 ||azpolitika.info/images/bnrs/Security_Operation_Services.gif

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -972,6 +972,7 @@ sportinfo.az##.craiBanner
 ||emlak.az/images/banners/
 ||dashinmazemlak.az/images/banner
 ||digital.newmedia.az/web/web_page_2.html
+||newmedia.az/nativebanner/get_ads.js
 qan.az##div[style="text-align: center"] > b > br+b+a[href^="http://qan.az/chat/simaz/go.php?id="]
 ||bizplus.az/wp-content/themes/Newsmag-child/banners/
 bizplus.az##.td_block_widget > a[href^="https://goo.gl/"] > img

--- a/BaseFilter/sections/foreign.txt
+++ b/BaseFilter/sections/foreign.txt
@@ -710,6 +710,7 @@ auto.am##.azd-top
 ##.ainsyndication
 az##.makerekframe
 !
+||newmedia.az
 xeberle.com##.momizat-ads
 xeberle.com##.header-right a[target="_blank"]
 ||azpolitika.info/images/bnrs/Security_Operation_Services.gif
@@ -972,7 +973,6 @@ sportinfo.az##.craiBanner
 ||emlak.az/images/banners/
 ||dashinmazemlak.az/images/banner
 ||digital.newmedia.az/web/web_page_2.html
-||newmedia.az/nativebanner/get_ads.js
 qan.az##div[style="text-align: center"] > b > br+b+a[href^="http://qan.az/chat/simaz/go.php?id="]
 ||bizplus.az/wp-content/themes/Newsmag-child/banners/
 bizplus.az##.td_block_widget > a[href^="https://goo.gl/"] > img

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -96,6 +96,7 @@ hatarako.net##div[class^="SnsButton"]
 jo-katsu.com##.single-sns-box
 career-ch.com##.banner_add_LINE
 hobbyhall.fi###product-share
+baku.ws##.social-media-banner
 lebonlogiciel.com##.box-network
 musee-pla.com##.wrap_share_btn
 shopstaff.jp##.mb-8.mt-6

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -1253,6 +1253,7 @@ gmx.com##div[data-mod-name="taboolateasers"]
 ||api.cian.ru/browser-telemetry/v*/send-stats/
 ||api.cian.ru/ebc-analytics/
 ||c-rings.net^$script,third-party
+||static.read.tools/stats.min.js^$third-party
 ||go.techtarget.com/clicktrack-r/
 ||api.earthly.dev/analytics|
 ||earthly.dev/blog/assets/js/analytics.js

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -80,6 +80,7 @@ $cookie=_awl;maxAge=30,domain=nypost.com|al.com|9news.com
 !
 ! NOTE: Specific rules
 !
+||static.read.tools/stats.min.js
 ||api.diffchecker.com/external/mixpanel/user-properties|
 ||hltv.org/js/ht.manual.js
 ||hltv.org/ht/event|
@@ -1253,7 +1254,6 @@ gmx.com##div[data-mod-name="taboolateasers"]
 ||api.cian.ru/browser-telemetry/v*/send-stats/
 ||api.cian.ru/ebc-analytics/
 ||c-rings.net^$script,third-party
-||static.read.tools/stats.min.js^$third-party
 ||go.techtarget.com/clicktrack-r/
 ||api.earthly.dev/analytics|
 ||earthly.dev/blog/assets/js/analytics.js


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/200920
removed the banner, removed the social media banner, and stretched the element on the main page to eliminate the empty space