### PR TITLE
Fix #232549 bilibili.com

### DIFF
--- a/SpywareFilter/sections/general_extensions.txt
+++ b/SpywareFilter/sections/general_extensions.txt
@@ -6,6 +6,14 @@
 ! Bad: example.org###rek (should be in specific.txt)
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/232549
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])vd_source=[^&#]*&|[?&]vd_source=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])vd_source=[^&#]*&|[?&]vd_source=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])trackid=[^&#]*&|[?&]trackid=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])trackid=[^&#]*&|[?&]trackid=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])spm_id_from=[^&#]*&|[?&]spm_id_from=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])spm_id_from=[^&#]*&|[?&]spm_id_from=[^&#]*(?=#|$)/$1/')
+!
 ! Youtube
 !+ NOT_PLATFORM(ext_chromium_mv3)
 www.youtube.com#%#//scriptlet('prevent-xhr', '/\/api\/stats\/atr\?.+?&rt=\d+\.\d+.+?&volume=\d+&cbr=.+?&fexp=v1%[-%0-9C]{300,}&.+?&muted=\d(&vis=3)?&docid=/ method:POST')

--- a/SpywareFilter/sections/general_extensions.txt
+++ b/SpywareFilter/sections/general_extensions.txt
@@ -7,12 +7,8 @@
 !
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/232549
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])vd_source=[^&#]*&|[?&]vd_source=[^&#]*(?=#|$)/$1/')
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])vd_source=[^&#]*&|[?&]vd_source=[^&#]*(?=#|$)/$1/')
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])trackid=[^&#]*&|[?&]trackid=[^&#]*(?=#|$)/$1/')
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])trackid=[^&#]*&|[?&]trackid=[^&#]*(?=#|$)/$1/')
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/([?&])spm_id_from=[^&#]*&|[?&]spm_id_from=[^&#]*(?=#|$)/$1/')
-bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/([?&])spm_id_from=[^&#]*&|[?&]spm_id_from=[^&#]*(?=#|$)/$1/')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.pushState', '2', 'repl:/(?<=[?&])(?:vd_source|trackid|spm_id_from)=[^&#]*&?//g')
+bilibili.com#%#//scriptlet('trusted-replace-argument', 'history.replaceState', '2', 'repl:/(?<=[?&])(?:vd_source|trackid|spm_id_from)=[^&#]*&?//g')
 !
 ! Youtube
 !+ NOT_PLATFORM(ext_chromium_mv3)


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Missed analytics or tracker;

## What issue is being fixed?

Fix https://github.com/AdguardTeam/AdguardFilters/issues/232549

### Add your comment and screenshots

Bilibili.com re-injects stripped tracking parameters (`vd_source`, `trackid`, `spm_id_from`) into URLs via `history.pushState` and `history.replaceState` for logged-in users. The existing `$removeparam` rules in TrackParamFilter strip these params on page load, but Bilibili's JavaScript adds them back through the History API, bypassing URL-level filtering.

This PR adds `trusted-replace-argument` scriptlets to intercept History API calls and strip these three parameters from the URL argument before the call executes.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met