### PR TITLE
fix(cookies): hide cookie banner on loadview-testing.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -377,6 +377,8 @@ sabancivakfi.org###ez-banner[role="banner"]
 !
 ! NOTE: Regular rules
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/232322
+loadview-testing.com###ccp-cookie-banner
 demilac.com.tr###cnpl_v01
 kolaygelsin.com##div[class^="Box_container___"][data-testid="box-container"]:has(> img[src="/assets/icons/cookie.svg"])
 expresskargo.com.tr##div[data-testid="cookie-banner-overlay"]


### PR DESCRIPTION
- [x] This is not an ad/bug report;
- [x] My code follows the guidelines and syntax of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

Fix #232322

Hides the cookie consent banner on loadview-testing.com.

Rule added to `AnnoyancesFilter/Cookies/sections/cookies_specific.txt`:
`loadview-testing.com###ccp-cookie-banner`

Tested with Firefox + uBlock Origin 1.71.0.

1. Screenshots

► Screenshot 1 (Before):
<img width="1407" height="840" alt="image" src="https://github.com/user-attachments/assets/bcac3f2b-2ad4-4b0d-b79e-19da5bfa4fed" />


► Screenshot 2 (After):
<img width="1407" height="840" alt="image" src="https://github.com/user-attachments/assets/c888eccc-fb7d-44c8-b95c-8b6a671ff962" />


- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met