### PR TITLE
Fix #232295 www.asahi.com leftover

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -60,6 +60,8 @@ gundamlog.com###more > iframe[src^="https://richlink.blogsys.jp"]
 !
 ! NOTE: Specific rules
 !
+asahi.com#$#div:has(> .section-container > div > #recommend_click) { margin-top: 16px !important; }
+asahi.com##.section-container:has(> div > #recommend_click)
 nogizaka46link.blog.jp##.include1_iframe1
 nogizaka46link.blog.jp##.include2_iframe1
 ||sonybank.jp/banners/js/fbaasbanner.js

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -60,7 +60,7 @@ gundamlog.com###more > iframe[src^="https://richlink.blogsys.jp"]
 !
 ! NOTE: Specific rules
 !
-asahi.com#$#div:has(> .section-container > div > #recommend_click) { margin-top: 16px !important; }
+asahi.com#$#.border-t:has(> .section-container > div > #recommend_click) { margin-top: 16px !important; }
 asahi.com##.section-container:has(> div > #recommend_click)
 nogizaka46link.blog.jp##.include1_iframe1
 nogizaka46link.blog.jp##.include2_iframe1


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #232295

### Add your comment and screenshots

Please see https://github.com/AdguardTeam/AdguardFilters/issues/232295#issuecomment-4571431002

The user reported that Outbrain content was incorrectly blocked. But it is ads. So I added a leftover rule.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met