### PR TITLE
Fix #230412 ragmaya.kr

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -12322,3 +12322,5 @@ dirtstyle.tv##.lightbox
 bigbrothercanada.ca#%#//scriptlet('set-constant', 'video_player_config.players.0.adblock', 'false')
 !+ PLATFORM(ios, ext_android_cb)
 @@||bigbrothercanada.ca^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/230412
+ragmaya.kr#%#//scriptlet('set-session-storage-item', 'rm_adblock_bypass', '1')


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix <https://github.com/AdguardTeam/AdguardFilters/issues/230412>

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->

  `ragmaya.kr` ships a self-implemented anti-adblock detection script (`/static/rm_adblock_wall.js?v=20260423w`) that overlays the page when it detects that Google AdSense (`adsbygoogle.js`) failed to load. AdGuard's blocking of `||googlesyndication.com/pagead/` is correct (it is a real ad endpoint); what the reporter saw as "site broken" is the wall the site itself injects in response.
  
  > Note: the issue was filed under `T: Incorrect Blocking`, but the underlying cause is an anti-adblock detection wall, not over-blocking — hence the `AdGuard gets detected on a website` category above. Maintainers may want to re-label the issue.
  
  **Detection logic (rm_adblock_wall.js)**
  
  The script triggers the wall when **2 of 3** detection methods report blocking:
  
  1. **Bait element** — creates `<div class="adsbox pub_300x250 ad-banner ad-unit adsbygoogle">` and checks `offsetHeight === 0` after 200 ms.
  2. **AdSense state** — checks whether `window.adsbygoogle` is properly populated (push function present) after 2 s.
  3. **Image ping** — loads `pagead2.googlesyndication.com/pagead/images/px.gif` with a 3 s timeout.
  
  When triggered, `showWall()` injects `<div id="rmAdblockWall">…</div>` and additionally sets `document.documentElement.style.overflow = 'hidden'` and `document.body.style.overflow = 'hidden'`.
  
  **Built-in bypasses (left in the script by the site author)**
  
  ```js
  // App environment short-circuit
  if (isAppEnv()) return;   // ?app=1 / Capacitor / WebView UA / NATIVE_DEVICE_ID / ragmaya_is_app=1 cookie
  
  // Session-level bypass for ?noadblock=1 visitors
  if (sessionStorage.getItem('rm_adblock_bypass') === '1') return;
  ```
  
  **Fix**
  
  ```
  ragmaya.kr#%#//scriptlet('set-session-storage-item', 'rm_adblock_bypass', '1')
  ```
  
  Added to `BaseFilter/sections/antiadblock.txt`. The fix exploits the site's own session-storage bypass: setting `rm_adblock_bypass = '1'` before `rm_adblock_wall.js` runs causes it to short-circuit at the early `return` above, so neither the detection logic nor `showWall()` ever execute. Preferred over a pure cosmetic hide for three reasons:
  
  1. **No DOM mutation, no side effects.** A cosmetic `###rmAdblockWall` rule hides the visible wall, but `showWall()` still applies inline `overflow:hidden` to `<html>`/`<body>` — a latent risk that requires two additional `#$#` overflow-reset rules to fully neutralize. The scriptlet prevents `showWall()` from running at all, so the inline overflow lock never gets set.
  2. **Single rule replaces three.** One scriptlet vs. cosmetic + html overflow + body overflow.
  3. **Aligns with site intent.** The bypass key is one the site author themselves placed for `?noadblock=1` visitors; the rule uses an explicitly-supported escape hatch rather than fighting injected DOM.
  
  Fits the existing `antiadblock.txt` scriptlet convention — e.g. `bigbrothercanada.ca#%#//scriptlet('set-constant', 'video_player_config.players.0.adblock', 'false')` already in this file.



2. Screenshots

<details>

<summary>Screenshot 1: Without the rule — anti-adblock wall covers the page</summary>

<!-- paste screenshot here -->

<img width="3018" height="1640" alt="230412-ragmaya-wall-visible" src="https://github.com/user-attachments/assets/3e95bfb4-134f-490d-90c9-5920c1534bed" />

</details>

<details>

<summary>Screenshot 2: With the scriptlet — wall is never injected, page renders normally</summary>

<!-- paste screenshot here -->

<img width="3014" height="1638" alt="230412-ragmaya-wall-hidden" src="https://github.com/user-attachments/assets/818e8063-1a01-4657-84b4-48d665634fdc" />

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
