### PR TITLE
Maintenance: Remove non-removeparam rules from URL tracking param filter

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -104,8 +104,6 @@ $removeparam=sms_uph
 $removeparam=ttclid
 ! spot.im
 $removeparam=spot_im_redirect_source
-! WordPress Visitor Statistics plugin
-$cookie=_wp_visitor
 ! tracker.my.com
 $removeparam=mt_link_id
 ! https://github.com/AdguardTeam/AdguardFilters/issues/164394

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -783,8 +783,6 @@ $removeparam=from,domain=doujinnomori.com|shinshi-manga.net|echiman.com|dojin-na
 ||controld.com^$removeparam=cid
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-8455734
 ?ref=upstract.com^$removeparam=ref
-! https://github.com/AdguardTeam/AdguardFilters/issues/172125
-||prothomalo.com^$cookie=uuid_v2
 ! Wargaming tracking
 ||track.wargaming-aff.com/click?pid=$removeparam=ref_id
 ||trck.wargaming.net^$removeparam
@@ -1255,8 +1253,6 @@ $removeparam=newsstand,domain=sportalkorea.com
 ||bild.de^$removeparam=t_ref
 ! https://github.com/AdguardTeam/AdguardFilters/issues/152218
 ||simplelogin.io^$removeparam=slref
-! https://github.com/AdguardTeam/AdguardFilters/issues/152313
-||applesfera.com^$cookie=NID
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151756
 ||pravda.com.ua^$removeparam=pageviewCount
 ! https://github.com/AdguardTeam/AdguardFilters/pull/152161
@@ -1488,9 +1484,6 @@ $removeparam=ici,domain=shein.co.uk|shein.com
 ||cinematoday.jp^$removeparam=g_clk
 ! affiliate links on h7-game.com (nsfw)
 $removeparam=afid,domain=123chat.jp|kanochat.jp|live.fc2.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/136734
-||investing.com^$cookie=smd
-||investing.com^$cookie=udid
 ! https://github.com/AdguardTeam/AdguardFilters/pull/137576
 ||basketballking.jp^$removeparam=cx_art
 ! https://github.com/AdguardTeam/AdguardFilters/issues/136987
@@ -1703,9 +1696,6 @@ $removeparam=clid,domain=adguard-vpn.*|adguardvpn-help.*
 ||mirtesen.ru^$removeparam=ad
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-2381922
 $removeparam=oref,domain=defenseone.com|govexec.com|nextgov.com|route-fifty.com
-! https://github.com/AdguardTeam/AdguardFilters/issues/123160
-||whistleout.com.au^$cookie=ARRAffinity
-||whistleout.com.au^$cookie=ARRAffinitySameSite
 ! https://github.com/AdguardTeam/AdguardFilters/issues/123340
 ||rac.co.uk^$removeparam=cid
 ! https://github.com/AdguardTeam/AdguardFilters/pull/122979


### PR DESCRIPTION
The URL tracking parameters filter has rules in it that do not remove any tracking parameters, i.e., they don't have a `removeparam` modifier. I noticed this while writing a parser for the [compiled list](https://github.com/AdguardTeam/FiltersRegistry/blob/master/filters/filter_17_TrackParam/filter.txt).

This PR removes these unnecessary rules. I'm pretty sure I got all of them. I just ran `:v/\(^!\|removeparam\)/d` in Vim, and cleaned it up after.

This doesn't have a corresponding issue.

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
