### PR TITLE
fix #228025 amazon.com - missed trackers

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -4999,6 +4999,7 @@ dreamprogs.net##td[width="88"][height="31"]
 ||amazon.com^*/impress.html
 ||m.media-amazon.com/images/G/*/msa/vowels/metrics
 ||m.media-amazon.com/images/I/*.js?AUIClients/GWMMetricsJS
+||m.media-amazon.com/images/S/sash/$script
 ||amazonaws.com/pixelpop/app/pixelpop-
 ||an.yandex.ru/count/
 ||aol.com/ping?

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -4997,6 +4997,8 @@ dreamprogs.net##td[width="88"][height="31"]
 ||amazon.com/empty.gif?
 ||amazon.com/follow/log-metrics^
 ||amazon.com^*/impress.html
+||m.media-amazon.com/images/G/*/msa/vowels/metrics
+||m.media-amazon.com/images/I/*.js?AUIClients/GWMMetricsJS
 ||amazonaws.com/pixelpop/app/pixelpop-
 ||an.yandex.ru/count/
 ||aol.com/ping?

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -4999,7 +4999,7 @@ dreamprogs.net##td[width="88"][height="31"]
 ||amazon.com^*/impress.html
 ||m.media-amazon.com/images/G/*/msa/vowels/metrics
 ||m.media-amazon.com/images/I/*.js?AUIClients/GWMMetricsJS
-||m.media-amazon.com/images/S/sash/$script
+||m.media-amazon.com/images/S/sash/*.js?csm_attribution=
 ||amazonaws.com/pixelpop/app/pixelpop-
 ||an.yandex.ru/count/
 ||aol.com/ping?

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -2778,7 +2778,6 @@ $removeparam=asc_source,domain=aboutamazon.com|amazon.*|amzn.to
 ||amazon.*/hz/contact-us/csp$removeparam=from
 ||amazon.*/hz/contact-us/csp$removeparam=source
 ||amazon.*/message-us$removeparam=muClientName
-||m.media-amazon.com^$removeparam=csm_attribution
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83138
 ||app.mi.com/download/*?id=$removeparam=ref
 ||app.mi.com/download/*?id=$removeparam=nonce

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -2778,6 +2778,7 @@ $removeparam=asc_source,domain=aboutamazon.com|amazon.*|amzn.to
 ||amazon.*/hz/contact-us/csp$removeparam=from
 ||amazon.*/hz/contact-us/csp$removeparam=source
 ||amazon.*/message-us$removeparam=muClientName
+||m.media-amazon.com^$removeparam=csm_attribution
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83138
 ||app.mi.com/download/*?id=$removeparam=ref
 ||app.mi.com/download/*?id=$removeparam=nonce


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

This PR addresses issue #228025 by adding previously missed tracker entries for amazon.com to both the spyware and tracking parameter filter lists.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met