### PR TITLE
Fix #230153 www.nieuwsblad.be

### DIFF
--- a/CyrillicFilters/RussianFilter/sections/specific.txt
+++ b/CyrillicFilters/RussianFilter/sections/specific.txt
@@ -172,6 +172,9 @@ rg.ru##div[class^="PageArticleSecondList_partner"]
 ||ruwiki.ru/api/ruwiki/rest/adv/
 realty.yandex.ru##div[class*="OfferCardAd"]
 realty.yandex.ru##.CardSection:has(> div[class*="OfferCardAd"])
+! https://github.com/AdguardTeam/AdguardFilters/issues/229965
+market.yandex.ru##[data-apiary-widget-name="@monetize/MadvHeaderPromo"]
+market.yandex.ru#$##MainHeader { margin-top: 0 !important }
 flcksbr.*#$#.wrapper { height: 100% !important; }
 habr.com,khersondaily.com##.banner-slider
 searchfloor.org#%#//scriptlet('prevent-addEventListener', 'click', '/window\.open[\s\S]*?window\.location\.href/')

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -126,6 +126,10 @@ iphoned.nl##div[data-name="featured-header-container"] > header[data-campaign]
 iphoned.nl##article > .no-content-styles:has(> div[data-nosnippet] > div[data-name="dynamic-content-injected"][data-campaign])
 rtl.nl##div[data-adslot-variant]
 bright.nl##html > body .ad:not(#style_important)
+nieuwsblad.be###ad_abovehero-1
+nieuwsblad.be###ad_inline-1
+nieuwsblad.be###ad_inline-2
+nieuwsblad.be###ad_recirculation-1
 nieuwsblad.be##.cba_container_grid
 dumpert.nl##div[class^="css-"]:has(> div[class^="css-"]:only-child > .ad)
 402online.com##.bannerblock

--- a/DutchFilter/sections/specific.txt
+++ b/DutchFilter/sections/specific.txt
@@ -126,10 +126,9 @@ iphoned.nl##div[data-name="featured-header-container"] > header[data-campaign]
 iphoned.nl##article > .no-content-styles:has(> div[data-nosnippet] > div[data-name="dynamic-content-injected"][data-campaign])
 rtl.nl##div[data-adslot-variant]
 bright.nl##html > body .ad:not(#style_important)
-nieuwsblad.be###ad_abovehero-1
-nieuwsblad.be###ad_inline-1
-nieuwsblad.be###ad_inline-2
-nieuwsblad.be###ad_recirculation-1
+nieuwsblad.be##[id^="ad_abovehero-"]
+nieuwsblad.be##[id^="ad_inline-"]
+nieuwsblad.be##[id^="ad_recirculation-"]
 nieuwsblad.be##.cba_container_grid
 dumpert.nl##div[class^="css-"]:has(> div[class^="css-"]:only-child > .ad)
 402online.com##.bannerblock


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix <https://github.com/AdguardTeam/AdguardFilters/issues/230153>

## Description

The ad URLs on www.nieuwsblad.be are properly blocked, but unprocessed 
ad container layouts remain visible.

These layouts use dynamic IDs that vary by article:
- `ad_abovehero-*`
- `ad_inline-*`
- `ad_recirculation-*`

To handle the dynamic suffixes, I used attribute prefix selectors.

## Filter rules added
```Adblock Filter List 
nieuwsblad.be##[id^="ad_abovehero-"]
nieuwsblad.be##[id^="ad_inline-"]
nieuwsblad.be##[id^="ad_recirculation-"]
```
## Additional observations

The same `ad_*` ID prefix pattern is also present on sister sites using 
the same Mediahuis CMS. I verified this on standaard.be and hln.be — 
the identical ID patterns appear in their article pages, so the rules 
could be generalized as
```Adblock Filter List 
nieuwsblad.be,standaard.be,hln.be##[id^="ad_inline-"]
nieuwsblad.be,standaard.be,hln.be##[id^="ad_abovehero-"]
nieuwsblad.be,standaard.be,hln.be##[id^="ad_recirculation-"]
```

Additionally, ads from `shop.nieuwsblad.be` are still displayed on news 
article pages even after this PR. Since these promotional contents are 
unrelated to news articles and may distract readers from the main 
content, it might be worth considering blocking them on 
`www.nieuwsblad.be` pages as well.

Happy to open separate issues and follow-up PRs for these if maintainers 
prefer.

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
