### PR TITLE
Fix AdGuardTeam#207788 tiermaker.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/antiadblock.txt
+++ b/AnnoyancesFilter/Popups/sections/antiadblock.txt
@@ -4195,6 +4195,7 @@ pornone.com#@#.overheaderbanner
 @@||yorkshirepost.co.uk^$generichide
 ||piano.io/api/tinypass.min.js$domain=hobbyconsolas.com|computerhoy.com|businessinsider.es|snrec.jp|thehindu.com|australiangeographic.com.au
 sanalkurs.net###toast-container > .toast-error[aria-live="assertive"]
+tiermaker.com##div.fEy1Z2XT
 !#safari_cb_affinity
 !#endif
 ! NOTE: The rules for content blockers only end ⬆️


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

This update removes the anti-adblocker popup on TierMaker, restoring full access to the site for users with AdGuard enabled.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Enter the issue address

This one : <https://github.com/AdguardTeam/AdguardFilters/issues/207788>

### Add your comment and screenshots

1. Your comment

The filter I added targets the div with the class "fEy1Z2XT" which corresponds to the anti-adblocker popup on TierMaker and removes its display. As a result, the website becomes fully functional even with an AdGuard enabled.

2. Screenshots

<details>

<summary>Screenshot 1 (before):</summary>

![Capture d'écran 2025-06-18 203218](https://github.com/user-attachments/assets/24e7c3ea-93cd-4639-819e-1bcc9d4a1771)

</details>

<details>

<summary>Screenshot 2 (after):</summary>

![Capture d'écran 2025-06-18 205725](https://github.com/user-attachments/assets/aa5aebff-6d77-452e-ab36-6b4e97858cab)

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
