### PR TITLE
Fix #226665 www.javmost.ws

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -25,6 +25,8 @@
 !
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/226665
+@@||mostplayer.com^$subdocument,stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227211
 @@||fc2stream.tv/e/$stealth=referrer
 ! Auth by id.gov.ua


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Fix #226665 www.javmost.ws

AdGuard's stealth mode "Hide your Referrer from third-parties" strips the Referer header when the browser loads the mostplayer.com embed (SERVER 2's player).

The mostplayer.com server validates the incoming Referer header and returns 204 No Content (empty response) when it's missing, resulting in a black player.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
