### PR TITLE
Fix #230331 paste4free.site

### DIFF
--- a/BaseFilter/sections/antiadblock.txt
+++ b/BaseFilter/sections/antiadblock.txt
@@ -12322,3 +12322,5 @@ dirtstyle.tv##.lightbox
 bigbrothercanada.ca#%#//scriptlet('set-constant', 'video_player_config.players.0.adblock', 'false')
 !+ PLATFORM(ios, ext_android_cb)
 @@||bigbrothercanada.ca^$generichide
+! https://github.com/AdguardTeam/AdguardFilters/issues/230331
+paste4free.site#%#//scriptlet('set-constant', 'popunders', 'noopFunc')


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix <https://github.com/AdguardTeam/AdguardFilters/issues/230331>

### Add your comment and screenshots

1. Your comment

<!-- Please write a comment here -->

`paste4free.site` ships an inline anti-adblock detection script that overlays the page with an "AdBlock Detectado!" modal once it detects that its popunder ad SDK (`comradegoodsfloor.com/...`) failed to load. AdGuard's blocking of the popunder network is correct; what the reporter saw is the wall the site itself injects in response.

**Detection logic (inline in page HTML)**

```js
function abd3t3ct3d() {
    let t = document.createElement("style");
    let e = document.createElement("div");
    e.classList.add("ab-modal-wrapper", "center");
    e.innerHTML = '<div class="ab-modal-wrapper center">...AdBlock Detectado!...</div>';
    t.innerHTML = ".ab-modal-wrapper{position:fixed;width:100vw;height:100vh;z-index:9999;...}";
    document.head.appendChild(t);
    document.body.prepend(e);
}

setTimeout(function() {
    if (void 0 === window.popunders) abd3t3ct3d();
}, 10);
```

The trigger is a single condition: `void 0 === window.popunders`. The popunder SDK sets this global on successful load; when blocked, it stays `undefined` and the 10 ms timeout fires `abd3t3ct3d()`, which prepends a `position: fixed; z-index: 9999` full-viewport overlay to `<body>`.

**Fix**

```
paste4free.site#%#//scriptlet('set-constant', 'popunders', 'noopFunc')
```

Pre-defines `window.popunders` as a no-op function at `document_start`, so the trigger condition evaluates `false` and `abd3t3ct3d()` never runs — the modal never enters the DOM.

Preferred over `##.ab-modal-wrapper` for two reasons: the 10 ms timer is short enough that the modal could flash before the cosmetic selector takes effect; and the class name is trivial to rename in a future deploy, whereas `popunders` is tied to the ad network's SDK convention and would require coordinated changes with `comradegoodsfloor.com` to rename.

Fits the existing `set-constant` pattern in this file — e.g. `bigbrothercanada.ca#%#//scriptlet('set-constant', 'video_player_config.players.0.adblock', 'false')`.

2. Screenshots

<details>

<summary>Screenshot 1: Without the rule — "AdBlock Detectado!" modal covers the page</summary>

<!-- paste screenshot here -->

<img width="3014" height="1502" alt="230331-paste4free site-modal-visible" src="https://github.com/user-attachments/assets/2768de02-7fc7-4eb2-90e2-66dbce671bf9" />

</details>

<details>

<summary>Screenshot 2: With the scriptlet — modal is never injected, page renders normally</summary>

<!-- paste screenshot here -->

<img width="3024" height="1526" alt="230331-paste4free site-modal-hidden" src="https://github.com/user-attachments/assets/f83e8924-be04-4c2c-8425-56c70e1092cc" />


</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
