### PR TITLE
Adjusted Stale Bot

### DIFF
--- a/.github/workflows/stale_issues_high.yml
+++ b/.github/workflows/stale_issues_high.yml
@@ -22,8 +22,8 @@ jobs:
           exempt-issue-labels: 'A: By design,A: In progress,A: Problematic'
           any-of-labels: 'P1: Critical,P2: High,P3: Medium'
           exempt-all-issue-assignees: true
-          days-before-issue-stale: 10
-          days-before-issue-close: 4
+          days-before-issue-stale: 3
+          days-before-issue-close: 10
           operations-per-run: 100
           remove-issue-stale-when-updated: true
           ascending: true

--- a/.github/workflows/stale_issues_low.yml
+++ b/.github/workflows/stale_issues_low.yml
@@ -22,7 +22,7 @@ jobs:
           exempt-issue-labels: 'A: By design,A: In progress,A: Problematic'
           any-of-labels: 'P4: Low,P5: Lowest'
           exempt-all-issue-assignees: true
-          days-before-issue-stale: 4
+          days-before-issue-stale: 7
           days-before-issue-close: 3
           operations-per-run: 100
           remove-issue-stale-when-updated: true


### PR DESCRIPTION
This is necessary so that important issues move up the list and remain unresolved for less time.