### PR TITLE
Fix sotavision.world

### DIFF
--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -1219,7 +1219,6 @@ global.honda##.p-post22__sns-list
 mediafire.com##.dl-utility-nav li:has(> a#shareButton)
 nagasaki-np.co.jp##.div_sns_share
 komonews.com,cbs12.com##div[class^="GallerySocialIcons"]
-new-reporter.com##.tdb_single_post_share + .td_block_separator
 solasto-career.com##div[class^="css-"] > div[class^="css-"]:has(> div > p > button.react-share__ShareButton)
 kino.tricolor.tv##.film-share
 militarywatchmagazine.com##.row > div.d-flex:has(> span.share-network-facebook)
@@ -3632,7 +3631,6 @@ sunporno.com##.sharesBlogger
 hisubway.online##button[onclick^="navigator.share"]
 androidworld.be##button[onclick^="window.open("][onclick*="/share"]
 chainsawman.dog##.l-header__sns
-odigital.sapo.pt##.tdb_single_post_share + .td_block_separator
 eco.sapo.pt##.meta__block ul.social
 eco.sapo.pt##.meta__share-link
 trackmusik.fr##.bShare > span
@@ -7318,8 +7316,8 @@ wsu.edu##.spine-share-tab
 cian.ru##div[data-name="SharingButton"]
 focus.ua##.yo-social-panel
 easyspeak.ru##.right_soc_block
-erocafe.net,newhotgames.com,pravda.if.ua,root-nation.com,odnaminyta.com##.tdb_single_post_share
-newhotgames.com,pravda.if.ua##.tdb_single_post_share + div.td_block_separator
+sotavision.world,erocafe.net,newhotgames.com,pravda.if.ua,root-nation.com,odnaminyta.com##.tdb_single_post_share
+sotavision.world,new-reporter.com,odigital.sapo.pt,newhotgames.com,pravda.if.ua##.tdb_single_post_share + .td_block_separator
 m.mistrzowie.org##.mmg_facebook_share
 player-smotri.mail.ru##div[class*="ShareButtonWrapper-"]
 chelny-izvest.ru##.page-main__details-share


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [x] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

https://sotavision.world/k-55-godam-kolonii-prigovorili-chetveryh-zhurnalistov-obvinyaemyh-v-uchastii-v-ekstremistskom-fbk/

### Add your comment and screenshots

1. Your comment

share button leftovers

2. Screenshots

<details><summary>Screenshot 1:</summary>

![image](https://github.com/user-attachments/assets/d62edea9-4059-4462-850b-485dca1c2106)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
