### PR TITLE
Fix #203187 seattletimes.com

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -12110,7 +12110,6 @@ cumilf.com##.visibility
 ||exe.io/files/shazme.js
 ||s3.amazonaws.com^$domain=game3rb.com
 srt.am##.text-center > center > a[target="_blank"] > img
-washingtonpost.com##wp-ad[class]
 washingtonpost.com##main > aside.grid-item > div[style="height: 1250px;"]
 theverge.com,washingtonpost.com##.outbrain-wrapper
 hentaitoday.com##.widget_random_banner_widget


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/203187

Related issue: https://github.com/AdguardTeam/AdguardFilters/issues/41292

Looks like the rule is obsolete now?