### PR TITLE
Fix #230951 dizifilm.to

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -1488,6 +1488,8 @@ oyungemisi.com##.slot-container
 ||hdfilmcanavari.org/hm/hm.php
 fullhdfilmizle.*##footer > div.top.text
 fullhdfilmizle.*##div[style="width: 100%;height:50px;margin-bottom:10px;"]
+||fullhdfilmizle.*/ad/*.mp4^         
+fullhdfilmizle.*##div.my-4:has(video[src*="/ad/"])
 fullhdfilmmodu2.*##.fkay
 livefullfilmizle.org,elzemfilm.org,fullhdfilmmodu2.*##a[target="_blank"] > video
 ||fullhdfilmmodu.*/caching/caching.php

--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -1488,7 +1488,7 @@ oyungemisi.com##.slot-container
 ||hdfilmcanavari.org/hm/hm.php
 fullhdfilmizle.*##footer > div.top.text
 fullhdfilmizle.*##div[style="width: 100%;height:50px;margin-bottom:10px;"]
-||fullhdfilmizle.*/ad/*.mp4^         
+||fullhdfilmizle.*/ad/*.mp4
 fullhdfilmizle.*##div.my-4:has(video[src*="/ad/"])
 fullhdfilmmodu2.*##.fkay
 livefullfilmizle.org,elzemfilm.org,fullhdfilmmodu2.*##a[target="_blank"] > video


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?



- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?
Fix #230951 

Video ads served from the site's own domain (`/ad/*.mp4`) are not blocked on `fullhdfilmizle.*`.
Added a network rule to block self-hosted video ad requests and a cosmetic rule to remove the ad container element.

New rules:
```
||fullhdfilmizle.*/ad/*.mp4^         
fullhdfilmizle.*##div.my-4:has(video[src*="/ad/"])
```



2. Screenshots

<details>

<summary>Screenshot 1: Before (ad visible)</summary>


<img width="949" height="698" alt="image" src="https://github.com/user-attachments/assets/f49a28b3-cd7a-4452-b370-dee7166a66df" />
</details>

<details>

<summary>Screenshot 2: After (ad blocked)</summary>

<img width="922" height="811" alt="image" src="https://github.com/user-attachments/assets/ebce7907-5c5a-4bee-84d8-b21fb1ec4d29" />

</details>

### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
