### PR TITLE
fix #232120 medyascope.tv

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -5,6 +5,8 @@
 ! Good: example.org###rek; ||example.com/ads/
 ! Bad: example.org#@##banner_ad (for instance, should be in allowlist.txt or in antiadblock.txt)
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/232120
+medyascope.tv##.elementor-element-6a5fbe4d
 !
 ! Images hosting. Used for advertising on many sites
 !+ NOT_OPTIMIZED


### PR DESCRIPTION
## Prerequisites
- [x] This is not an ad/bug report;
- [x] My code follows the guidelines and syntax of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?
Fix <https://github.com/AdguardTeam/AdguardFilters/issues/232120>

### Add your comment and screenshots

1. Your comment

Hides the newsletter subscription form ("Andaç'a abone olun") at the bottom of medyascope.tv pages. The form is built with Elementor and was not covered by existing filters.

Rule added to `TurkishFilter/sections/specific.txt`:
`medyascope.tv##.elementor-element-6a5fbe4d`

Tested in Firefox with uBlock Origin 1.71.0.

2. Screenshots

<details>
<summary>Screenshot 1 (Before):</summary>
<img width="1470" height="878" alt="스크린샷 2026-05-28 오후 7 53 14" src="https://github.com/user-attachments/assets/42d79546-2fe4-4422-bf6b-b9724700b1fb" />
 -->

</details>

<details>
<summary>Screenshot 2 (After):</summary>
<img width="1470" height="878" alt="스크린샷 2026-05-28 오후 7 53 39" src="https://github.com/user-attachments/assets/5c556060-9372-4a4c-90b5-345a8f742462" />
 -->

</details>

### Terms
- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met