### PR TITLE
Rotating Domains Checker integration

### DIFF
--- a/.github/workflows/rdc.yml
+++ b/.github/workflows/rdc.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1

--- a/.github/workflows/rdc.yml
+++ b/.github/workflows/rdc.yml
@@ -63,6 +63,9 @@ jobs:
           # Clone Rotating Domains Checker repository (public, no token needed)
           git clone https://github.com/Alex-302/RotatingDomainsChecker.git /tmp/checker
           cd /tmp/checker
+          # SECURITY: Pinned to a specific commit to prevent malicious code injection
+          # Update this commit when you want to upgrade to newer version
+          git checkout 06000c9
           npm install
           npm run build
 

--- a/.github/workflows/rdc.yml
+++ b/.github/workflows/rdc.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: 📋 Upload log file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rotating-domains-checker-log
           path: logs/rotating-domains-checker.log

--- a/.github/workflows/rdc.yml
+++ b/.github/workflows/rdc.yml
@@ -1,0 +1,84 @@
+name: Rotating Domains Checker
+
+on:
+  # Automatic run daily at 02:00 UTC
+  schedule:
+    - cron: '0 2 * * *'
+  # Manual run with mode selection
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Run mode'
+        required: false
+        default: 'prod_live'
+        type: choice
+        options:
+          - ''              # Use config.yml setting
+          - 'prod_live'     # Production mode with changes
+          - 'prod_dry'      # Production mode without changes (git operations simulation)
+          - 'test_live'     # Test directory with changes
+          - 'test_dry'      # Test directory without changes (git operations simulation)
+
+      config-path:
+        description: 'Path to configuration file'
+        required: false
+        default: './rdc_config.yml'
+        type: string
+
+      filters-path:
+        description: 'Path to filters directory'
+        required: false
+        default: './'
+        type: string
+
+jobs:
+  check-domains:
+    name: Rotating Domains Checker
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write          # Required for commits
+      pull-requests: write     # Required for PR creation
+      actions: read            # Required for reading workflow info
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🚀 Run Rotating Domains Checker
+        run: |
+          # Configure git user for commits
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          # Clone Rotating Domains Checker repository (public, no token needed)
+          git clone https://github.com/Alex-302/RotatingDomainsChecker.git /tmp/checker
+          cd /tmp/checker
+          npm install
+          npm run build
+
+          # Return to filters repository and run checker
+          cd $GITHUB_WORKSPACE
+          node /tmp/checker/dist/index.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_CONFIG_PATH: ${{ github.event.inputs.config-path || './config.yml' }}
+          INPUT_MODE: ${{ github.event.inputs.mode || '' }}
+          INPUT_FILTERS_PATH: ${{ github.event.inputs.filters-path || './' }}
+
+      - name: 📋 Upload log file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rotating-domains-checker-log
+          path: logs/rotating-domains-checker.log
+          retention-days: 7

--- a/.github/workflows/rdc.yml
+++ b/.github/workflows/rdc.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 1
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4291,6 +4291,9 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 ||blogger.googleusercontent.com/img/$domain=/patronspor[0-9a-z]{14}\.cfd$/
 [$domain=/patronspor[0-9a-z]{14}\.cfd$/]##.background-link
 [$domain=/patronspor[0-9a-z]{14}\.cfd$/]##.top-banner-header
+||blogger.googleusercontent.com/img/$domain=patronspor05648a2w45awes.cfd
+patronspor05648a2w45awes.cfd##.background-link
+patronspor05648a2w45awes.cfd##.top-banner-header
 !
 ! Frequently changed domains: zbahistv*.com
 ! Source: zbahistv26.com

--- a/rdc_config.yml
+++ b/rdc_config.yml
@@ -1,0 +1,64 @@
+# TrackDomains Configuration
+
+http:
+  timeout: 10000          # fallback timeout (used if specific timeouts are not provided)
+  retries: 2              # exponential backoff
+  resolveTimeout: 10000   # timeout for resolve (redirect) phase
+  heuristicTimeout: 10000 # timeout for heuristic phase
+  userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+processing:
+  parallel: 10           # legacy/global fallback parallelism (rarely used)
+  resolveParallel: 20    # concurrent resolve checks (main phase)
+  heuristicParallel: 50  # concurrent heuristic checks (lightweight DNS+HTTP, can be high)
+  redirectDepth: 150     # max 3xx redirects before error (protect from infinite loops)
+
+dnsPreCheck:
+  enabled: true          # enable DNS pre-check before HTTP requests (both phases)
+  timeout: 3000          # DNS lookup timeout (ms)
+  retryOnce: true        # retry once on EAI_AGAIN (temporary DNS failure)
+
+contentProbe:
+  enabled: true          # global toggle; per-site probe_text overrides when present
+
+antibot:
+  detectCodes: [403, 409]         # potential antibot HTTP codes
+  detectUrlPattern: "__cf_chl_tk" # antibot URL pattern
+
+thresholds:
+  failedDaysWarning: 14  # log warning when site fails for 14+ days
+
+heuristic:
+  enabled: true          # enable domain[N].tld heuristic search
+  maxAttempts: 50        # increase to check more domains, if there are difficulties in finding working domains
+  skipOnAntibot: true    # skip heuristic if antibot detected
+  attemptParallel: 3     # max concurrent attempts per site (lower = less DNS load)
+  dnsParallel: 50        # max concurrent DNS lookups in batch pre-filter (lightweight, can be high)
+  forceHeuristicOnCodes: [403, 404, 500, 502, 503, 504]  # force heuristic for these HTTP status codes
+
+# Global skip_text — skip domains whose response body contains these phrases (parked/expired domains)
+skip_text:
+  - "is for sale"
+  - "Domain is parked"
+
+logging:
+  saveToFile: true       # save logs to file
+  incremental: true      # append to existing log file (false = overwrite)
+  filePath: "logs/rotating-domains-checker.log"
+
+git:
+  mode: "debug"           # "prod" = commit directly to master, "debug" = create PR
+  branch: "master"
+  prBranchPrefix: "domain-rotate"
+
+# Filters directory settings
+filtersdir:
+  repoPath: "ProdFilters"         # path to filters directory (for debugging, will be changed to ".." for production)
+  filterDirPattern: "*Filter"     # directories ending with "Filter"
+  filePattern: "*.txt"
+
+# Test filters directory settings
+filtersdir_test:
+  repoPath: "TestFilters"         # path to test filters directory
+  filterDirPattern: "TestFilter"  # directories ending with "Filter"
+  filePattern: "testfilter.txt"   # only this specific test file

--- a/watchers.yml
+++ b/watchers.yml
@@ -1,0 +1,5 @@
+# Rotating Domains Checker - monitored websites
+
+sites:
+  Patronspor (patronspor*.cfd):
+    last_known_mirror: patronspor05648a2w45awes.cfd


### PR DESCRIPTION
Integrated this tool - https://github.com/Alex-302/RotatingDomainsChecker

With the current config only one domain will be processed - patronspor05648a2w45awes.cfd
patronspor05648a2w45awes.cfd is obsolete now. 
Expected result after execution:
`patronspor05648a2w45awes.cfd` 
in the rules will be replaced by
`patronspor04548a2wer45awes.cfd`
The result will be committed via a pull-request.