### PR TITLE
Fix #227687 amazon.com prime video ads

### DIFF
--- a/BaseFilter/sections/general_extensions.txt
+++ b/BaseFilter/sections/general_extensions.txt
@@ -116,6 +116,8 @@ primevideo.com#%#//scriptlet('json-prune', 'cuepointPlaylist vodPlaybackUrls.res
 ||primevideo.com/cdp/getVideoAds
 ||amazon.dev/getVideoAds
 ||amazon.dev/getAds
+! https://github.com/AdguardTeam/AdguardFilters/issues/227687
+||amazon.com/cdp/getVideoAds
 !#if (!ext_ublock)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/217308
 ! Fixes low-resolution issue on live streams


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #227687 amazon.com prime video ads

### Add your comment and screenshots

It can be reproduced intermittently. Add a fallback rule for the [existing blocking video ads rule](https://github.com/AdguardTeam/AdguardFilters/blob/63d0c01c613f8acc717a14f3d9ca82da4b51cd1e/BaseFilter/sections/general_extensions.txt#L129).

<details><summary>Tested recorded video</summary>

https://github.com/user-attachments/assets/8a4c54b6-55f6-4438-bd1d-589743a476cf

Regarding `#@%#` in the user exist rule: it can only be reproduced when AdGuard is disabled. To manage this, add the exception scriptlet rule #@%# to enable intermittent enforcement.

</details> 

### Terms

- [x] By submitting this issue, I agree that the pull request does not contain private info and all conditions are met