### PR TITLE
remove duplicate filter rules

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -525,7 +525,6 @@ telugusexkathalu.com,daemon-hentai.com,teamkong.rf.gd,ad4msan.com,ossels.ai,worl
 telugusexkathalu.com,daemon-hentai.com,teamkong.rf.gd,ad4msan.com,rozgarnews.com,chat.irc.in.th,ossels.ai,world-iptv.club,edoga.biz.hr,radiofreehubcity.com,jobalertswithgbrar.com,spyro.blogu.co.uk,cybermania.ws,teamkong.tk#%#//scriptlet('abort-current-inline-script', 'jQuery', '#zdn-adblock-overlay')
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_safari)
 rozgarnews.com,chat.irc.in.th,edoga.biz.hr,radiofreehubcity.com,jobalertswithgbrar.com,spyro.blogu.co.uk,cybermania.ws#@#.ad-unit:not(.textads)
-rozgarnews.com,chat.irc.in.th,edoga.biz.hr,radiofreehubcity.com,jobalertswithgbrar.com,spyro.blogu.co.uk,cybermania.ws#@#.ad-unit:not(.textads)
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$xmlhttprequest,domain=cybermania.ws|spyro.blogu.co.uk|jobalertswithgbrar.com|radiofreehubcity.com|edoga.biz.hr|chat.irc.in.th|rozgarnews.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,script,domain=cybermania.ws|spyro.blogu.co.uk|jobalertswithgbrar.com|radiofreehubcity.com|edoga.biz.hr|chat.irc.in.th|rozgarnews.com
 @@||google-analytics.com/collect?*ad-test$image,domain=cybermania.ws|spyro.blogu.co.uk|jobalertswithgbrar.com|radiofreehubcity.com|edoga.biz.hr|chat.irc.in.th|rozgarnews.com
@@ -9594,7 +9593,6 @@ freevocabulary.com#$##adWrap { display: block!important; height: 1px!important; 
 @@||cdn.jsdelivr.net/npm/videojs-contrib-ads/dist/videojs.ads.min.css$domain=yandexcdn.com
 @@||cdn.jsdelivr.net/npm/videojs-contrib-ads/dist/videojs.ads.min.js$domain=yandexcdn.com
 @@||storage.googleapis.com/vkcdnservice.appspot.com/script$domain=yandexcdn.com
-||deliver.vkcdnservice.com/api/spots/$redirect=nooptext,domain=yandexcdn.com
 ||deliver.vkcdnservice.com/api/spots/$redirect=nooptext,domain=yandexcdn.com
 !+ PLATFORM(ios, ext_safari, ext_android_cb)
 @@||deliver.vkcdnservice.com/api/spots/$domain=yandexcdn.com

--- a/BaseFilter/sections/content_blocker.txt
+++ b/BaseFilter/sections/content_blocker.txt
@@ -1716,7 +1716,6 @@ coachmag.co.uk#@#.plainAd
 @@||google-analytics.com/analytics.js$domain=volvo-club.cz
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39709
 @@||10play.com.au/static/ads.js
-@@||10play.com.au/static/ads.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39588
 tvtropes.org##div[style*="z-index: 100001;"][style*="position: fixed;"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39745

--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -187,7 +187,6 @@ dlsdk.appsflyer.com^
 ||log.documentreaderapp.com^
 ||datasink.sensorsjourney.com^
 ||apm-native.redbascket.com^
-||apm-native.redbascket.com^
 ||apm-fe.rnote.com^
 ||lng.xiaohongshu.com^
 ||t2.xiaohongshu.com^

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -2879,7 +2879,6 @@ $removeparam=s,domain=twitter.com|x.com
 !
 ||boomstore.de/*.html$removeparam=campaign
 ||www.alternate.de^$removeparam=campaign
-||www.alternate.de^$removeparam=campaign
 !
 ||cosse.de^$removeparam=sPartner
 ||www.technikdirekt.de^$removeparam=sPartner


### PR DESCRIPTION
While poking around the filter sources I noticed a few rules that appear twice on consecutive lines in the same file — likely copy-paste accidents during merges. Removing the second occurrence in each pair. No functional change since the rule was already active; this just trims the dead lines.

Affected:

- `BaseFilter/sections/antiadblock.txt:528` — `rozgarnews.com,chat.irc.in.th,…#@#.ad-unit:not(.textads)`
- `BaseFilter/sections/antiadblock.txt:9598` — `||deliver.vkcdnservice.com/api/spots/$redirect=nooptext,domain=yandexcdn.com`
- `BaseFilter/sections/content_blocker.txt:1719` — `@@||10play.com.au/static/ads.js`
- `SpywareFilter/sections/mobile.txt:190` — `||apm-native.redbascket.com^`
- `TrackParamFilter/sections/specific.txt:2882` — `||www.alternate.de^$removeparam=campaign`

Each was verified back-to-back identical (same line content, same surrounding `!#if` context where applicable, no comment between them). aglint passes on all four files.

For what it's worth, a broader scan turned up ~120 more duplicate rule pairs across the repo where the two occurrences live in different parts of the same file (still the same conditional context though). Happy to send a follow-up if there's interest — kept this PR scoped to the unambiguous back-to-back ones to keep review easy.