### PR TITLE
Generically block Clickadu

### DIFF
--- a/BaseFilter/sections/general_url.txt
+++ b/BaseFilter/sections/general_url.txt
@@ -19,6 +19,9 @@
 ! /asset/jquery/slim-3.2.min.js$domain=avple.video|javhdfree.icu|nekolink.site|mambast.tk|netflav.com|fembed-hd.com|ndrama.xyz|pornhole.club|ffem.club|jvembed.com|dzmdplay.xyz|jav247.top|yuistream.xyz|javfu.net|iframe2videos.xyz|viplayer.cc|watchjavnow.xyz|cdn-myhdjav.info|embed-media.com|fembed9hd.com|cloudrls.com|vidgo.top
 !
 !
+! Clickadu
+! ex. https://ztagfuazw.in/otdzup/vmehpub/lmigze
+/^https:\/\/[0-9a-z]{6,12}\.in(?:\/[a-z]{2,10}){1,3}$/$script,third-party,match-case
 ! Dangerous sites in ads
 ! https://urlscan.io/search/#page.url%3A%22%2Fl%2FDMP_picture_captcha%3F%22
 /l/DMP_picture_captcha?$document,popup


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

NA

### Add your comment and screenshots

1. Your comment

(nsfw) `https://hentaitube.icu/`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
