### PR TITLE
Fix websites using Intercom chat widget

### DIFF
--- a/.aglintrc.yaml
+++ b/.aglintrc.yaml
@@ -20,6 +20,8 @@ rules:
     - regexp-patterns:
         # Do not forget to escape special regex characters
         #
+        # Breaks websites that use Intercom chat widget
+        - ^\|\|api-iam\.intercom\.io\/messenger\/web\/ping$
         # Breaks adding Yahoo account in email clients
         - ^\|\|udc.yahoo.com\^$
         # https://github.com/AdguardTeam/AdguardFilters/issues/188783#issuecomment-2359649738


### PR DESCRIPTION
Blocking `api-iam.intercom.io/messenger/web/ping` will cause the websites not able to use Intercom chat widgets.

Related issue threads:

- https://github.com/AdguardTeam/AdguardFilters/issues/212300
- https://github.com/AdguardTeam/AdguardFilters/issues/212295
- https://github.com/AdguardTeam/AdguardFilters/issues/212246
- https://github.com/uBlockOrigin/uAssets/issues/29376
- https://github.com/uBlockOrigin/uAssets/pull/27339

I'm not sure if we still plan to add it to Annoyances Widgets list?