### PR TITLE
Update engine and release age requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,16 @@ updates:
     schedule:
       # No need to check for updates more often than once a month
       interval: monthly
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for NPM - typically AGLint updates
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
+      # TODO: npm does not yet support excluding specific dependencies
+      # exclude:
+      #   - '@adguard/*'

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+allow-git=none

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "markdownlint-cli": "^0.48.0"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22",
+                "npm": ">=11.10.0"
             }
         },
         "node_modules/@adguard/aglint": {
@@ -863,9 +864,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2693,9 +2694,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2881,9 +2882,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-            "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3125,9 +3126,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "license": "GPL-3.0-only",
     "type": "module",
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22",
+        "npm": ">=11.10.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR updates the npm configuration to enforce a minimum release age for packages. This helps reduce the risk of dependency chain attacks by preventing newly published packages from being installed immediately.

Unfortunately, npm does not support exclusions for this feature and enforces the rule for all packages.

Another open question is that `min-release-age` requires at least npm 11.10.0 (Feb 2026). Older versions silently ignore the configuration unless we enforce a strict engine version.

We may also want to consider switching to pnpm, but that would introduce an additional installation step for everyone setting up the repository.