### PR TITLE
Fix #226920 log.onmas.kt.com allow for KT app

### DIFF
--- a/SpywareFilter/sections/mobile_allowlist.txt
+++ b/SpywareFilter/sections/mobile_allowlist.txt
@@ -10,7 +10,7 @@
 @@||app.adjust.world^$app=com.spotify.music
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/226920
-@@||log.onmas.kt.com^$app=ktshow.cs
+@@||log.onmas.kt.com^$app=com.ktshow.cs
 ! https://github.com/AdguardTeam/AdguardFilters/issues/220073
 @@||google-analytics.com^$app=com.backbone
 ! https://github.com/AdguardTeam/AdguardFilters/issues/203036

--- a/SpywareFilter/sections/mobile_allowlist.txt
+++ b/SpywareFilter/sections/mobile_allowlist.txt
@@ -9,6 +9,8 @@
 @@||api2.branch.io^$app=com.spotify.music
 @@||app.adjust.world^$app=com.spotify.music
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/226920
+@@||log.onmas.kt.com^$app=ktshow.cs
 ! https://github.com/AdguardTeam/AdguardFilters/issues/220073
 @@||google-analytics.com^$app=com.backbone
 ! https://github.com/AdguardTeam/AdguardFilters/issues/203036


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #226920 log.onmas.kt.com allow for KT app

The KT app (`ktshow.cs`) fails to log in when `log.onmas.kt.com` is blocked.

Confirmed with incorrect password input. The domain is required for authentication.

Tested with non-filtering DNS. Thanks to @piquark6046.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
