### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Each line defines file patterns and the corresponding owners (preceded by '@')
+
+.aglintrc.yaml               @Alex-302 @scripthunter7 @slavaleleka
+.github/workflows/*          @Alex-302 @scripthunter7 @slavaleleka
+.github/dependabot.yml       @Alex-302 @scripthunter7 @slavaleleka
+.husky/*                     @Alex-302 @scripthunter7 @slavaleleka
+.markdownlint.json           @Alex-302 @scripthunter7 @slavaleleka
+.markdownlintignore          @Alex-302 @scripthunter7 @slavaleleka
+.vscode/*                    @Alex-302 @scripthunter7 @slavaleleka
+package.json                 @Alex-302 @scripthunter7 @slavaleleka
+yarn.lock                    @Alex-302 @scripthunter7 @slavaleleka

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,9 @@ updates:
     schedule:
       # No need to check for updates more often than once a month
       interval: monthly
-    reviewers:
-      - Alex-302
-      - scripthunter7
 
   # Maintain dependencies for NPM - typically AGLint updates
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
-    reviewers:
-      - Alex-302
-      - scripthunter7


### PR DESCRIPTION
Dependabot will remove the `reviewers` field on May 27, as its logic duplicates the functionality of the `CODEOWNERS` file.
See the following comment as an example: https://github.com/AdguardTeam/AdguardFilters/pull/205157#issuecomment-2871164239

This PR adds a `CODEOWNERS` file to the repository, which specifies which person/team is responsible for which files. If a PR modifies any of the files listed in this file, GitHub will automatically add the designated person/team as a reviewer to the PR.

Btw, if we add the following line:

```codeowners
*.txt @AdguardTeam/filters-maintainers
```

it means that any changes affecting filters must be reviewed by someone from the filter maintainers team.

Related docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
