### PR TITLE
Revert "fix ridibooks.com airbridge tracker (#234792)"

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -85,7 +85,6 @@
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-16774089
 ||t.info.telus.com^$removeparam=s
 ! ridibooks.com - book detail page reference tracker
-||ridibooks.com^$removeparam=airbridge_referrer
 ||ridibooks.com^$removeparam=_rdt_sid
 ||ridibooks.com^$removeparam=_rdt_idx
 ||ridibooks.com^$removeparam=_rdt_arg


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [x] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

We first revert the changes regarding the below breakage. 

> @piquark6046: I think that it should be reconsidered because of https://gall.dcinside.com/mgallery/board/view/?id=adguard&no=10972&page=1
Will be checked. — https://github.com/List-KR/List-KR/pull/1075#issuecomment-4891107672

### Note

Airbridge have attribution features, the risk associated with linking to specific service events seems high, so we should take a conservative approach even if we receive external reports.

This is because although the Airbridge attribution pipeline is a B2B solution that relays 'ads', But there is a flow that integrates externally to provide rewards users want, such as coupons and discounts.

This reverts commit 417177aca24436468243d6316b4446434e1250a8.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met