### PR TITLE
Fix #223240 hon.jp

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -8840,7 +8840,7 @@ metaratings.ru,metaratings.by,metarating.com.ua,meta-ratings.kz##div[class^="Sub
 telecomasia.net,meta.reviews##.subscription
 !
 ! Google Revenue Manager
-||news.google.com/swg/js/v1/swg-basic.js$domain=ilenta.com|studentwalker.com|turkiyegazetesi.com.tr|tv3.lt|roboin.io|iha.com.tr|premierguitar.com|tecnoandroid.it|abcgazetesi.com.tr|insidenova.com|fpsjp.net|pixelnerd.pl|benguturk.com|leparisien.fr|knowtechie.com|meyka.com|xenospectrum.com
+||news.google.com/swg/js/v1/swg-basic.js$domain=ilenta.com|studentwalker.com|turkiyegazetesi.com.tr|tv3.lt|roboin.io|iha.com.tr|premierguitar.com|tecnoandroid.it|abcgazetesi.com.tr|insidenova.com|fpsjp.net|pixelnerd.pl|benguturk.com|leparisien.fr|knowtechie.com|meyka.com|xenospectrum.com|hon.jp
 !
 ! Progorod
 pgn21.ru,usolie.info,newtambov.ru,gorodkirov.ru,navigator-kirov.ru,pg11.ru,pg12.ru,pg13.ru,pg21.ru,prochepetsk.ru,prodzer.ru,progorod33.ru,progorod43.ru,progorod58.ru,progorod59.ru,progorod62.ru,progorod76.ru,progorodnn.ru,progorodnsk.ru,progorodsamara.ru,progoroduhta.ru##div[class^="social-list-subscribe_"]

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -1584,7 +1584,7 @@ sirabee.com##div[data-newsy-ad-name]
 ||lyze.jp/img/banner/
 ||m-pe.tv/img/banner/
 baynews.blog.jp#?#div[class$="t-column-inner"] > center:contains(スポンサーリンク)
-||news.google.com/*/swg-basic.js$domain=poitan.jp|7-24blog.com|hon.jp
+||news.google.com/*/swg-basic.js$domain=poitan.jp|7-24blog.com
 xn--ipv6-yn4cxgwe959zqrkp58g.com##.post_content > div.is-style-bg_stripe:has(> center > p > a[href*="valuecommerce.com"])
 xn--ipv6-yn4cxgwe959zqrkp58g.com##.post_content > div > div.is-style-border_sm:has(> div.is-style-dent_box > p > a[href^="https://network.mobile.rakuten.co.jp/campaign/"])
 xn--ipv6-yn4cxgwe959zqrkp58g.com##div[style="width:100%;margin:0 auto;"]

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -1584,7 +1584,7 @@ sirabee.com##div[data-newsy-ad-name]
 ||lyze.jp/img/banner/
 ||m-pe.tv/img/banner/
 baynews.blog.jp#?#div[class$="t-column-inner"] > center:contains(スポンサーリンク)
-||news.google.com/*/swg-basic.js$domain=poitan.jp|7-24blog.com
+||news.google.com/*/swg-basic.js$domain=poitan.jp|7-24blog.com|hon.jp
 xn--ipv6-yn4cxgwe959zqrkp58g.com##.post_content > div.is-style-bg_stripe:has(> center > p > a[href*="valuecommerce.com"])
 xn--ipv6-yn4cxgwe959zqrkp58g.com##.post_content > div > div.is-style-border_sm:has(> div.is-style-dent_box > p > a[href^="https://network.mobile.rakuten.co.jp/campaign/"])
 xn--ipv6-yn4cxgwe959zqrkp58g.com##div[style="width:100%;margin:0 auto;"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ ] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

This appears to be a **Subscribe with Google (SwG)** prompt. SwG popups are typically injected by Google’s SwG client script, most commonly `swg-basic.js`, which is loaded from `news.google.com`.

In existing AdGuard filter patterns, SwG prompts are already handled by blocking this script at the network level:

```adblock
||news.google.com/*/swg-basic.js$domain=poitan.jp|7-24blog.com
```

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
