### PR TITLE
Make AGLint glob pattern quoted

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "homepage": "https://github.com/AdguardTeam/AdguardFilters#readme",
     "scripts": {
-        "aglint": "aglint --cache --cache-location .aglintcache --cache-strategy content '**/*.txt'",
+        "aglint": "aglint --cache --cache-location .aglintcache --cache-strategy content \"**/*.txt\"",
         "markdownlint": "markdownlint .",
         "lint": "npm run aglint && npm run markdownlint",
         "prepare": "node .husky/install.js"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "homepage": "https://github.com/AdguardTeam/AdguardFilters#readme",
     "scripts": {
-        "aglint": "aglint --cache --cache-location .aglintcache --cache-strategy content **/*.txt",
+        "aglint": "aglint --cache --cache-location .aglintcache --cache-strategy content '**/*.txt'",
         "markdownlint": "markdownlint .",
         "lint": "npm run aglint && npm run markdownlint",
         "prepare": "node .husky/install.js"


### PR DESCRIPTION
This change is needed so that the glob pattern is resolved by AGLint and not by the shell, which could cause inconsistent behavior in some cases