### PR TITLE
fix places.googleapis.com

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -112,7 +112,7 @@
 @@||hotstar.com/api/internal$stealth=ip
 ! https://github.com/AdguardTeam/AdguardFilters/issues/234157
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233892
-@@||places.googleapis.com/*autocomplete$stealth=referrer
+@@||places.googleapis.com^$stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233859
 @@.mp4?headers$media,stealth=referrer,domain=vidlink.pro
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233830

--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -113,6 +113,7 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/234157
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233892
 @@||places.googleapis.com^$stealth=referrer
+@@||addressvalidation.googleapis.com^$stealth=referrer
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233859
 @@.mp4?headers$media,stealth=referrer,domain=vidlink.pro
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233830


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Website or app doesn't work properly;

## What issue is being fixed?

https://github.com/AdguardTeam/AdguardFilters/issues/233814
https://github.com/AdguardTeam/AdguardFilters/issues/233892
https://github.com/AdguardTeam/AdguardFilters/issues/234157
~~https://www.jbhifi.com.au/ _(Add any item to cart and then checkout)_~~

Unable to complete checkout process on various websites due to the Google API being blocked for address confirmation due to hiding the referrer from third parties.

Error output from Google API:
```
{
  "error": {
    "code": 403,
    "message": "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API.",
    "status": "PERMISSION_DENIED"
  }
}
```

Previous attempts to resolve this worked for specifically chemistwarehouse.com.au with #233892 as the URL was:
`https://places.googleapis.com/$rpc/google.maps.places.v1.Places/AutocompletePlaces`

Then to resolve #234157, it was a different URL:
`https://places.googleapis.com/v1/places:autocomplete`

Now just being on jbhifi.com.au, it's become even more randomised with the same style as the following URL (replaces x with random letters and numbers, replaces y with specific API key):
`https://places.googleapis.com/v1/places/xxxxxxxxxxxxxxxxx?fields=addressComponents&key=yyyyy`

---

Currently the rule in **allowlist_stealth.txt** is:
`@@||places.googleapis.com/*autocomplete$stealth=referrer`

So to accommodate all three variants, I've modified the rule to allow it to be broader:
`@@||places.googleapis.com^$stealth=referrer`

As per [Google's API docs](https://developers.google.com/maps/documentation/places/web-service/overview), it looks like this domain is used for accepting HTTP requests for this particular purpose, and I do not see why we cannot relax this rule to the places.googleapis.com domain with the stealth modifier.

Alternatively, we could further tighten it with two rules, although if the URL changes again it will require another edit:
`@@||places.googleapis.com/$rpc/google.maps.places.v1.Places/*$stealth=referrer`
`@@||places.googleapis.com/v1/places*$stealth=referrer`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
