### PR TITLE
Fix #211021

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_allowlist.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_allowlist.txt
@@ -12,6 +12,8 @@
 !+ NOT_OPTIMIZED PLATFORM(windows, mac, android)
 ||geolocation.onetrust.com/cookieconsentpub/*/geo/location$xmlhttprequest,redirect-rule=noopjson
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/211021
+user.huami.com#@#.gdpr-container:not(#style_important)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/210977
 @@||app.usercentrics.eu/browser-ui/$domain=meineschufa.de
 @@||api.usercentrics.eu/settings/$domain=meineschufa.de


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Fixes https://github.com/AdguardTeam/AdguardFilters/issues/211021

This line in the general cookie filters prevents the page linked in the issue from being displayed.

https://github.com/AdguardTeam/AdguardFilters/blob/5ad0e19fe090d52c31bd1536f3338947807b45d2/AnnoyancesFilter/Cookies/sections/cookies_general.txt#L234

This PR adds an exception for `user.huami.com` for this filter.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
