### PR TITLE
Fix #231379 www.marmiton.org

### DIFF
--- a/BaseFilter/sections/allowlist.txt
+++ b/BaseFilter/sections/allowlist.txt
@@ -144,6 +144,8 @@ $popup,third-party,domain=dood.ws,badfilter
 !
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/231379
+@@||afcdn.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/230813
 @@||tg1.aniview.com/api/adserver/spt?$domain=nuovavenezia.it
 @@||player.avplayer.com^$domain=nuovavenezia.it


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [ ] Missed ads or ad leftovers;
- [x] Website or app does not work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons - share, like, tweet, etc;
- [ ] Annoyances - pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

Fix https://github.com/AdguardTeam/HostlistsRegistry/issues/823

### Add your comment and screenshots

1. Your comment

Allow `afcdn.com`, which is used by Marmiton for static CSS, JS, and image assets and is incorrectly blocked by DNS typosquatting protection.

2. Screenshots

N/A

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
