### PR TITLE
Upd #228631 minefun.io patched `.poki-ad-slot` leftover

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -930,6 +930,7 @@ $third-party,script,domain=klto9.com|f2movies.to|hacamchicac.com|yourporngod.com
 !
 ! NOTE: Specific rules
 !
+lurkers.io,swordmasters.io,vectaria.io,cryzen.io,tribals.io,venge.io,minefun.io##.poki-ad-slot
 elamigosgamez.net##.content_store
 elamigosgamez.net##.row > div.portfolio-item:not(:has(> div.card > a[href^="https://www.elamigosgamez.net/"]))
 elamigosgamez.net##.container > h3.my-4:contains(Advertising)


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

### Add your comment and screenshots

Please check the https://github.com/AdguardTeam/AdguardFilters/issues/228631#issuecomment-4234707449 comment first.

I investigated Poki standalone game domains from https://poki.com/en/io and https://poki.us.com/games/io.

Domains with Poki SDK but no `.poki-ad-slot` fired (lurkers.io, swordmasters.io, vectaria.io) are included preventively.

Scope: poki.com/en/io and poki.us.com/games/io only. Other Poki game categories have not yet been investigated.
Because there are too many game services on poki.com.

> This game SDK source path is `game-cdn.poki.com/scripts/*/poki-sdk-core-*.js`


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met