### PR TITLE
Add additional Snapchat metrics filters

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -2018,8 +2018,10 @@ nukigazo.com###text-2
 brasil247.com###taboola-mid-article-leia-mais
 ||libcdnjs.com/api/event
 ||api.snapchat.com/web/metrics
+||api-kit.snapchat.com/com.snap.camerakit.v3.Metrics^
 ||snapchat.com/web-analytics
 ||snapchat.com/report-metrics/
+||web.snapchat.com/web-blizzard/web/send^
 ||accounts.snapchat.com/accounts/static/scripts/pixel.js
 ||snap-api.arkoselabs.com/metrics/
 ||zona.plus/ajax/visit-stats


### PR DESCRIPTION
Hi, I was trying to understand how Snapchat communicates with Fiddler, and I found these three telemetry endpoints.


https://web.snapchat.com/web-blizzard/web/send
<img width="626" height="406" alt="Capture d'écran 2025-10-17 204350" src="https://github.com/user-attachments/assets/a0a80f18-8a2a-4e85-b6b3-02287c8bb331" />

https://api-kit.snapchat.com/com.snap.camerakit.v3.Metrics/SetOperationalMetrics
<img width="1422" height="759" alt="image" src="https://github.com/user-attachments/assets/6143e6f4-9a1f-4e2e-b070-d24f1638dc7b" />

https://api-kit.snapchat.com/com.snap.camerakit.v3.Metrics/SetBusinessEvents
<img width="1403" height="172" alt="Capture d'écran 2025-10-17 205037" src="https://github.com/user-attachments/assets/c2eb5f37-654a-4e07-bca7-738a7018804f" />
