### PR TITLE
Address True Anthem tracking params

### DIFF
--- a/TrackParamFilter/sections/general_url.txt
+++ b/TrackParamFilter/sections/general_url.txt
@@ -9,6 +9,11 @@
 !
 ! NOTE: Generic rules
 !
+! True Anthem
+! https://github.com/AdguardTeam/AdguardFilters/issues/228929
+! https://github.com/AdguardTeam/AdguardFilters/issues/222986
+$removeparam=link_source
+$removeparam=taid
 ! Telergam Ads click tracking
 $removeparam=tgclid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/224235

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -88,9 +88,6 @@ ref=shadcn.com^$removeparam=ref
 ||ratel-ad.com^$removeparam=advertiser
 ||123chat.jp/promotion/$removeparam=cid
 ||123chat.jp/promotion/$removeparam=p
-! https://github.com/AdguardTeam/AdguardFilters/issues/222986
-||tw.news.yahoo.com^$removeparam=link_source
-||tw.news.yahoo.com^$removeparam=taid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/223033
 ||netmonet.co^$removeparam=id
 ||netmonet.co^$removeparam=wpid


### PR DESCRIPTION
Related issues:

- https://github.com/AdguardTeam/AdguardFilters/issues/222986

- https://github.com/AdguardTeam/AdguardFilters/issues/228929


References:

- https://support.trueanthem.com/hc/en-us/articles/23899197013140-Setup-Custom-UTM-and-Query-String-Tracking

I'm not too confident of false positives rates of these 2 params if removing globally. For `link_source`, maybe we can narrow it more to

```adblock
^link_source=ta_$removeparam=link_source
```