### PR TITLE
Fix #214868 求人ボックス.com

### DIFF
--- a/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
+++ b/AnnoyancesFilter/MobileApp/sections/mobile-app_specific.txt
@@ -504,6 +504,7 @@ savefrom.net##.smart-app-br-body
 savefrom.net##.sf-apk-promo
 ||xn--pckua2a7gp15o89zb.com/bundles/kyujinboxweb/pc/img/top/banner_app.jpg
 xn--pckua2a7gp15o89zb.com##div[class^="p-home_"][class$="p-top_special"]
+xn--pckua2a7gp15o89zb.com##.p-resultArea_sideWrap--appbnr
 sp.manga.nicovideo.jp##div.fixed.bottom-2
 hinatazaka46.com,businessinsider.com,sakurazaka46.com##.app-button
 hangikredi.com##div[class*="bg-bannerLeftGradient"]
@@ -3746,6 +3747,7 @@ m.vkvideo.ru#%#//scriptlet('trusted-set-cookie', 'remixvideo_mvk_first_session_p
 m.vkvideo.ru##div[class*="OpenInAppPromoButton_"]
 foxtrot.com.ua##.mobile-app-header-info-banner
 apnews.com##.HtmlModule[data-gtm-topic="App Download Prompt"]
+xn--pckua2a7gp15o89zb.com##.p-appImgBnr
 ||earth.com/uploads/*/earthsnap-banner-news.webp
 spb.napopravku.ru#$#html { overflow: auto !important; }
 spb.napopravku.ru#$#.bottom-sheet-banner { display: none !important; }

--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -267,6 +267,8 @@ uralairlines.ru##.promo-code-popup
 ||kasegeru.blog.jp/blogframe/contents/content_bestbuy$subdocument
 escharts.com##.x-cloak-hidden[x-on\:show-team-demo-banner\.window]
 escharts.com##.x-cloak-hidden[x-data*="side-banner_team"]
+xn--pckua2a7gp15o89zb.com##a:has(> img[alt="開催中！ 求人ボックス キングオブコント2025 豪華プレゼントが当たるキャンペーン！"])
+xn--pckua2a7gp15o89zb.com#?#[alt*="2025年 オリコン顧客満足度®調査 求人情報サービス 第1位"]:upward(2)
 anglers.jp##.custom_campaign_pr
 360doc.com##.clear360doc > .vipact
 uaa.com###popup_box


### PR DESCRIPTION
  
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?




### Enter the issue address
 
### Add your comment and screenshots

 
<details><summary>screenshot</summary>

![](https://i.slow.pics/njqATh1B.jpg)
 

</details><br/>

`xn--pckua2a7gp15o89zb.com##.p-resultArea_sideWrap--appbnr` is the item shown in the PR screenshot (above the red arrow).
`xn--pckua2a7gp15o89zb.com##.p-appImgBnr` corresponds to Screenshot 3 in the issue.

`xn--pckua2a7gp15o89zb.com##a:has(&gt; img[alt=&quot;開催中！ 求人ボックス キングオブコント2025 豪華プレゼントが当たるキャンペーン！&quot;])` is the banner shown in the issue’s Screenshot 1 and in the PR screenshot (red arrow).
`xn--pckua2a7gp15o89zb.com#?#[alt*=&quot;2025年 オリコン顧客満足度®調査 求人情報サービス 第1位&quot;]:upward(2)` is the banner shown in the issue’s Screenshot 2 and in the PR screenshot (blue arrow).

 

 

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
