### PR TITLE
Cleanup obsolete generic cosmetic-filters

### DIFF
--- a/BaseFilter/sections/general_elemhide.txt
+++ b/BaseFilter/sections/general_elemhide.txt
@@ -55,8 +55,6 @@
 !+ NOT_OPTIMIZED
 ##.button-ad
 !+ NOT_OPTIMIZED
-##div[id^="ads300_250-widget-"]
-!+ NOT_OPTIMIZED
 ##.adWrapper
 !+ NOT_OPTIMIZED
 ##.center-ad
@@ -226,10 +224,6 @@
 ##.home-ad-region-1
 !+ NOT_OPTIMIZED
 ##.sidebar-big-box-ad
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-top
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-bottom
 !+ NOT_OPTIMIZED
 ###ad-after
 !+ NOT_OPTIMIZED

--- a/BaseFilter/sections/general_elemhide.txt
+++ b/BaseFilter/sections/general_elemhide.txt
@@ -436,7 +436,6 @@
 ##.video-brs
 ##a[href^="http://click.dtiserv2.com/"]
 ##div[data-e2e="advertisement"]
-##a[href^="https://join3.bannedsextapes.com/track/"]
 ##.puFloatLine > #puFloatDiv
 ##a[href*=".ufinkln.com/"]
 ##body > #overover[style="position:fixed;width:100%;height:100%;background:silver;z-index: 2;opacity: 0.1;"]

--- a/BaseFilter/sections/general_elemhide.txt
+++ b/BaseFilter/sections/general_elemhide.txt
@@ -231,20 +231,6 @@
 !+ NOT_OPTIMIZED
 ##.commercial-unit-mobile-bottom
 !+ NOT_OPTIMIZED
-###atvcap + #tvcap > .mnr-c > .commercial-unit-mobile-top
-!+ NOT_OPTIMIZED
-###taw > .med + div > #tvcap > .mnr-c:not(.qs-ic) > .commercial-unit-mobile-top
-!+ NOT_OPTIMIZED
-###topstuff > #tads
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-top .jackpot-main-content-container > .UpgKEd + .nZZLFc > .vci
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-top .jackpot-main-content-container > .UpgKEd + .nZZLFc > div > .vci
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-top > .v7hl4d
-!+ NOT_OPTIMIZED
-##.commercial-unit-mobile-top > div[data-pla="1"]
-!+ NOT_OPTIMIZED
 ###ad-after
 !+ NOT_OPTIMIZED
 ###ad-p3

--- a/BaseFilter/sections/general_elemhide.txt
+++ b/BaseFilter/sections/general_elemhide.txt
@@ -455,7 +455,6 @@
 ###ad_google
 ###advertRightTopPosition
 ###banner-top-right
-###bannerfloat22
 ###bb_banner
 ###blox-top-promo
 ###bp_banner
@@ -469,7 +468,6 @@
 ##.SC_TBlock
 ##.ad_register_prompt
 ##.ad_showthread_firstpost_start_placeholder
-##.adheader403
 ##.b-header-banner
 ##.baners_block
 ##.banner_header
@@ -489,6 +487,3 @@
 ##.top-r-ads
 ##.topbannerad
 ##.widget-sidebar-right-banner
-##a[href*="//sub2.bubblesmedia.ru/"]
-##a[href^="http://softexcellence.com/"]
-##img[title^="advertisement"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
