### PR TITLE
fix #227882 sulasok.uno

### DIFF
--- a/BaseFilter/sections/general_extensions.txt
+++ b/BaseFilter/sections/general_extensions.txt
@@ -335,6 +335,8 @@ kat.*,kickass.*,kickass2.*,kickasstorrents.*,kat2.*,kattracker.*,thekat.*,thekic
 !
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/227882
+sulasokvids.net,sulasok.uno#%#(()=>{const o=new MutationObserver(()=>document.querySelectorAll('a[href*="/watch.php"]').forEach(e=>e.href=e.href.replace("/watch.php","/video.php")));o.observe(document,{childList:!0,subtree:!0});setTimeout(o.disconnect.bind(o),1e3)})();
 ! https://github.com/AdguardTeam/AdguardFilters/issues/226746
 !+ NOT_PLATFORM(ext_ff)
 omoi.com#%#(()=>{const t={apply:(t,e,o)=>{try{const t=o[0];t?.matches?.("azuki-reader")&&!0===t?.showAd&&Object.defineProperty(o[0],"showAd",{value:!1})}catch(t){}return Reflect.apply(t,e,o)}};window.Function.prototype.bind=new Proxy(window.Function.prototype.bind,t)})();


### PR DESCRIPTION
This rule ensures that links redirect directly to the content, bypassing the intermediary ad page.