### PR TITLE
add #237122 iqws-cds.intechiq.com

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -30,6 +30,8 @@
 !
 ! NOTE: Specific rules
 !
+! https://github.com/AdguardTeam/AdguardFilters/pull/237126
+@@||iqws-cds.intechiq.com/rest/$xmlhttprequest,stealth=3p-auth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/237164
 @@/cdn/files/*$media,document,third-party,stealth=referrer,domain=kimoitv.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/236748


### PR DESCRIPTION
## Prerequisites

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

- [x] Website or app doesn't work properly;

## What issue is being fixed?

- Fix https://github.com/AdguardTeam/AdguardFilters/issues/237122
- Fix all other websites and apps that will use [Intech Solutions Pty Ltd](https://www.intechsolutions.com.au/), which are Address Validation Software based in Australia, which include Australian and New Zealand Government websites.

> Australian Government 2026 Census is unable to be used due to address validation being blocked due to "Protect against DPI" being enabled for stealth mode. Unchecking "Protect against DPI" and refreshing the page allows the address list to load.

I'd be comfortable whitelisting the entire domain instead of `iaws-cds.intechia.com/rest/address/search` as they use other validation services that may use other URL types within this domain.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
