### PR TITLE
Fix #201457 webdramaturkey.net

### DIFF
--- a/TurkishFilter/sections/general_extensions.txt
+++ b/TurkishFilter/sections/general_extensions.txt
@@ -62,9 +62,10 @@ mislink3.com#%#//scriptlet('trusted-replace-node-text', 'script', 'saniye--', 'v
 yeppuu.com#%#//scriptlet('abort-on-property-write', 'openRandomUrl')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/167825
 pllsfored.com#%#//scriptlet("set-constant", "window.config.adv", "emptyObj")
+! https://github.com/AdguardTeam/AdguardFilters/issues/201457
 ! https://github.com/AdguardTeam/AdguardFilters/issues/165655
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197202
-webdramaturkey.net,afroditscans.com#%#//scriptlet("abort-on-property-read", "openPopup")
+webdramaturkey.*,afroditscans.com#%#//scriptlet("abort-on-property-read", "openPopup")
 ! https://github.com/uBlockOrigin/uAssets/issues/19921
 dizipia.com#%#//scriptlet('abort-on-property-write', 'popURL')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/161599
@@ -242,10 +243,10 @@ mackolik.com,sahadan.com#%#setTimeout ("HideFloatAdBanner()", 1000);
 !------- CSS fixes --------------------!
 !--------------------------------------!
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/201457
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197202
-webdramaturkey.net#$#.container { margin-top: 0px !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/182860
-webdramaturkey.com#$#body > .container { margin-top: 0 !important; }
+webdramaturkey.*#$#body > .container { margin-top: 0 !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/182795
 dizikorea.*#$#.wrapper { margin-top: 0 !important; }
 ! https://github.com/AdguardTeam/AdguardFilters/issues/182537

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -467,7 +467,7 @@ softonic.com.tr##.black-friday-ads
 sinefy3.com##.bg-cover-faker > div:not([class]):not([id]) > center
 ||storage.oyungezer.com.tr/ogz-public/ads/
 ||webdramaturkey.com/*/*.mp4
-animeizlesene.com,webdramaturkey.com##.ads-embed
+animeizlesene.com,webdramaturkey.*##.ads-embed
 ntv.com.tr#?#.slick-track > div.slick-slide > div > div.ntv-main-slider-item:has(> a[href^="http://pubads.g.doubleclick.net/"])
 ntv.com.tr#?#.slick-track > div.slick-slide > div > li.ntv-main-slider-pagination-item:has(> a[href^="http://pubads.g.doubleclick.net/"])
 /^https:\/\/www\.donanimhaber\.com\/images\/images\/[a-z_-]+[0-9]+x[0-9]+(_|-)/$domain=donanimhaber.com


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/201457

They change to `webdramaturkey.org` now.

Related issue: https://github.com/AdguardTeam/AdguardFilters/issues/197202