### PR TITLE
upd: Revert "fix #228025 amazon.com - missed trackers (#228079)"

### DIFF
--- a/SpywareFilter/sections/specific.txt
+++ b/SpywareFilter/sections/specific.txt
@@ -5153,8 +5153,6 @@ dreamprogs.net##td[width="88"][height="31"]
 ||amazon.com/empty.gif?
 ||amazon.com/follow/log-metrics^
 ||amazon.com^*/impress.html
-||m.media-amazon.com/images/G/*/msa/vowels/metrics
-||m.media-amazon.com/images/S/sash/*.js?csm_attribution=
 ||amazonaws.com/pixelpop/app/pixelpop-
 ||an.yandex.ru/count/
 ||aol.com/ping?


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

upd https://github.com/AdguardTeam/AdguardFilters/issues/227687#issuecomment-4364605482

### Add your comment and screenshots

After these changes, loading of the main content on amazon.com (#229793) and product page content is having issues.

I think these tracker filters are very risky. This reverts commit 500487955ab263889627d0a449dc21b0f0bc7992.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met