### PR TITLE
Remove _kx used for Unsubsribing urls

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -212,8 +212,6 @@ $removeparam=cx_recsWidget
 $removeparam=mkt_tok
 ! Mindbox email tracking
 $removeparam=mindbox-message-key
-! Klaviyo onsite tracking
-$removeparam=_kx
 ! https://github.com/AdguardTeam/AdguardFilters/issues/123544
 ! ad click tracking
 ?uclick=*&uclickhash=$removeparam


### PR DESCRIPTION
Address https://github.com/brave/brave-browser/issues/53588

https://github.com/uBlockOrigin/uAssets/pull/32181

> It turns out that, like the https://github.com/brave/brave-browser/issues/10151, it's necessary for unsubscribe links to work.

Safer to remove, Will be removed from brave-core also.
