### PR TITLE
Update tracking_servers.txt to allow `app.posthog.com`

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -263,6 +263,7 @@
 ||cloudfilt.com^$third-party
 ||highway.cablecar.sph.com.sg^
 ||i.posthog.com^
+||*.i.posthog.com^
 ||app.optibase.io^$third-party
 ||abtshield.com^$third-party
 ||track.fusionmedia.io^
@@ -990,7 +991,6 @@
 ||px*.mediahills.ru^
 ||sdk.conscent.in^$third-party
 ||tpstelemetry.tencent.com^
-||app.posthog.com^$third-party
 ||crossees.com^
 ||humanz.com^$third-party
 ||gateway.foresee.com^

--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -263,7 +263,7 @@
 ||cloudfilt.com^$third-party
 ||highway.cablecar.sph.com.sg^
 ||i.posthog.com^
-||*.i.posthog.com^
+.i.posthog.com^
 ||app.optibase.io^$third-party
 ||abtshield.com^$third-party
 ||track.fusionmedia.io^


### PR DESCRIPTION
# Creating the pull request

Added wildcard entry for i.posthog.com and removed app.posthog.com.

Posthog never collects analytics via `app.posthog.com`, that's merely the entrypoint to the PostHog app used to route people between `us.posthog.com` and `eu.posthog.com`. All analytics is done via `*.i.posthog.com` instead.

The `$thirdparty` rule was supposed to help with this, but this is being added to DNS entries in https://github.com/AdguardTeam/AdGuardSDNSFilter and they don't support `$thirdparty`.

Another possible change is, instead of doing this, to simply add `app.posthog.com` as an exception in https://github.com/AdguardTeam/AdGuardSDNSFilter but that felt more wrong since it might raise some eyebrows.

See https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1660

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

See https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1660

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
