### PR TITLE
redirect xhr of adsbygoogle.js by default

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -7,6 +7,9 @@
 ! Good: @@/adblocker/detect.js$domain=example.org
 ! Bad: ||ad.doubleclick.net^ (should be in adservers.txt)
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/204150
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect=googlesyndication-adsbygoogle
+!
 ! .pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links is often used as a bait
 #$#.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }
 !


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/204119
https://github.com/AdguardTeam/AdguardFilters/issues/204150
(though doesn't work on iOS)

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
