### PR TITLE
Fix redundancy between mobile.txt and the rest

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -13,7 +13,6 @@
 ||adeventtracker.spotify.com^
 ||do-not-tracker.org^
 ||eviltracker.net^
-||spotify.com/ads/
 ||trackersimulator.org^
 !
 ! https://github.com/AdguardTeam/AdguardForAndroid/issues/908
@@ -267,7 +266,6 @@ dlsdk.appsflyer.com^
 ||gdl.youngle.tech^$app=com.apkpure.aegon
 ||tc.weszxdrf.com^$app=com.apkpure.aegon
 ||ip.chinaz.com^$app=com.apkpure.aegon
-||urbanairship.com^
 ||hz-telemetry.adobe.io^
 ||smartcard.apps.coloros.com^
 ||log-boot.capcutapi.com^$app=com.xt.retouchoversea
@@ -788,7 +786,6 @@ d4?appid*type*
 ||tenant-content.apm.appfolio-analytics.com^
 ||log.avlyun.com^
 ||api-analytics.prod.birdapp.com^
-||mpianalytics.com^
 ||umengjmacs.m.taobao.com^
 ||umengacs.m.taobao.com^
 ||sdk-api-v1.singular.net^
@@ -833,9 +830,6 @@ d4?appid*type*
 ||analytics.snaptube.app^
 ||px.ucweb.com^
 ||adtima-static.zadn.vn^
-||akstat.io^
-||advangelists.com^
-||bfmio.com^
 ||ztevents.zaloapp.com^
 ||log.adtimaserver.vn^
 ||tunion-api.m.taobao.com^
@@ -937,7 +931,6 @@ d4?appid*type*
 ||analytics-tracker.thescore.com^
 ||rosenberg.appmetrica.webvisor.com^
 ||report*.appmetrica.webvisor.com^
-||geoplugin.net^
 ||d.applvn.com^
 ||rt.applvn.com^
 ||api*.moengage.com^

--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -357,7 +357,6 @@ d4?appid*type*
 ||atb-stats-api.imolive.tv^
 ||i.mxplayer.j2inter.com^
 ||allapp.link/*/event
-||flashtalking.com^
 ||stat.weamvideo.com^
 ||log.ultimatecleaner.pro^
 ||impression.link^
@@ -450,8 +449,6 @@ d4?appid*type*
 ||opentelemetry-collector.shared-services.us-east-1.general.prod.wildlife.io^
 ||rabbit.meitustat.com^
 ||mediation.mwmadnetworks.com^
-||xplosion.de^
-||theadex.com^
 ||meitustat.com^
 ||analysis.vesync.com^
 ||insights.zennioptical.com^
@@ -598,7 +595,6 @@ d4?appid*type*
 ||tracking-widget.fillr.com^
 ||api.data-analytics.pokemon.com^
 ||arcspire.io^
-||onthe.io^
 ||t.adx.opera.com^
 ||sensors.snaptube.app^
 ||analytics.kongregate.io^
@@ -838,17 +834,8 @@ d4?appid*type*
 ||px.ucweb.com^
 ||adtima-static.zadn.vn^
 ||akstat.io^
-||chartbeat.net^
 ||advangelists.com^
-||agkn.com^
-||33across.com^
-||cpx.to^
 ||bfmio.com^
-||mathtag.com^
-||w55c.net^
-||bidswitch.net^
-||simpli.fi^
-||getclicky.com^
 ||ztevents.zaloapp.com^
 ||log.adtimaserver.vn^
 ||tunion-api.m.taobao.com^
@@ -938,7 +925,6 @@ d4?appid*type*
 ||rts.mobula.sdk.duapps.com^
 ||aftonbladetnya.sc.omtrdc.net^
 ||omni-ads.omni.news^
-||npario-inc.net^
 ||wzrkt.com^
 ||analytics-events.inshorts.com^
 ||e-ssl.apsalar.com^
@@ -964,8 +950,6 @@ d4?appid*type*
 ||sdk-orion.appboy.com^
 ||api.elysium.opera.com/api/elysium/log_session_events
 ||api.elysium.opera.com/api/elysium/log_session_info
-||pippio.com^
-||io.narrative.io^
 ||loadus.exelator.com^
 ||api.mixpanel.com^
 ||decide.mixpanel.com^
@@ -1021,15 +1005,12 @@ d4?appid*type*
 ||c.bigmir.net^
 ||carfax.sc.omtrdc.net^
 ||cedexis-radar.net^
-||cedexis.com^
 ||clientmetrics-augmentum.kik.com^
 ||clientmetrics.kik.com^
 ||collector.brandify.com^
 ||config2.mparticle.com^
 ||crasheye.cn^
 ||crittercism.com/api/
-||crwdcntrl.net^
-||demdex.net^
 ||dsg.sc.omtrdc.net^
 ||etl.xlmc.sandai.net^
 ||events.lbesecapi.com^
@@ -1040,15 +1021,12 @@ d4?appid*type*
 ||inst.platform.bing.com/api/log
 ||installtracker.com^
 ||invenio_tracking_*.sgnapps.com^
-||krxd.net^
 ||lepodownload.mediatek.com^
 ||log.umsns.com^
-||lp4.io^
 ||m.vk.com/counters.php
 ||m.xiangce.baidu.com/mobileapp/motu-*?guid=
 ||metrics.adflake.com^
 ||metrics.sdkbox.com^
-||mixpanel.com/track
 ||mlb.did.ijinshan.com^
 ||mobile-collector.newrelic.com^
 ||mobile-global.baidu.com/mbrowser/stat/
@@ -1058,13 +1036,11 @@ d4?appid*type*
 ||nativesdks.mparticle.com^
 ||nrc.tapas.net^
 ||online-metrix.net^
-||openstat.net^
 ||pingma.qq.com^
 ||play.googleapis.com/log|
 ||play.googleapis.com/play/log^
 ||prugskh.com^
 ||prugskh.net^
-||quantcount.com^
 ||rc.dxsvr.com^
 ||rlog-api.under9.co^
 ||rlog.9gag.com^
@@ -1084,13 +1060,10 @@ d4?appid*type*
 ||trk.pinterest.com^
 ||tumblr.com/services/cslog
 ||tunein.adswizz.com^
-||upalytics.com^
 ||ups.ksmobile.net^
 ||ws.ksmobile.net^
 ||www-google-analytics.l.google.com^
-||yadro.ru^
 ||ymtracking.com^
-||zdbb.net^
 !
 ! https://github.com/hagezi/dns-blocklists/issues/6060
 -logsdk.kwai-pro.com^
@@ -1151,7 +1124,6 @@ d4?appid*type*
 ||intlsucus.ucweb.com^
 ||adtrack-intl.ucweb.com^
 ||mum.alibabachengdun.com^
-||localytics.com^
 ||upoll.umengcloud.com^
 ||utop.umengcloud.com^
 ! KingRoot

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -3586,7 +3586,7 @@ animespirit.*###CollapsiblePanel_Statistics
 ||fresnel.vimeocdn.com/add/player-test-impression?beacon
 ||exelator.com/pixel.gif
 ||api-js.mixpanel.com/engage/?
-||api-js.mixpanel.com/track/?
+||mixpanel.com/track
 ||try.abtasty.com/*.js$third-party
 ||analytics.*.*/*.php
 ||notebookinfo.de/javascript/*/collector.js
@@ -3867,7 +3867,6 @@ abp?type=js&session$domain=prosieben.de|sat1.de|kabeleins.de|sixx.de|prosiebenma
 ||trtarsiv.com/js/Player/jwTracking.js
 ||histats.com^$domain=avgle.com
 ||google-analytics.com^$domain=avgle.com
-||io.narrative.io/?$third-party
 ||business-key.com/top/$third-party
 ||businessinsider.com/track.gif
 ||bs.yandex.ru/informer/$third-party

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -382,7 +382,7 @@ misterworker.com##.custom_text_home:has(> #mw-clerk-sliderhp)
 ||chata.quickcep.com/im/behavior/visitor/update
 ||vkvideo.ru/al_video.php?act=track_player_events
 ||spclient.wg.spotify.com/gabo-receiver-service*/v3/events/
-||spclient.wg.spotify.com/ads/
+||spotify.com/ads/
 ||spclient.wg.spotify.com/ad-logic/
 -spclient.spotify.com/gabo-receiver-service*/v3/events
 ||api.fubo.tv/papi/v1/tracking

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -1633,7 +1633,7 @@
 ||rc.vtex.com.br^
 ||browser.events.data.msn.cn^
 ||browser.events.data.msn.com^
-||urbanairship.com^$third-party
+||urbanairship.com^
 ||iesnare.com^$third-party
 ||lngtd.com^$third-party
 ||dw-eu.com.com^
@@ -1686,8 +1686,8 @@
 ||k50.ru^$third-party
 ||snowdayonline.xyz^$third-party
 ||log.hitsteps.com^$third-party
-||advangelists.com^$third-party
-||bfmio.com^$third-party
+||advangelists.com^
+||bfmio.com^
 ||beacons.mediamelon.com^$third-party
 ||smartocto.com^$third-party
 ||baikalize.com^$third-party
@@ -1726,7 +1726,7 @@
 ||aufp.io^$third-party
 ||celebrus.com^$third-party
 ||techlab-cdn.com^$third-party
-||mpianalytics.com^$third-party
+||mpianalytics.com^
 ||realytics.net^$third-party
 ||eue.d-teknoloji.com.tr^$third-party
 ||track.mp3vizor.com^$third-party
@@ -2029,7 +2029,7 @@
 ||adblockanalytics.com^$third-party
 ||hexagon-analytics.com^$third-party
 ||stat.media^$third-party
-||akstat.io^$third-party
+||akstat.io^
 ||top10sportsites.com^$third-party
 ||otik.de^$third-party
 ||bounce-ads.de^$third-party
@@ -2041,7 +2041,7 @@
 ||props.id^$third-party
 ||gft2.de^$third-party
 ||srvtrck.com^$third-party
-||geoplugin.net^$third-party
+||geoplugin.net^
 ||ktrackdata.com^
 ||tda.io^$third-party
 ||statpipe.ru^$third-party

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -69,6 +69,7 @@
 !
 !
 ||events.api.gamma.app^
+||flashtalking.com^
 ||io.narrative.io^
 ||pirsch.io^$third-party
 ||d2g2u2795e3fzw.cloudfront.net^

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -69,6 +69,7 @@
 !
 !
 ||events.api.gamma.app^
+||io.narrative.io^
 ||pirsch.io^$third-party
 ||d2g2u2795e3fzw.cloudfront.net^
 ||mobiexchange.com^$third-party
@@ -2021,7 +2022,7 @@
 ||wzrkt.com^$third-party
 ||ymetrica.com^$third-party
 ||dep-x.com^$third-party
-||quantcount.com^$third-party
+||quantcount.com^
 ||szsmtk.com^$third-party
 ||phywi.org^$third-party
 ||doomna.com^$third-party
@@ -2074,7 +2075,7 @@
 ||24log.de^$third-party
 ||24log.ru^$third-party
 ||2cnt.net^$third-party
-||33across.com^$third-party
+||33across.com^
 ||360i.com^$third-party
 ||360tag.com^$third-party
 ||3dlivestats.com^$third-party
@@ -2162,7 +2163,7 @@
 ||agentinteractive.com^$third-party
 ||agillic.eu^$third-party
 ||agilone.com^$third-party
-||agkn.com^$third-party
+||agkn.com^
 ||aidata.io^$third-party
 ||aimediagroup.com^$third-party
 ||airpr.com^$third-party
@@ -2263,7 +2264,7 @@
 ||bfoleyinteractive.com^$third-party
 ||bhs4.com^$third-party
 ||bid.run^$third-party
-||bidswitch.net^$third-party
+||bidswitch.net^
 ||bigcattracks.com^$third-party
 ||bigsauron.ru^$third-party
 ||bigstats.net^$third-party
@@ -2340,7 +2341,7 @@
 ||cashburners.com^$third-party
 ||cashcount.com^$third-party
 ||cccpmo.com^$third-party
-||cedexis.com^$third-party
+||cedexis.com^
 ||celebros-analytics.com^$third-party
 ||certifica.com^$third-party
 ||cetrk.com^$third-party
@@ -2348,7 +2349,7 @@
 ||chart.dk^$third-party
 ||chartaca.com^$third-party
 ||chartbeat.com^$third-party
-||chartbeat.net^$third-party
+||chartbeat.net^
 ||checkeffect.at^$third-party
 ||checkstat.nl^$third-party
 ||christiantop1000.com^$third-party
@@ -2459,7 +2460,7 @@
 ||countus.fr^$third-party
 ||countyou.de^$third-party
 ||countz.com^$third-party
-||cpx.to^$third-party
+||cpx.to^
 ||cqcounter.com^$third-party
 ||cquotient.com^$third-party
 ||craftkeys.com^$third-party
@@ -2473,7 +2474,7 @@
 ||crowdscience.com^$third-party
 ||crowdskout.com^$third-party
 ||crsspxl.com^$third-party
-||crwdcntrl.net^$third-party
+||crwdcntrl.net^
 ||csdata1.com^$third-party
 ||ctnsnet.com^$third-party
 ||customer.io^$third-party
@@ -2502,7 +2503,7 @@
 ||decibelinsight.net^$third-party
 ||decideinteractive.com^$third-party
 ||demandbase.com^$third-party
-||demdex.net^$third-party
+||demdex.net^
 ||deqwas.net^$third-party
 ||device9.com^$third-party
 ||dialogtech.com^$third-party
@@ -2721,7 +2722,7 @@
 ||geocontatore.com^$third-party
 ||georiot.com^$third-party
 ||getbackstory.com^$third-party
-||getclicky.com^$third-party
+||getclicky.com^
 ||getconversion.net^$third-party
 ||getsmartcontent.com^$third-party
 ||gez.io^$third-party
@@ -2939,7 +2940,7 @@
 ||kopsil.com^$third-party
 ||kostenlose-counter.com^$third-party
 ||kqzyfj.com^$third-party
-||krxd.net^$third-party
+||krxd.net^
 ||kupona.de^$third-party
 ||laserstat.com^$third-party
 ||lciapi.ninthdecimal.com^
@@ -2974,7 +2975,7 @@
 ||livewebstats.dk^$third-party
 ||lloogg.com^$third-party
 ||load.sumome.com^$third-party
-||localytics.com^$third-party
+||localytics.com^
 ||lockview.cn^$third-party
 ||logaholic.com^$third-party
 ||logcounter.com^$third-party
@@ -2991,7 +2992,7 @@
 ||lopley.com^$third-party
 ||losecounter.de^$third-party
 ||losstrack.com^$third-party
-||lp4.io^$third-party
+||lp4.io^
 ||lporirxe.com^$third-party
 ||stats.lptracker.ru^$third-party
 ||lsfinteractive.com^$third-party
@@ -3022,7 +3023,7 @@
 ||marktest.pt^$third-party
 ||masterstats.com^$third-party
 ||matheranalytics.com^$third-party
-||mathtag.com^$third-party
+||mathtag.com^
 ||maxtracker.net^$third-party
 ||maxymiser.com^$third-party
 ||maxymiser.net^$third-party
@@ -3158,7 +3159,7 @@
 ||nordicresearch.com^$third-party
 ||notifyvisitors.com^$third-party
 ||nowinteract.com^$third-party
-||npario-inc.net^$third-party
+||npario-inc.net^
 ||nprove.com^$third-party
 ||nr-data.net^$third-party
 ||nr7.us^$third-party
@@ -3194,12 +3195,12 @@
 ||online-metrix.net^$third-party
 ||onlinewebstat.com^$third-party
 ||onlinewebstats.com^$third-party
-||onthe.io^$third-party
+||onthe.io^
 ||openclick.com^$third-party
 ||openhit.com^$third-party
 ||openinternetexchange.com^$third-party
 ||openinternetexchange.net^$third-party
-||openstat.net^$third-party
+||openstat.net^
 ||opentracker.net^$third-party
 ||oproi.com^$third-party
 ||optimix.asia^$third-party
@@ -3255,7 +3256,7 @@
 ||pimpmypr.de^$third-party
 ||pingdom.net^$third-party
 ||pingomatic.com^$third-party
-||pippio.com^$third-party
+||pippio.com^
 ||piwik.org^$third-party
 ||pixanalytics.com^$third-party
 ||pixel.ad^$third-party
@@ -3475,7 +3476,7 @@
 ||silverpush.co^$third-party
 ||simplehitcounter.com^$third-party
 ||simplereach.com^$third-party
-||simpli.fi^$third-party
+||simpli.fi^
 ||simplycast.us^$third-party
 ||simplymeasured.com^$third-party
 ||singlefeed.com^$third-party
@@ -3629,7 +3630,7 @@
 ||terabytemedia.com^$third-party
 ||tetigi.com^$third-party
 ||tetoolbox.com^$third-party
-||theadex.com^$third-party
+||theadex.com^
 ||thebestlinks.com^$third-party
 ||thecounter.com^$third-party
 ||thesearchagency.net^$third-party
@@ -3720,7 +3721,7 @@
 ||ugdturner.com^$third-party
 ||umbel.com^$third-party
 ||up-rank.com^$third-party
-||upalytics.com^$third-party
+||upalytics.com^
 ||upstats.ru^$third-party
 ||uptime.monitorus.ru^$third-party
 ||uptracs.com^$third-party
@@ -3789,7 +3790,7 @@
 ||votistics.com^$third-party
 ||vtracker.net^$third-party
 ||w3counter.com^$third-party
-||w55c.net^$third-party
+||w55c.net^
 ||w88.go.com^
 ||wa.and.co.uk^
 ||wa4y.com^$third-party
@@ -3885,14 +3886,14 @@
 ||xcounter.ch^$third-party
 ||xg4ken.com^$third-party
 ||xhit.com^$third-party
-||xplosion.de^$third-party
+||xplosion.de^
 ||xtractor.no^$third-party
 ||xtremline.com^$third-party
 ||xxxcounter.com^$third-party
 ||x.clearbit.com^$third-party
 ||x.clearbitjs.com^$third-party
 ||y-track.com^$third-party
-||yadro.ru^$third-party
+||yadro.ru^
 ||yamanoha.com^$third-party
 ||yaudience.com^$third-party
 ||ybotvisit.com^$third-party
@@ -3905,7 +3906,7 @@
 ||youramigo.com^$third-party
 ||zanox-affiliate.de^$third-party
 ||zanox.com^$third-party
-||zdbb.net^$third-party
+||zdbb.net^
 ||zero.kz^$third-party
 ||zesep.com^$third-party
 ||zipstat.dk^$third-party

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -441,7 +441,7 @@
 ||fourier.alibaba.com^
 ||fourier.aliexpress.com^
 ||sofire.1024tera.com^
-||ad-events.flashtalking.com^
+||flashtalking.com^
 ||market-click-baobab.yandex.ru^
 ||mon-*.lemon8-app.com^
 ||mon-*.lemon8-app.us^
@@ -1580,7 +1580,6 @@
 ||analytics.iraiser.eu^
 ||analytics.islamicfinder.org^
 ||analytics.livestream.com^
-||analytics.localytics.com^
 ||analytics.maileon.com^
 ||analytics.marquiz.ru^
 ||analytics.mindjolt.com^
@@ -1822,7 +1821,6 @@
 ||counter.top.ge^
 ||counter.ukr.net^
 ||counter.web.money^
-||counter.yadro.ru^
 ||counter.zerohedge.com^
 ||counter*-yadro*-ru.unblocked.lol^
 ||counter1.fc2.com^

--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -441,7 +441,6 @@
 ||fourier.alibaba.com^
 ||fourier.aliexpress.com^
 ||sofire.1024tera.com^
-||flashtalking.com^
 ||market-click-baobab.yandex.ru^
 ||mon-*.lemon8-app.com^
 ||mon-*.lemon8-app.us^


### PR DESCRIPTION
### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

There are many redundancy with mobile.txt and the rest of files in TPF, fixed only a part.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
