### PR TITLE
fix ridibooks.com airbridge tracker

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -83,6 +83,7 @@
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-16774089
 ||t.info.telus.com^$removeparam=s
 ! ridibooks.com - book detail page reference tracker
+||ridibooks.com^$removeparam=airbridge_referrer
 ||ridibooks.com^$removeparam=_rdt_sid
 ||ridibooks.com^$removeparam=_rdt_idx
 ||ridibooks.com^$removeparam=_rdt_arg


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [x] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

### Enter the issue address

https://github.com/List-KR/List-KR/pull/1075

### How to Test

1. vist `link.ridi.com/u8g405`
2. the alll parameters will be strip due to remove the `airbridge_referrer` parameter.

| key | value |
| -- | -- |
| `airbridge_referrer` | (URL encoded) `airbridge=true` <br/> `client_id=<value>` <br/> `event_uuid=<value>` <br/>`referrer_timestamp=1782988504632`<br/>`short_id=u8g405`<br/>`channel=inapp_share_ios`<br/>`campaign=Contents%20Home%20Share`<br/>`tracking_template_id=<value>`
| `https_deeplink` | `true` |
| `short_id` | `u8g405` |

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met