### PR TITLE
Fix Google AI Mode breakage caused by removing biw/bih

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -2669,6 +2669,9 @@ $removeparam=search_domain,domain=ya.ru|yandex.*
 ||google.*/search$removeparam=gs_l
 ||google.*/search$removeparam=oe
 ||google.*/websearch$removeparam=visit_id
+! Breaks Google AI Mode: https://github.com/AdguardTeam/AdguardFilters/issues/230074#issuecomment-4373810852
+! ||google.*/search$removeparam=biw
+! ||google.*/search$removeparam=bih
 ||google.*/search$removeparam=sa
 ||google.*/search$removeparam=source
 ||google.*/search$removeparam=aqs

--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -2669,8 +2669,6 @@ $removeparam=search_domain,domain=ya.ru|yandex.*
 ||google.*/search$removeparam=gs_l
 ||google.*/search$removeparam=oe
 ||google.*/websearch$removeparam=visit_id
-||google.*/search$removeparam=biw
-||google.*/search$removeparam=bih
 ||google.*/search$removeparam=sa
 ||google.*/search$removeparam=source
 ||google.*/search$removeparam=aqs


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

Related issue thread: https://github.com/AdguardTeam/AdguardFilters/issues/230074

Specific report/comment addressed by this PR: https://github.com/AdguardTeam/AdguardFilters/issues/230074#issuecomment-4373810852

Note: this PR only addresses the Google AI Mode `biw`/`bih` breakage described in the linked comment, not every report in the broader `google.com` issue thread.

### Add your comment and screenshots

1. Your comment

Google AI Mode (`udm=50`) breaks when the URL Tracking filter removes the `biw` and `bih` parameters from Google Search URLs.

This PR removes these two rules from the Google Search cleanup list:

```adblock
||google.*/search$removeparam=biw
||google.*/search$removeparam=bih
```

Manual testing: I tested the Google Search `removeparam` rules one by one. Removing `sca_esv`, `fbs`, `sa`, `ved`, and `sourceid` did not break AI Mode. AI Mode started working again only after preserving both `biw` and `bih`.

When broken, Chrome shows `ERR_TOO_MANY_REDIRECTS` instead of opening AI Mode.

`biw` and `bih` appear to be functional viewport/layout parameters for Google AI Mode, not purely tracking parameters.

2. Screenshots

<details>

<summary>Screenshot 1(biw/bih removed in param):</summary>

<img width="666" height="431" alt="image" src="https://github.com/user-attachments/assets/cdea9ba4-f51c-4e1a-93a3-d88904de9480" />

</details>

<details>

<summary>Screenshot 2 (biw/bih not removed in param):</summary>

<img width="752" height="462" alt="image" src="https://github.com/user-attachments/assets/dbeb6009-1449-42c8-acbc-1e7ec89488c1" />

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met