### PR TITLE
Fix: meta.com video not loading due to fbcdn.net blocking (issue #230286)

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -2803,6 +2803,8 @@
 @@||vlscppe.microsoft.com/fp/tags.js$stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33905
 @@||uzmantv.com/metadata/$stealth=referrer
+! https://github.com/AdguardTeam/AdguardFilters/issues/230286
+@@||embed.fbsbx.com/embed_vidyard.php$subdocument,stealth=referrer
 ! https://reddit.com/r/Adguard/comments/bq0cab/how_to_configure_so_that_kinja_sites_gizmodo/
 @@||kinja.com/api/profile/accountwithtoken$stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/33872

--- a/SpywareFilter/sections/allowlist.txt
+++ b/SpywareFilter/sections/allowlist.txt
@@ -4217,8 +4217,6 @@ kizi.com#%#window.google_trackConversion = function() {};
 @@||pixel.facebook.com/ajax/gigaboxx/endpoint/UpdateLastSeenTime.php?$image
 @@||pixel.facebook.com/ajax/notifications/mark_read.php?*&alert_ids%$image
 !
-! https://github.com/AdguardTeam/AdguardFilters/issues/230286
-@@||embed.fbsbx.com/embed_vidyard.php$subdocument,stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/131581
 @@||googletagmanager.com/gtm.js$domain=juffing.at
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20945

--- a/SpywareFilter/sections/allowlist.txt
+++ b/SpywareFilter/sections/allowlist.txt
@@ -4218,8 +4218,7 @@ kizi.com#%#window.google_trackConversion = function() {};
 @@||pixel.facebook.com/ajax/notifications/mark_read.php?*&alert_ids%$image
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/230286
-@@||*.fbcdn.net^$media,domain=meta.com
-@@||*.fbcdn.net^$xmlhttprequest,domain=meta.com
+@@||embed.fbsbx.com/embed_vidyard.php$subdocument,stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/131581
 @@||googletagmanager.com/gtm.js$domain=juffing.at
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20945

--- a/SpywareFilter/sections/allowlist.txt
+++ b/SpywareFilter/sections/allowlist.txt
@@ -4217,6 +4217,9 @@ kizi.com#%#window.google_trackConversion = function() {};
 @@||pixel.facebook.com/ajax/gigaboxx/endpoint/UpdateLastSeenTime.php?$image
 @@||pixel.facebook.com/ajax/notifications/mark_read.php?*&alert_ids%$image
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/230286
+@@||*.fbcdn.net^$media,domain=meta.com
+@@||*.fbcdn.net^$xmlhttprequest,domain=meta.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/131581
 @@||googletagmanager.com/gtm.js$domain=juffing.at
 ! https://github.com/AdguardTeam/AdguardFilters/issues/20945


### PR DESCRIPTION
## Prerequisites
- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?
Fix https://github.com/AdguardTeam/AdguardFilters/issues/230286

### Add your comment and screenshots
1. Your comment

Videos on Meta Quest official support pages do not load when AdGuard Tracking Protection filter is enabled. Meta serves video content via *.fbcdn.net CDN, which gets blocked by the filter.

Added exception rule to BaseFilter/sections/allowlist_stealth.txt:
@@||embed.fbsbx.com/embed_vidyard.php$subdocument,stealth=referrer

This rule allows Meta's video embed endpoint on embed.fbsbx.com, targeting specifically the referrer header restriction that was preventing videos from loading. Moved to allowlist_stealth.txt as the rule uses $stealth=referrer option.

2. Screenshots
<details>
<summary>Screenshot 1:</summary>
</details>

### Terms
- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met