### PR TITLE
fix #230284 spigotunlocked.com

### DIFF
--- a/AnnoyancesFilter/Popups/sections/popups_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/popups_specific.txt
@@ -7689,6 +7689,8 @@ kurashiru.com#$##dly-LandingPopupBanner { display: none !important; }
 !+ NOT_OPTIMIZED
 kurashiru.com#$#html.dly-modal-active { overflow: auto !important; }
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/230284
+spigotunlocked.com##li.notice[data-notice-id="2"]
 ! NOTE: Regular rules end ⬆️
 ! !SECTION: Popups - Regular rules
 !


### PR DESCRIPTION
# Creating the pull request

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix <https://github.com/AdguardTeam/AdguardFilters/issues/230284>

### Add your comment and screenshots

1. spigotunlocked.com displays a floating Discord server promotion popup on every visit, encouraging users to join a third-party Discord channel. This falls under the AdGuard Popup filter policy for third-party channel subscription popups.

Note: The Discord server link is already present in the footer, making the popup redundant.

2. Screenshots

<details>

<summary>Screenshot 1:</summary>

<img width="1229" height="901" alt="스크린샷 2026-04-30 오후 10 14 09" src="https://github.com/user-attachments/assets/18a674d0-6e75-4cb7-a419-fc8a2d65fd19" />


</details>



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
