### PR TITLE
Cleanup duplicate rules on some filters 

### DIFF
--- a/CyrillicFilters/common-sections/specific.txt
+++ b/CyrillicFilters/common-sections/specific.txt
@@ -83,7 +83,6 @@ tribuna.com##div[class$="__main_layout__empty_block"]
 rbc.ua##div[style="min-height:350px;"]
 ||enovosty.com/wp-content/uploads/*/klo_video_banner.mp4
 enovosty.com##.auto-banner
-stopcor.org##.idealmedia
 psm7.com###akurateco
 nikvesti.com##.desc-read-more-adv
 inforesist.org#%#//scriptlet('remove-node-text', 'script', 'attachShadow')
@@ -234,7 +233,7 @@ sib.fm#?#div[style^="min-height:"]:has(.banner)
 sib.fm##.partners-footer
 orda.kz##body .ad2
 orda.kz#?#body > div.layer0:has(> div.wrapper > div.ad1)
-food.obozrevatel.com##.idealmedia
+food.obozrevatel.com,stopcor.org##.idealmedia
 food.obozrevatel.com##.googleBanner
 doradvokat.com.ua###sidebar-right > div#media_image-40 ~ div.mg-widget
 web.telegram.org#$?#.message-date-group > div.Message:has(.text-content:contains(/#реклама/)) { remove: true; }

--- a/MailTrackingFilter/sections/specific.txt
+++ b/MailTrackingFilter/sections/specific.txt
@@ -491,8 +491,6 @@ click.redditmail.com$image
 ! Samsung News
 news.samsung.com/us/?noti=$image
 news.samsung.com%2Fus%2F%3Fnoti%3D$image
-! Amazon
-.awstrack.me$image
 ! Esputnik
 esputnik.com%2Frepository%2Fapplications%2Fcommons%2Fhidden.png
 esputnik.com/repository/applications/commons/hidden.png

--- a/SpywareFilter/sections/cookies_specific.txt
+++ b/SpywareFilter/sections/cookies_specific.txt
@@ -80,8 +80,6 @@ mcp.directory#%#//scriptlet('remove-cookie', 'dotcom_user')
 ||nicegram.app^$cookie=X-identify
 ! usnews.com
 ||usnews.com^$cookie=usn_visitor_id
-! kayak.com
-||kayak.com^$cookie=kmkid
 ! momondo.com
 ||momondo.com^$cookie=kmkid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/220298


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 

### Add your comment and screenshots

These rules appear multiple times in the list.

 
`.awstrack.me$image`
https://github.com/AdguardTeam/AdguardFilters/blob/bcbaf22d163e2d2999820447f47d300a48def452/MailTrackingFilter/sections/specific.txt#L54

`||kayak.com^$cookie=kmkid`
https://github.com/AdguardTeam/AdguardFilters/blob/bcbaf22d163e2d2999820447f47d300a48def452/SpywareFilter/sections/cookies_specific.txt#L872

`##.idealmedia`
 



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
