### PR TITLE
Add generic cooking sites

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_general.txt
@@ -34,6 +34,7 @@
 ##.widget_blog_subscription
 ###mc_embed_signup
 ! generic cooking sites
+##body[class*="adthrive-device-"] > .site-container .block-email
 ##.slick-on-page
 ##.seva-form
 ##.dpsp-email-save-this-tool

--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -2372,7 +2372,6 @@ cloudflare.com##.mb7 > div.bg-blue4:has(> section > form input#Email)
 monopol-magazin.de###block-stickyfooter
 monopol-magazin.de###block-footer-newsletter-form
 dallasnews.com##.dmnc_features-cta-social-cta-social-module__YgCAW
-whatgreatgrandmaate.com,julieblanner.com,amybakesbread.com,dinneratthezoo.com,spicysouthernkitchen.com,nutmegnanny.com,acedarspoon.com,therecipecritic.com,evolvingtable.com,chocolatecoveredkatie.com,acouplecooks.com##.block-email
 market.yandex.*##div[id="/content/footer/subscription"]
 ig.com##div[class^="grid__bg image-background "][style*="/NEWS-LEADGEN-BGIMAGE.jpg"]
 militarywatchmagazine.com##.followUs

--- a/SocialFilter/sections/general_elemhide.txt
+++ b/SocialFilter/sections/general_elemhide.txt
@@ -97,6 +97,8 @@
 ##a[href^="http://twitter.com/intent/tweet?"]
 ##a[href^="http://www.twitter.com/intent/tweet?"]
 ##a[href^="http://twitter.com/intent/tweet/?"]
+! generic cooking sites
+##body[class*="adthrive-device-"] > .site-container .block-social-share
 !
 ##iframe[src^="https://plugins.mixi.jp/favorite.pl?"]
 ###snsShareBottom

--- a/SocialFilter/sections/specific.txt
+++ b/SocialFilter/sections/specific.txt
@@ -9532,7 +9532,7 @@ auto-swiat.pl##.whitelistPremium > #detail + div[data-run-module="autoswiat/main
 m.ua##.soc-buttons-glist
 jbbs.seesaa.net##.bookmark > .sns_box
 oricon.co.jp##.sns-share-area
-dinneratthezoo.com,chocolatecoveredkatie.com,studyfinds.org,teleport2001.ru,vashvkus.ru,oricon.co.jp##.block-social-share
+studyfinds.org,teleport2001.ru,vashvkus.ru,oricon.co.jp##.block-social-share
 oricon.co.jp##.block-recommend-list.sns-box
 oricon.co.jp##.information > span[style] > a[onclick^="socialAct("]
 japan.zdnet.com##ul#social_bkm_wrap_top


### PR DESCRIPTION
Fix #222806

`##.block-email` and `.block-social-share` are quite risky to use as generic cosmetic rules.

However we can narrow it to adthrive sites only using other attributes of other elements.