### PR TITLE
Revert PeacockTV domain, fix #232610

### DIFF
--- a/SpywareFilter/sections/tracking_servers_firstparty.txt
+++ b/SpywareFilter/sections/tracking_servers_firstparty.txt
@@ -60,7 +60,6 @@
 ||sas.f.peacocktv.com^
 ||sas.f.stable-int.peacocktv.com^
 ||sas.int-nft.peacocktv.com^
-||sas.peacocktv.com^
 ||sas.stable-int.peacocktv.com^
 ||goto.simplywall.st^
 ||swssp.simplywall.st^


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

Corrects a site breakage in #232610 based on process-of-elimination testing while attempting to use the Account Preferences part of the website. Appears there's a critical component on that subdomain since blocking/allowing it specifically fixes the issue.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

- #232610

### Add your comment and screenshots

#### If possible, a screenshot of a page or application should not be cropped too much. Otherwise, it is not always clear where the element is located

0. **DO NOT** upload screenshots with sexually explicit material on GitHub directly.\
 Instead, upload it to a third-party image hosting and post the link to it without preview (!) here.\
 Also, mention if the link leads to NSFW content;

1. Add screenshots of the problem. You can drag and drop images or paste them from clipboard

    Use `<details> </details>` tag to hide screenshots under the spoiler;

2. Describe the issue in detail until it is absolutely clear from the screenshot what the problem is

    You can also indicate any other information that you think the developers should know.

**Warning:** Please remove personal information before uploading screenshots!

1. Your comment

From issue #229508, a block was introduced for multiple sub-domains relating to the PeacockTV service, all with an acronym of "sas". I've found that `sas.peacocktv.com` is necessary for parts of the website to work, specifically the user preferences section.

When blocked, errors are given for all sections of the preferences site. When allowed, everything starts working again.

2. Screenshots

<details><summary>Subscriptions tab displaying large red error box and missing data:</summary>

<img width="894" height="944" alt="Image" src="https://github.com/user-attachments/assets/0530ba3a-990d-401e-a3e0-96fcb36d5928" />

</details>

<details><summary>Settings tab without an explicit error message, but errors for all account data:</summary>

<img width="802" height="843" alt="Image" src="https://github.com/user-attachments/assets/5b18ba37-0be1-4d54-8652-fe11aa05b049" />

</details>


<details><summary>Subscriptions tab again, this time with the subdomain explicitly allowed:</summary>

<img width="826" height="823" alt="Image" src="https://github.com/user-attachments/assets/51f59bc7-afee-42ab-bcb1-d0edc3dc5413" />

</details>

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
