### PR TITLE
Update adservers.txt

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -68,6 +68,15 @@
 ||kiki18.com^
 ||insensitiveshoweraudible.com^
 ||huldeeforgoer.com^
+||samsungads.com^$third-party
+||smetrics.samsung.com^$third-party
+||nmetrics.samsung.com^$third-party
+||samsung-com.112.2o7.net^$third-party
+||analytics-api.samsunghealthcn.com^$third-party
+||click.oneplus.cn^$third-party
+||open.oneplus.net^$third-party
+||metrics.icloud.com^$third-party
+||metrics.mzstatic.com^$third-party
 ||baggyrepackingrocky.com^
 ||toodlerehouse.com^
 ||overplantovervaluetwine.com^


### PR DESCRIPTION
✅ Summary of changes

This pull request adds a small number of additional third-party domains that appear to be related to OEM-level telemetry or analytics. These entries are not currently present in the existing filter lists.

The change is intentionally minimal and scoped only to clearly identifiable analytics-style endpoints.

🔧 What problem does this pull request fix?
☑ Missed analytics or tracker
🧩 What issue is being fixed?

No existing issue is referenced.

This pull request is submitted as a small incremental improvement to telemetry coverage.

📌 Changes introduced

The following domains are added with $third-party restriction:

Samsung-related domains
samsungads.com
smetrics.samsung.com
nmetrics.samsung.com
samsung-com.112.2o7.net
OnePlus-related domains
click.oneplus.cn
open.oneplus.net
Apple-related metrics endpoints
metrics.icloud.com
metrics.mzstatic.com
⚠️ Risk assessment

This change is expected to be low-risk for the following reasons:

Rules target only analytics/telemetry-style endpoints
No core service domains (authentication, content delivery, OS functionality) are included
All rules are scoped using $third-party modifier
No broad wildcards or aggressive patterns are introduced
No modification of existing rules or removal of entries

No functional impact on end-user application behavior is expected.

✔️ Self-review checklist
☑ This is not an ad or bug report
☑ Changes follow AdGuard filter syntax guidelines
☑ Scope is limited to clearly identified telemetry endpoints
☑ No overblocking patterns introduced
☑ No sensitive or private information included
☑ No structural or formatting changes outside required entries
🧾 Additional notes

This PR is intended as a small incremental update to improve coverage of OEM telemetry endpoints while maintaining strict conservatism in scope and avoiding any risk of service disruption.