### PR TITLE
petbarn.com.au: banners within product listings

### DIFF
--- a/AnnoyancesFilter/Other/sections/self-promo.txt
+++ b/AnnoyancesFilter/Other/sections/self-promo.txt
@@ -5167,3 +5167,6 @@ blog.goo.ne.jp##.navbar__link--bottom
 eiga.com##.header-pure-banner
 !
 ||healthy-vape.shop/user_data/packages/*/img/banner/bnr_debut_gray.png
+
+! Banners within product listings.
+petbarn.com.au##[class^="ProductList"] > [class^="RecommendationBanner"]:upward(1)


### PR DESCRIPTION
### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Removes banners within product listings for `petbarn.com.au`.

#### Original:
<details>
<img width="2806" height="1670" alt="Screenshot 2025-10-21 at 18-16-10 Dog Carriers Petbarn" src="https://github.com/user-attachments/assets/e6a11cde-707e-49f9-8626-06718e838c3f" />
</details>

Note the banner ad presented inline with other product listings.

#### Filtered:
<details>
<img width="2806" height="1670" alt="Screenshot 2025-10-21 at 18-20-36 Dog Carriers Petbarn" src="https://github.com/user-attachments/assets/cc671e0b-b138-4ecb-aeeb-876c4d6bbad1" />
</details>

The banner ads within the product listings are now gone.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met