### PR TITLE
fix #229793 amazon.com mobile carousel infinite loading

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -5123,7 +5123,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||amazon.com/follow/log-metrics^
 ||amazon.com^*/impress.html
 ||m.media-amazon.com/images/G/*/msa/vowels/metrics
-||m.media-amazon.com/images/I/*.js?AUIClients/GWMMetricsJS
 ||m.media-amazon.com/images/S/sash/*.js?csm_attribution=
 ||amazonaws.com/pixelpop/app/pixelpop-
 ||an.yandex.ru/count/


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

fix #229793

### Enter the issue address

### Add your comment and screenshots

`GWMMetricsJS` is a functional lazy-load script for the gwm-window carousel, not a pure tracker.

It's a functional module that triggers `P.declare('cf')` in Amazon's AUI system, which in turn gates the loading of `GWMWebAssets` (carousel JS).

Blocking it → carousel skeleton never resolves.

Caused by #228025, a previously taken issue. But `msa/vowels/metrics` and `/sash/` rules kept (confirmed not causes).

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met