### PR TITLE
Add static.chunichi.co.jp

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -269,6 +269,7 @@ bengoshihoken-mikata.jp#$?#section.fix:has(> div.fix__wrap) { remove: true; }
 hotpowers.jp##.p-recommendation
 hotpowers.jp##div[id^="hotpo-"]
 chunichi.co.jp#?#.cmp-hdg005:has(> h2.hdg:contains(【PR】企画特集))
+||static.chunichi.co.jp/chunichi/js/spo-recruit-box.js
 news.mynavi.jp##div[id^="advads-"]
 okinawatimes.co.jp##body > .l-wrapper > div[class^="l-"]:has(> .OUTBRAIN)
 femimatsu.com##div[id^="ad"][id$="-div-id"]


### PR DESCRIPTION
# Creating the pull request

This is a contribution of a filter that blocks the ad I found it on the static.chunichi.co.jp,

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [o] This is not an ad/bug report;
- [o] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [o] I have performed a self-review of my own changes;
- [o] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

Blocks the ad on https://www.chunichi.co.jp/


### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [o] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Example: 
url is https://www.chunichi.co.jp/article/1284195



### Add your comment and screenshots
<img width="1265" height="2965" alt="s8" src="https://github.com/user-attachments/assets/2c1df941-cbd8-4cb0-aa4a-6f7ca6fc9ab7" />


### Terms

- [o] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
