### PR TITLE
Remove false positive tracking.trackchecker.net

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -172,7 +172,6 @@ dlsdk.appsflyer.com^
 ||usdiagnosis.icocofun.com^
 ||eats-ads-event-capture.coupang.com^
 ||trackchecker.ru/stat/
-||tracking.trackchecker.net^
 ||googletagmanager.com^$app=app.shinagawa.listentonovels.androidApp
 ||mon*-misc.fqnovel.com^
 ||clientlog.perfectworldgames.com^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fixes [209068](https://github.com/AdguardTeam/AdguardFilters/issues/209068)

### Add your comment and screenshots

1. Your comment

В [списке](https://github.com/AdguardTeam/AdguardFilters/commit/1686f1e4e28d0851a61925ffd66c748156cb98fc) от 1 июля появился домен tracking.trackchecker.net. Этот домен использует приложение TrackChecker для трекинга посылок (package tracking), не для аналитики. После блокировки этого домена у пользователей перестали отслеживаться трек-номера на некоторых почтовых службах (Почта России, DHL и т.п.), которые отслеживаются через этот сервер.

2. Screenshots

Скриншотов нет - приложение не получает ответа от сервера и соответственно не получает обновления событий у трек-номера.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
