### PR TITLE
fix #222058 thekitchn.com - Remove empty spacing from ad unit

### DIFF
--- a/AnnoyancesFilter/Other/sections/annoyances.txt
+++ b/AnnoyancesFilter/Other/sections/annoyances.txt
@@ -721,6 +721,8 @@ ultimedia.com#%#//scriptlet('set-constant', 'dtkPlayer.infos.visible_plus', '0')
 apartmenttherapy.com##.Post__topicFollowingRibbon
 ! Apartment Therapy, LLC sites - unrelated sticky video in sidebar
 apartmenttherapy.com,thekitchn.com,cubbyathome.com##.Video--right_rail
+! https://github.com/AdguardTeam/AdguardFilters/issues/222058
+www.thekitchn.com###chicory_premium_pairings_unit
 ! https://github.com/AdguardTeam/AdguardFilters/issues/147234
 auto.24tv.ua##.google-news-link
 auto.24tv.ua##.follow-us


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ ] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Please refer my first comment https://github.com/AdguardTeam/AdguardFilters/issues/222058#issuecomment-3749760696.

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

This PR adds a filter rule to hide the `#chicory_premium_pairings_unit` element on www.thekitchn.com that creates unwanted vertical spacing after ad blocking is applied.

I would appreciate the maintainers’ opinion on whether this element should be explicitly handled in the filter list.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
