### PR TITLE
change to `ubuntu-slim` to reduce bootstrapping timing

### DIFF
--- a/.github/workflows/assign-on-label.yml
+++ b/.github/workflows/assign-on-label.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   assign:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/change-on-reopen.yml
+++ b/.github/workflows/change-on-reopen.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   remove_labels_assignees:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/rm-labels-on-closed.yml
+++ b/.github/workflows/rm-labels-on-closed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   remove_label:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/stale_issues_gh.yml
+++ b/.github/workflows/stale_issues_gh.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/stale_issues_high.yml
+++ b/.github/workflows/stale_issues_high.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/stale_issues_low.yml
+++ b/.github/workflows/stale_issues_low.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     if: ${{ github.repository == 'AdguardTeam/AdguardFilters' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners

`ubuntu-latest` indicates that requesting a virtual machine on GitHub/Microsoft infra to run the job. But, `ubuntu-slim` indicates that requesting a docker container on a shared VM to run the job for a lightweight task & operation.

I think that adding/removing a label to a specific GitHub issue and reopening/closing a GitHub issue are the lightweight task & operation.
Also, Running a job in `ubuntu-slim` instead of a VM can reduce its bootstrapping timing and total duration.