### PR TITLE
Rotating Domains Checker: Updating domains

### DIFF
--- a/TurkishFilter/sections/specific.txt
+++ b/TurkishFilter/sections/specific.txt
@@ -4841,7 +4841,7 @@ turkkizlar31.com,turkkizlar32.com,turkkizlar33.com,turkkizlar34.com,turkkizlar35
 ||cimcime*.com/wp-content/uploads/*.gif
 [$domain=/cimcime\d+\.\w+$/]###ads-inside-main
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-cimcime133.live###ads-inside-main
+cimcime134.live###ads-inside-main
 !#endif
 !
 ! Frequently changed domains: dahahizli*.com
@@ -4927,8 +4927,8 @@ turkifsaclub.org#?#main > h3:contains(Sponsor Bannerlar)
 [$domain=/turkifsaclub\d+\.sbs/]##.ads-grid
 [$domain=/turkifsaclub\d+\.sbs/]#?#main > h3:contains(Sponsor Bannerlar)
 !#if (adguard_app_ios || adguard_ext_safari || adguard_ext_android_cb || ext_ublock)
-turkifsaclub130.sbs,turkifsaclub131.sbs,turkifsaclub132.sbs,turkifsaclub133.sbs,turkifsaclub134.sbs,turkifsaclub135.sbs,turkifsaclub136.sbs,turkifsaclub137.sbs,turkifsaclub138.sbs,turkifsaclub139.sbs,turkifsaclub140.sbs,turkifsaclub141.sbs,turkifsaclub142.sbs,turkifsaclub143.sbs,turkifsaclub144.sbs,turkifsaclub145.sbs,turkifsaclub146.sbs,turkifsaclub147.sbs,turkifsaclub148.sbs,turkifsaclub149.sbs,turkifsaclub150.sbs,turkifsaclub151.sbs,turkifsaclub152.sbs,turkifsaclub153.sbs,turkifsaclub154.sbs,turkifsaclub155.sbs,turkifsaclub156.sbs,turkifsaclub157.sbs,turkifsaclub158.sbs,turkifsaclub159.sbs,turkifsaclub160.sbs,turkifsaclub161.sbs,turkifsaclub162.sbs,turkifsaclub163.sbs##.ads-grid
-turkifsaclub130.sbs,turkifsaclub131.sbs,turkifsaclub132.sbs,turkifsaclub133.sbs,turkifsaclub134.sbs,turkifsaclub135.sbs,turkifsaclub136.sbs,turkifsaclub137.sbs,turkifsaclub138.sbs,turkifsaclub139.sbs,turkifsaclub140.sbs,turkifsaclub141.sbs,turkifsaclub142.sbs,turkifsaclub143.sbs,turkifsaclub144.sbs,turkifsaclub145.sbs,turkifsaclub146.sbs,turkifsaclub147.sbs,turkifsaclub148.sbs,turkifsaclub149.sbs,turkifsaclub150.sbs,turkifsaclub151.sbs,turkifsaclub152.sbs,turkifsaclub153.sbs,turkifsaclub154.sbs,turkifsaclub155.sbs,turkifsaclub156.sbs,turkifsaclub157.sbs,turkifsaclub158.sbs,turkifsaclub159.sbs,turkifsaclub160.sbs,turkifsaclub161.sbs,turkifsaclub162.sbs,turkifsaclub163.sbs#?#main > h3:contains(Sponsor Bannerlar)
+turkifsaclub130.sbs,turkifsaclub131.sbs,turkifsaclub132.sbs,turkifsaclub133.sbs,turkifsaclub134.sbs,turkifsaclub135.sbs,turkifsaclub136.sbs,turkifsaclub137.sbs,turkifsaclub138.sbs,turkifsaclub139.sbs,turkifsaclub140.sbs,turkifsaclub141.sbs,turkifsaclub142.sbs,turkifsaclub143.sbs,turkifsaclub144.sbs,turkifsaclub145.sbs,turkifsaclub146.sbs,turkifsaclub147.sbs,turkifsaclub148.sbs,turkifsaclub149.sbs,turkifsaclub150.sbs,turkifsaclub151.sbs,turkifsaclub152.sbs,turkifsaclub153.sbs,turkifsaclub154.sbs,turkifsaclub155.sbs,turkifsaclub156.sbs,turkifsaclub157.sbs,turkifsaclub158.sbs,turkifsaclub159.sbs,turkifsaclub160.sbs,turkifsaclub161.sbs,turkifsaclub162.sbs,turkifsaclub163.sbs,turkifsaclub164.sbs##.ads-grid
+turkifsaclub130.sbs,turkifsaclub131.sbs,turkifsaclub132.sbs,turkifsaclub133.sbs,turkifsaclub134.sbs,turkifsaclub135.sbs,turkifsaclub136.sbs,turkifsaclub137.sbs,turkifsaclub138.sbs,turkifsaclub139.sbs,turkifsaclub140.sbs,turkifsaclub141.sbs,turkifsaclub142.sbs,turkifsaclub143.sbs,turkifsaclub144.sbs,turkifsaclub145.sbs,turkifsaclub146.sbs,turkifsaclub147.sbs,turkifsaclub148.sbs,turkifsaclub149.sbs,turkifsaclub150.sbs,turkifsaclub151.sbs,turkifsaclub152.sbs,turkifsaclub153.sbs,turkifsaclub154.sbs,turkifsaclub155.sbs,turkifsaclub156.sbs,turkifsaclub157.sbs,turkifsaclub158.sbs,turkifsaclub159.sbs,turkifsaclub160.sbs,turkifsaclub161.sbs,turkifsaclub162.sbs,turkifsaclub163.sbs,turkifsaclub164.sbs#?#main > h3:contains(Sponsor Bannerlar)
 !#endif
 !
 ! Frequently changed domains: yavasgir*.com

--- a/watchers.yml
+++ b/watchers.yml
@@ -2,9 +2,7 @@ sites:
   Vegamovies:
     initial_domain: https://vegamovies.hot/?re=vg
     last_known_mirror: vegamovies.navy
-    failed_since: 2026-07-07 19:35
-    failed_days: 1
-    potentially_dead: true
+    success_since: 2026-07-08 19:55
   Fmovies (fmovies.*):
     last_known_mirror: www.fmovies.gd
     success_since: 2026-07-07 06:44
@@ -28,7 +26,7 @@ sites:
   Patronmac (patronmac*.cfd):
     last_known_mirror: patronmac96.cfd
     failed_since: 2026-07-07 19:35
-    failed_days: 1
+    failed_days: 2
     potentially_dead: true
   Piabet TV (piabettv*.live):
     force_search_ahead: true
@@ -71,7 +69,9 @@ sites:
   OnionPlay (onionplay.*):
     accept_antibot: true
     last_known_mirror: onionplay.st
-    success_since: 2026-06-03 01:58
+    failed_since: 2026-07-08 19:55
+    failed_days: 0
+    potentially_dead: true
   VidMoly (vidmoly.*):
     last_known_mirror: vidmoly.biz
     path: "/embed-embed.html"
@@ -89,18 +89,17 @@ sites:
   Sadeceifsa (sadeceifsa*.lol):
     last_known_mirror: sadeceifsa16.icu
     failed_since: 2026-07-08 13:37
-    failed_days: 0
+    failed_days: 1
     potentially_dead: true
   Hdturkifsa (hdturkifsa*.icu):
     last_known_mirror: hdturkifsa54.cfd
-    failed_since: 2026-07-08 13:37
-    failed_days: 0
-    potentially_dead: true
+    success_since: 2026-07-08 19:55
   Cimcime:
-    last_known_mirror: cimcime133.live
-    failed_since: 2026-07-08 13:37
-    failed_days: 0
-    potentially_dead: true
+    last_known_mirror: cimcime134.live
+    success_since: 2026-07-08 19:55
   MaçtanMaça:
     last_known_mirror: mactanmaca512.sbs
     success_since: 2026-07-06 19:36
+  Patronlig:
+    last_known_mirror: patronlig16.cfd
+    success_since: 2026-07-08 19:55

--- a/watchers.yml
+++ b/watchers.yml
@@ -70,7 +70,7 @@ sites:
     accept_antibot: true
     last_known_mirror: onionplay.st
     failed_since: 2026-07-08 19:55
-    failed_days: 0
+    failed_days: 1
     potentially_dead: true
   VidMoly (vidmoly.*):
     last_known_mirror: vidmoly.biz
@@ -88,9 +88,7 @@ sites:
     success_since: 2026-06-22 20:05
   Sadeceifsa (sadeceifsa*.lol):
     last_known_mirror: sadeceifsa16.icu
-    failed_since: 2026-07-08 13:37
-    failed_days: 1
-    potentially_dead: true
+    success_since: 2026-07-08 20:05
   Hdturkifsa (hdturkifsa*.icu):
     last_known_mirror: hdturkifsa54.cfd
     success_since: 2026-07-08 19:55


### PR DESCRIPTION
Rotating Domains Checker: Updating domains

🔄  Watchers with active mirror changed: 0 (filter mirror cleanup only)
✅ Unchanged watchers:
     Vegamovies (vegamovies.navy), Fmovies (fmovies.*) (www.fmovies.gd), Belestepe (belestepe*.sbs) (belestepe615.sbs), Jmanga (jmanga.*) (jmanga.beer), iNat TV (inattv*.xyz) (inattv1317.xyz), HDFilmCehennemi (hdfilmcehennemi*.org) (hdfilmcehennemi27.org), voe.sx (pamelachangemission.com), HiMovies (himovies.*) (himovies.bz), Zonatmo (zonatmo.*) (zonatmo.to), VidMoly (vidmoly.*) (vidmoly.biz), Mapple-1 (mapple.*) (mapple.rip), Mapple-2 (mapplee.com) (mapplee.com), Sadeceifsa (sadeceifsa*.lol) (sadeceifsa16.icu), Hdturkifsa (hdturkifsa*.icu) (hdturkifsa54.cfd), Cimcime (cimcime134.live), MaçtanMaça (mactanmaca512.sbs), Patronlig (patronlig16.cfd)

🚨 Errors (no replacements made):
     - Patronmac (patronmac*.cfd) [https://patronmac96.cfd]: Antibot detected: 403 or __cf_chl_tk in URL (0.82s)
     - OnionPlay (onionplay.*) [https://onionplay.st]: Skipped by skip_text: "Redirecting..." (0.88s)

---

## Changes
- Updated domain names in filter rules
- Updated watchers.yml with new last_known_mirror values

## Verification
Please review the changes before merging.

---
*This PR was created automatically by Rotating Domains Checker*