### PR TITLE
fix #229811 v.daum.net

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -9790,6 +9790,9 @@ world.rugby##.main-nav__promo-link
 buzzfeed.com##.Ad--loading
 businesstoday.in##.sponsored_widget
 ||show.wealthn.com/iframe/ad*.php
+! https://github.com/AdguardTeam/AdguardFilters/issues/229811
+v.daum.net##div[data-cloud$="_ad"]
+v.daum.net##.ad_body2
 v.24liveblog.com##.lb24-base-list-ad
 ||animeflv.*/api/pop.php
 ||gifyu.com^$domain=masahub.net


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [ ] This is not an ad/bug report;
- [ ] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [ ] I have performed a self-review of my own changes;
- [ ] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Closes #229811.

### Add your comment and screenshots

<details>
  <summary>Screenshot 1</summary>

  ![Screenshot 1](https://cdn.adguardcdn.com/sitereports/pphxhkkb6hw0c0o0c88s0sows0w8g4w9unog77hrbw.png?nc=1)
</details>

Three Kakao AdFit slots on v.daum.net article pages were rendering unblocked: the article-bottom 728x90 (`<div class="ad_wrap" data-cloud="pc_dynamic_article_bottom_ad">`), and two 300x250 sidebar slots wrapped in `<div class="box_cluster box_ad">` with `data-cloud="pc_dynamic_aside_top_ad"` / `pc_dynamic_aside_bottom_ad`. There is also a middle-content ad that gets injected at runtime into `<div class="ad_body2">`.

I targeted the parent containers via `data-cloud$="_ad"` rather than the inner `ins.kakao_ad_area` to avoid leaving empty space behind. Checked across a few article URLs and on iPhone Safari UA — mobile uses `data-cloud="dynamic_*_ad"` (no `pc_` prefix) so the same selector covers both. The `_ad`-suffixed `data-cloud` values I observed are all ads; non-ad cloud values (`newsview_comment_container`, etc.) don't end in `_ad`, so over-blocking risk on this domain is low.

Network blocking isn't an option for this site — `display.ad.daum.net/sdk/native?ctag=` is already allowlisted (`BaseFilter/sections/allowlist.txt:3069`, comment says "daum.net - broken"), so the SDK has to load and the fix has to be cosmetic.

Same `kakao_ad_area` + `data-cloud$="_ad"` pattern shows up on news.daum.net and sports.daum.net as well — happy to extend this in a follow-up if it would help.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met




