### PR TITLE
Fix #227413 duckduckgo.com infinite redirect caused by `removeparam=atb`

### DIFF
--- a/TrackParamFilter/sections/allowlist.txt
+++ b/TrackParamFilter/sections/allowlist.txt
@@ -7,6 +7,7 @@
 !
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227413
+! DuckDuckGo uses atb for its own session state — removing it breaks search
 @@||duckduckgo.com^$removeparam=atb
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227699
 @@||msn.com^$app=msedgewebview2.exe,removeparam=ocid

--- a/TrackParamFilter/sections/allowlist.txt
+++ b/TrackParamFilter/sections/allowlist.txt
@@ -6,6 +6,8 @@
 !
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/227413
+@@||duckduckgo.com^$removeparam=atb
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227699
 @@||msn.com^$app=msedgewebview2.exe,removeparam=ocid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227175


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #227413 duckduckgo.com infinite redirect caused by `removeparam=atb`

### Add your comment and screenshots

- DDG(duckduckgo.com) `atb` parameter is not a third-party tracker it's DDG's own session identifier (ATB = "At The Beginning"), used internally to serve search results
- Stripping it causes an infinite redirect loop:
  `duckduckgo.com/?q=test&atb=v418-1` → DDG rewrites the URL → AdGuard strips `atb` again → loop

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met