### PR TITLE
fix #228027 snapchat.com missed trackers: SSO metrics, GCP, AWS

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -2500,8 +2500,11 @@ brasil247.com###taboola-mid-article-leia-mais
 ||snapchat.com/web-analytics
 ||snapchat.com/report-metrics/
 ||web.snapchat.com/web-blizzard/web/send^
+||gcp.api.snapchat.com/web-blizzard/web/send^
 ||accounts.snapchat.com/accounts/static/scripts/pixel.js
 ||accounts.snapchat.com/accounts/sso?client_id=snapchat-com-metrics
+||aws.api.snapchat.com/snapchat.cdp.cof.CircumstancesService/targetingQuery^
+||aws.api.snapchat.com/snapchat.ab.exposure_service.ExposureService/BatchUpdateAbExposure^
 ||snap-api.arkoselabs.com/metrics/
 ||zona.plus/ajax/visit-stats
 ||showstopped.com/owa/log.php

--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -2501,6 +2501,7 @@ brasil247.com###taboola-mid-article-leia-mais
 ||snapchat.com/report-metrics/
 ||web.snapchat.com/web-blizzard/web/send^
 ||accounts.snapchat.com/accounts/static/scripts/pixel.js
+||accounts.snapchat.com/accounts/sso?client_id=snapchat-com-metrics
 ||snap-api.arkoselabs.com/metrics/
 ||zona.plus/ajax/visit-stats
 ||showstopped.com/owa/log.php


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

fix #228027 snapchat.com missed trackers: SSO metrics, GCP, AWS

### Add your comment and screenshots

blocking the `/sso?client_id=snapchat-com-metrics`, this does not matter when logging in. I confirmed on my browser. Also, I found GCP and AWS tracker endpoints:

- `gcp.api.snapchat.com/web-blizzard/web/send`:
  - Analytics/telemetry (Snapchat's "Blizzard" pipeline)
  - Called 5× during login; protobuf POST; different subdomain from the already-blocked `web.snapchat.com/web-blizzard/web/send`
- `aws.api.snapchat.com/snapchat.cdp.cof.CircumstancesService/targetingQuery`:
  - CDP audience targeting; gRPC-web; called 2×
- `aws.api.snapchat.com/snapchat.ab.exposure_service.ExposureService/BatchUpdateAbExposure`:
  - A/B test exposure logging
  - gRPC-web; payload includes experiment key `GOOGLE_OAUTH_CONSUMER_LOGIN_AB__188607`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met