### PR TITLE
Upd #227654 turkzzersifsa3.blog

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -250,7 +250,6 @@ rockcult.ru##.telegram_promo
 kotaku.com##div[data-mrf-recirculation="home-newsletter"]
 gazeta.ru##.b_header-service > a._icon-tg
 mashable.com##section[x-data="window.smsSignup()"]
-sotweturkifsa8.blog##a[href="https://t.me/turkifsalifevip"]
 lifewire.com##div[id^="mntl-taxonomysc-newsletter_"]
 thepioneerwoman.com##journey-full-width-newsletter
 justonecookbook.com###body > .bodysection:has(> .container > .subscribebar)

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4386,22 +4386,18 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 ! Source: turkzzersifsa3.blog
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-[$domain=/^turkzzersifsa\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
 turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-turkzzersifsa3.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#endif
 !
 ! Frequently changed domains: turkifsalife*.blog
 ! Source: turkifsalife16.blog
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-[$domain=/^turkifsalife\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
 turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-turkifsalife16.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#endif
 !
 ! Frequently changed domains: sotweturkifsa*.blog

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4387,8 +4387,8 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog,turkzzersifsa11.blog,turkzzersifsa12.blog,turkzzersifsa13.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog,turkzzersifsa11.blog,turkzzersifsa12.blog,turkzzersifsa13.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#endif
 !
 ! Frequently changed domains: turkifsalife*.blog
@@ -4396,8 +4396,8 @@ turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#endif
 !
 ! Frequently changed domains: sotweturkifsa*.blog

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4387,8 +4387,8 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#endif
 !
 ! Frequently changed domains: turkifsalife*.blog
@@ -4396,8 +4396,8 @@ turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog,turkifsalife21.blog,turkifsalife22.blog,turkifsalife23.blog,turkifsalife24.blog,turkifsalife25.blog,turkifsalife26.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 !#endif
 !
 ! Frequently changed domains: sotweturkifsa*.blog

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4388,9 +4388,9 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 [$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 [$domain=/^turkzzersifsa\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa3.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#endif
 !
 ! Frequently changed domains: turkifsalife*.blog
@@ -4399,9 +4399,9 @@ turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,
 [$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 [$domain=/^turkifsalife\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkifsalife16.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#endif
 !
 ! Frequently changed domains: sotweturkifsa*.blog
@@ -4410,12 +4410,6 @@ turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turk
 [$domain=/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 [$domain=/^sotweturkifsa\d+\.blog$/]##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
 [$domain=/^sotweturkifsa\d+\.blog$/]###block-35
-!#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
-sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog###block-35
-!#endif
 !
 ! Frequently changed domains: turkifsa*.porn
 ! Source: turkifsa.porn

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -192,7 +192,9 @@ ifsagram6.com##.banner-wrap
 ||zerotik.space/maczer15.js
 filmgo2.org,filmmolly.com##.sayfa-sol > a[target="_blank"]
 turkifsahub.com##a[href^="https://go.aff.teslaaffilate.com/"]
-turkzzersifsa3.blog,turkifsalife16.blog,turkifsalifetr1.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa3.blog##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
+turkzzersifsa3.blog,turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 *$script,third-party,domain=turkifsalifetr1.blog
 ifsagram6.com###promoPopup
 ifsagram6.com#%#//scriptlet('trusted-replace-node-text', 'script', 'adPlayed', 'let adPlayed = false', 'let adPlayed = true')

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4382,17 +4382,39 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 ! WARNING: When adding new rules here, try to find an initial source of an actual domain,
 !          or add a last known domain
 !
-! Frequently changed domains: turkzzersifsa*.blog, turkifsalife*.blog, sotweturkifsa*.blog
-! Source: turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog
-[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
-[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]###block-35
+! Frequently changed domains: turkzzersifsa*.blog
+! Source: turkzzersifsa3.blog
+[$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+[$domain=/^turkzzersifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+[$domain=/^turkzzersifsa\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
-turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
-turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog###block-35
+turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa1.blog,turkzzersifsa2.blog,turkzzersifsa3.blog,turkzzersifsa4.blog,turkzzersifsa5.blog,turkzzersifsa6.blog,turkzzersifsa7.blog,turkzzersifsa8.blog,turkzzersifsa9.blog,turkzzersifsa10.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+!#endif
+!
+! Frequently changed domains: turkifsalife*.blog
+! Source: turkifsalife16.blog
+[$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+[$domain=/^turkifsalife\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+[$domain=/^turkifsalife\d+\.blog$/]##.entry-content a[href="https://t.me/turkifsalifevip"]
+!#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
+turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkifsalife1.blog,turkifsalife2.blog,turkifsalife3.blog,turkifsalife4.blog,turkifsalife5.blog,turkifsalife6.blog,turkifsalife7.blog,turkifsalife8.blog,turkifsalife9.blog,turkifsalife10.blog,turkifsalife11.blog,turkifsalife12.blog,turkifsalife13.blog,turkifsalife14.blog,turkifsalife15.blog,turkifsalife16.blog,turkifsalife17.blog,turkifsalife18.blog,turkifsalife19.blog,turkifsalife20.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+!#endif
+!
+! Frequently changed domains: sotweturkifsa*.blog
+! Source: sotweturkifsa8.blog
+[$domain=/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+[$domain=/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+[$domain=/^sotweturkifsa\d+\.blog$/]##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
+[$domain=/^sotweturkifsa\d+\.blog$/]###block-35
+!#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
+sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+sotweturkifsa1.blog,sotweturkifsa2.blog,sotweturkifsa3.blog,sotweturkifsa4.blog,sotweturkifsa5.blog,sotweturkifsa6.blog,sotweturkifsa7.blog,sotweturkifsa8.blog,sotweturkifsa9.blog,sotweturkifsa10.blog###block-35
 !#endif
 !
 ! Frequently changed domains: turkifsa*.porn

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -169,8 +169,6 @@ pornoizle9.icu##body > div[style="display: block;"]:has(ins[data-zoneid])
 pornoizle9.icu##.a-d_Py5f
 pornoizle9.icu#%#//scriptlet('abort-on-property-read', 'open')
 ||pornoizle9.icu/pk8/ntr/b100.js
-sotweturkifsa8.blog###block-35
-sotweturkifsa8.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 trtspor.com.tr##div[class]:has(> div.ad-container)
 turkleak1.live#%#//scriptlet('prevent-addEventListener', 'click', 'window.open')
 velvetporntube.com##.bns-place-ob
@@ -192,9 +190,6 @@ ifsagram6.com##.banner-wrap
 ||zerotik.space/maczer15.js
 filmgo2.org,filmmolly.com##.sayfa-sol > a[target="_blank"]
 turkifsahub.com##a[href^="https://go.aff.teslaaffilate.com/"]
-turkzzersifsa3.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
-turkzzersifsa3.blog##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
-turkzzersifsa3.blog,turkifsalife16.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
 *$script,third-party,domain=turkifsalifetr1.blog
 ifsagram6.com###promoPopup
 ifsagram6.com#%#//scriptlet('trusted-replace-node-text', 'script', 'adPlayed', 'let adPlayed = false', 'let adPlayed = true')
@@ -4386,6 +4381,19 @@ lovefilmizle.net,elzemfilm.org,dizicaps.*,erotikfilmtube.com,sexfilmleriizle.com
 ! NOTE: Frequently changed domains
 ! WARNING: When adding new rules here, try to find an initial source of an actual domain,
 !          or add a last known domain
+!
+! Frequently changed domains: turkzzersifsa*.blog, turkifsalife*.blog, sotweturkifsa*.blog
+! Source: turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog
+[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]##.entry-content > div:has(> a[href="https://t.me/turkifsalifevip"])
+[$domain=/^turkzzersifsa\d+\.blog$/|/^turkifsalife\d+\.blog$/|/^sotweturkifsa\d+\.blog$/]###block-35
+!#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
+turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog#%#//scriptlet('prevent-addEventListener', 'DOMContentLoaded', 'app_advert')
+turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog#%#//scriptlet('prevent-addEventListener', 'click', 'popUnder')
+turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog##.entry-content a[href="https://t.me/turkifsalifevip"]
+turkzzersifsa3.blog,turkifsalife16.blog,sotweturkifsa8.blog###block-35
+!#endif
 !
 ! Frequently changed domains: turkifsa*.porn
 ! Source: turkifsa.porn


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [x] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Cannot reproduce the reported issue from #227654. However, I found that two cases need to be blocked:

### Block `paymoney.click` link replace injection

The site's WordPress `pro-seo-booster` plugin injects an inline script that fires on `DOMContentLoaded`, iterates all links, and wraps their `href` values through `paymoney.click` using `btoa`.

1. The current tab will navigate to `paymoney.click` when clicking the replaced links.
2. A few seconds later, redirect to the `url` param. This is encoded in base64.

### Others

- Hide Telegram channel subscription button on video pages

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met