### PR TITLE
Fix htrace.wetvinfo.com

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -1927,6 +1927,7 @@
 ||host*.rvshare.com^
 ||host*.rigbyandpeller.com^
 ||hstats*.hepsiburada.com^
+||htrace.wetvinfo.com^
 ||huffingtonpost.fr/px.gif^
 ||hummingbird.mavencoalition.io^
 ||hwa.his.huawei.com^


### PR DESCRIPTION
Tencent QQ will send POST requests to `https://htrace.wetvinfo.com/kv`, which looks like tracking. After blocking it, no abnormal behavior of the application was found.

![Picture](https://github.com/user-attachments/assets/9ce361bb-1c20-4581-8948-e45aa5c00ddb)
