### PR TITLE
Fix #230492 musenboya.com anti-adblock

### DIFF
--- a/JapaneseFilter/sections/antiadblock.txt
+++ b/JapaneseFilter/sections/antiadblock.txt
@@ -462,13 +462,15 @@ coolpan.net#@#.ad-area:not(.text-ad)
 g-pc.info#%#//scriptlet('set-constant', 'adsbygoogle.loaded', 'true')
 !+ PLATFORM(ios, ext_android_cb, ext_safari)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=g-pc.info
+! https://github.com/AdguardTeam/AdguardFilters/issues/230492
 ! https://github.com/AdguardTeam/AdguardFilters/issues/103488
 ||ad-stir.com/js/adstir.js$script,redirect=noopjs,domain=musenboya.com
 ||i-mobile.co.jp/script/v1/spot.js$script,redirect=noopjs,domain=musenboya.com
 ||nend.net/js/nendAdLoader.js$script,redirect=noopjs,domain=musenboya.com
 @@||musenboya.com^$generichide
 musenboya.com##.widget_pc_ad
-musenboya.com#%#//scriptlet('prevent-setTimeout', '/location\.href|document\./')
+musenboya.com#%#//scriptlet('prevent-element-src-loading', 'script', 'imp-adedge.i-mobile.co.jp')
+musenboya.com#%#//scriptlet('prevent-element-src-loading', 'script', 'js.ad-stir.com')
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
 @@||ad-stir.com/js/adstir.js$domain=musenboya.com
 @@||js1.nend.net/js/nendAdLoader.js$domain=musenboya.com


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [x] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

close #230492

### Add your comment and screenshots

Site removed `setTimeout` wrapper from `onerror` handler.
Therefore, `prevent-setTimeout` no longer intercepts the redirect.

`prevent-element-src-loading` catches `src` assignment before the network request fires, making `onerror` unreachable.


### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met