### PR TITLE
Upd #221971 AS

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -66,9 +66,9 @@ triblive.com###storyContent > div[data-type="float"][data-stn-player]
 ! SECTION: Ad-Shield
 ! adthrive/Raptive
 !+ NOT_PLATFORM(ios, ext_safari, ext_android_cb, ext_ublock)
-||ads.adthrive.com/abd/abd.js$redirect=noopjs
+||ads.adthrive.com/abd/abd.js$xmlhttprequest,redirect=noopjs
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
-@@||ads.adthrive.com/abd/abd.js
+@@||ads.adthrive.com/abd/abd.js$xmlhttprequest
 ! Ad-Shield Light - the website's NextJS script tries to initialize Ad-Shield script.
 weatherzone.com.au##div[class*=" "][height="270px"]
 weatherzone.com.au##div[class*=" "][height="74px"]

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -64,6 +64,11 @@ triblive.com###storyContent > div[data-type="float"][data-stn-player]
 !
 ! START: Ad-Shield ad reinsertion
 ! SECTION: Ad-Shield
+! adthrive/Raptive
+!+ NOT_PLATFORM(ios, ext_safari, ext_android_cb, ext_ublock)
+||ads.adthrive.com/abd/abd.js$redirect=noopjs
+!+ PLATFORM(ios, ext_safari, ext_android_cb)
+@@||ads.adthrive.com/abd/abd.js
 ! Ad-Shield Light - the website's NextJS script tries to initialize Ad-Shield script.
 weatherzone.com.au##div[class*=" "][height="270px"]
 weatherzone.com.au##div[class*=" "][height="74px"]

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -65,6 +65,7 @@ triblive.com###storyContent > div[data-type="float"][data-stn-player]
 ! START: Ad-Shield ad reinsertion
 ! SECTION: Ad-Shield
 ! adthrive/Raptive
+!+ NOT_PLATFORM(ext_ublock)
 ||ads.adthrive.com/abd/abd.js$xmlhttprequest,redirect=noopjs
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@||ads.adthrive.com/abd/abd.js$xmlhttprequest
@@ -78,6 +79,7 @@ weatherzone.com.au##main > div[class*=" "]:has(> div[class*="img_"])
 weatherzone.com.au,lifehacker.jp#%#!function(){var e=Object.getOwnPropertyDescriptor(Element.prototype,"innerHTML").set;Object.defineProperty(Element.prototype,"innerHTML",{set:function(t){return t.includes("html-load.com")?e.call(this,""):e.call(this,t)}})}();
 weatherzone.com.au,lifehacker.jp#%#//scriptlet('remove-node-text', 'script', 'html-load.com')
 !#endif
+!+ NOT_PLATFORM(ext_ublock)
 ||html-load.com^$script,redirect=noopjs,domain=lifehacker.jp
 !+ PLATFORM(ext_ff)
 weatherzone.com.au,lifehacker.jp#%#//scriptlet('trusted-replace-node-text', 'script', 'html-load.com', '/[\S\s]+html-load.com[\S\s]+/', '!function(){var e=Object.getOwnPropertyDescriptor(Element.prototype,"innerHTML").set;Object.defineProperty(Element.prototype,"innerHTML",{set:function(t){return t.includes("html-load.com")?e.call(this,""):e.call(this,t)}})}();')

--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -65,7 +65,6 @@ triblive.com###storyContent > div[data-type="float"][data-stn-player]
 ! START: Ad-Shield ad reinsertion
 ! SECTION: Ad-Shield
 ! adthrive/Raptive
-!+ NOT_PLATFORM(ios, ext_safari, ext_android_cb, ext_ublock)
 ||ads.adthrive.com/abd/abd.js$xmlhttprequest,redirect=noopjs
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@||ads.adthrive.com/abd/abd.js$xmlhttprequest
@@ -79,7 +78,6 @@ weatherzone.com.au##main > div[class*=" "]:has(> div[class*="img_"])
 weatherzone.com.au,lifehacker.jp#%#!function(){var e=Object.getOwnPropertyDescriptor(Element.prototype,"innerHTML").set;Object.defineProperty(Element.prototype,"innerHTML",{set:function(t){return t.includes("html-load.com")?e.call(this,""):e.call(this,t)}})}();
 weatherzone.com.au,lifehacker.jp#%#//scriptlet('remove-node-text', 'script', 'html-load.com')
 !#endif
-!+ NOT_PLATFORM(ios, ext_safari, ext_android_cb, ext_ublock)
 ||html-load.com^$script,redirect=noopjs,domain=lifehacker.jp
 !+ PLATFORM(ext_ff)
 weatherzone.com.au,lifehacker.jp#%#//scriptlet('trusted-replace-node-text', 'script', 'html-load.com', '/[\S\s]+html-load.com[\S\s]+/', '!function(){var e=Object.getOwnPropertyDescriptor(Element.prototype,"innerHTML").set;Object.defineProperty(Element.prototype,"innerHTML",{set:function(t){return t.includes("html-load.com")?e.call(this,""):e.call(this,t)}})}();')


### PR DESCRIPTION
# Creating the pull request

> Prevents sites using AdThrive/Raptive from triggering Ad-Shield.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Fix #221971
#222492
#222507
#222696

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
