### PR TITLE
Fix/232354 autohaus kainz cookie banner

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -377,6 +377,8 @@ sabancivakfi.org###ez-banner[role="banner"]
 !
 ! NOTE: Regular rules
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/232322
+loadview-testing.com###ccp-cookie-banner
 demilac.com.tr###cnpl_v01
 kolaygelsin.com##div[class^="Box_container___"][data-testid="box-container"]:has(> img[src="/assets/icons/cookie.svg"])
 expresskargo.com.tr##div[data-testid="cookie-banner-overlay"]

--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -377,6 +377,10 @@ sabancivakfi.org###ez-banner[role="banner"]
 !
 ! NOTE: Regular rules
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/232354
+autohaus-kainz.de###ccBarMain
+autohaus-kainz.de###ccBar-opener
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/232322
 loadview-testing.com###ccp-cookie-banner
 demilac.com.tr###cnpl_v01


### PR DESCRIPTION
- [x] This is not an ad/bug report;
- [x] My code follows the guidelines and syntax of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

Fix #232354

Hides the cookie consent banner on autohaus-kainz.de.

Rules added to `AnnoyancesFilter/Cookies/sections/cookies_specific.txt`:
`autohaus-kainz.de###ccBarMain`
`autohaus-kainz.de###ccBar-opener`

Tested with Firefox + uBlock Origin 1.71.0.

1. Screenshots

► Screenshot 1 (Before):
<img width="1407" height="840" alt="image" src="https://github.com/user-attachments/assets/d87f0150-7d56-4a2a-83e0-b8de2081df0a" />


► Screenshot 2 (After):
<img width="1407" height="840" alt="image" src="https://github.com/user-attachments/assets/6dd48a17-4a48-46c9-876a-da507d1e4ddf" />


- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met