### PR TITLE
Upd #231817 zaxid.net video ad wrapper

### DIFF
--- a/CyrillicFilters/UkrainianFilter/sections/specific.txt
+++ b/CyrillicFilters/UkrainianFilter/sections/specific.txt
@@ -4,6 +4,7 @@
 ! Good: example.org###rek; ||example.com/ads/
 ! Bad: example.org#@##banner_ad (for instance, should be in allowlist.txt or in antiadblock.txt)
 !
+zaxid.net##.video-adv-wrapper
 ! `/upload/rk/` - URL and element hiding rule
 /upload/rk/*$domain=citrus.ua|xsport.ua|zi.dn.ua|zi.ua
 citrus.ua,xsport.ua,zi.dn.ua,zi.ua##img[src^="/upload/rk/"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue addres

Upd https://github.com/AdguardTeam/AdguardFilters/issues/231817

### Add your comment and screenshots

Addresses the first (Ads) report from #231817.

After the video ad is blocked, an empty "ВІДЕО ДНЯ" container remains on article pages. 

The existing rule:
football24.ua,zaxid.net##div[id^="videoAdvWrapper"]

no longer matches zaxid.net because the site now uses desktopVideoAdvWrapper and mobileVideoAdvWrapper IDs.

Added a rule targeting .video-adv-wrapper, which is used by both variants.

While checking this, I also noticed that the old shared rule appears to be obsolete for football24.ua after the site's redesign. I left it unchanged to keep this PR focused.

Issue #231817 contains multiple reports. The annoyance report is handled in a separate [PR](https://github.com/AdguardTeam/AdguardFilters/compare/master...tpqls774:fix/231817-zaxid.net-video-adv?expand=1).

<details>
<summary>Screenshots</summary>
Before:
<img width="1582" height="980" alt="스크린샷 2026-05-28 오후 2 21 09" src="https://github.com/user-attachments/assets/4c19e9a1-b11a-4d1c-b98e-70d7d79728fb" />


After:
<img width="1582" height="980" alt="스크린샷 2026-05-28 오후 2 21 32" src="https://github.com/user-attachments/assets/c738c339-83fa-4a75-b948-84fc1abaf08c" />
</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met