### PR TITLE
Fix erkekadam.org remove tracking param `kaynak`

### DIFF
--- a/TrackParamFilter/sections/specific.txt
+++ b/TrackParamFilter/sections/specific.txt
@@ -6,6 +6,8 @@
 ! Bad: ||example.org^$xmlhttprequest,redirect=noopvast-3.0 (for instance, should be in specific.txt)
 !
 !
+! https://github.com/AdguardTeam/AdguardFilters/pull/237405
+||erkekadam.org^$removeparam=kaynak
 ! https://github.com/AdguardTeam/AdguardFilters/issues/237045
 ||supply.amazon.com^$removeparam=ref_
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-17821852


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

I didn't create an issue for this trivial PR.

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [X] This is not an ad/bug report;
- [X] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [X] I have performed a self-review of my own changes;
- [X] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?
[erkekadam.org](https://erkekadam.org/) website had a referer-like tracking parameter called `kaynak` (literally "origin" in Turkish) in its internal links. This PR removes that parameter.

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [X] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

I didn't create an issue for this trivial PR.

### Add your comment and screenshots


### Terms

- [X] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
