### PR TITLE
Fix #230378 straders.net

### DIFF
--- a/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
+++ b/AnnoyancesFilter/Popups/sections/subscriptions_specific.txt
@@ -9464,7 +9464,11 @@ mail.ru###subscriptionFormWeekMainBlockId
 magazine.skyeng.ru##.tg-banner
 !+ NOT_OPTIMIZED
 nli-research.co.jp##.mail_maga
-!
+! https://github.com/AdguardTeam/AdguardFilters/issues/230378
+!+ NOT_OPTIMIZED
+straders.net##.elementor-popup-modal
+!+ NOT_OPTIMIZED
+straders.net##.dialog-prevent-scroll:style(overflow: auto !important)
 ! NOTE: Regular rules end ⬆️
 ! !SECTION: Subscriptions - Regular rules
 !


### PR DESCRIPTION
## Prerequisites
- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
- [x] Annoyances — pop-ups, cookie warnings, etc;

## What issue is being fixed?
Fix [#230378](https://github.com/AdguardTeam/AdguardFilters/issues/230378)

## Add your comment and screenshots
straders.net displays an Elementor newsletter popup on page load. Two rules are required:
1. `.elementor-popup-modal` hides the popup (class-based selector used instead of ID-based `.elementor-97606` for stability).
2. `.dialog-prevent-scroll:style(overflow: auto !important)` restores scroll, as Elementor adds this class to `<body>` even when the popup is hidden.

Both rules verified with AdGuard Browser Extension user rules.

## Terms
- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met