### PR TITLE
Fix #226569 watchanimeworld.net

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -585,7 +585,7 @@ planetazdorovo.ru##.footer-social
 livelib.ru#$##popup-show-submailunreg { display: none !important; }
 livelib.ru#$#body { overflow: auto !important; }
 securitylab.ru##.banner-detailed
-anime-world.to,watchanimeworld.in###tg-bar
+anime-world.to,watchanimeworld.net###tg-bar
 medium.com##div > p ~ figure:has(iframe[src^="https://cdn.embedly.com/widgets/media.html"])
 ||cms.thewire.in/special/thewire-ads/
 thewire.in##.side-article-content > .icp3-wrapper

--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -585,7 +585,7 @@ planetazdorovo.ru##.footer-social
 livelib.ru#$##popup-show-submailunreg { display: none !important; }
 livelib.ru#$#body { overflow: auto !important; }
 securitylab.ru##.banner-detailed
-anime-world.to,watchanimeworld.net###tg-bar
+anime-world.to,watchanimeworld.net,piratexplay.cc###tg-bar
 medium.com##div > p ~ figure:has(iframe[src^="https://cdn.embedly.com/widgets/media.html"])
 ||cms.thewire.in/special/thewire-ads/
 thewire.in##.side-article-content > .icp3-wrapper


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #226569 watchanimeworld.net

### Add your comment

- Since watchanimeworld.in now redirects to watchanimeworld.net
- I also checked anime-world.to (same rules). It still has its own separate webpage.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
