### PR TITLE
Fix #237396 lovelive-petitsoku.com

### DIFF
--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -77,6 +77,8 @@ nizimoenews.livedoor.blog,butumori.com,netizen-voice.blog.jp,ityouchannel.livedo
 ! NOTE: Blogroll specific rules
 !
 aurorascreen.org##.discord-popup
+lovelive-petitsoku.com###content-top.wwa > .content-top.wwa
+lovelive-petitsoku.com##.widget-below-comment-form
 24tv.ua##.whatsapp-subscribe-widget
 odessa.ua##div.maincont > div[style^="margin: "]:has(> a[href="https://t.me/slovo_odessa"])
 girlsvip-matome.com###kanren_box2

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -61,7 +61,7 @@ gundamlog.com###more > iframe[src^="https://richlink.blogsys.jp"]
 ! NOTE: Specific rules
 !
 itmedia.co.jp##.p-header-banner
-lovelive-petitsoku.com##.widget_custom_html a[href^="https://px.a8.net"]
+lovelive-petitsoku.com##.widget_custom_html a[href^="https://px.a8.net/svt/ejp?"]
 lovelive-petitsoku.com#%#//scriptlet('remove-node-text', '#text', '[PR]')
 jmedj.co.jp#$?#.ad-data:not([href*="jmedj.co.jp"]) { remove: true; }
 famitsu.com##div[class^="ArticleDetail_articleMainFooter"] > div[class^="CommonParts_commonPartsContainer"]:has(a[href^="https://amzn.to"])

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -6119,7 +6119,6 @@ sanblo.com###custom_html-69
 newbalance-days.com,japan-railway.com###custom_html-70
 gadgets.evolves.biz###custom_html-71
 japan-railway.com###custom_html-72
-lovelive-petitsoku.com###custom_html-74
 erostopics.net###custom_html-78
 smartasw.com###custom_html-95
 erostopics.net,clicccar.com,moez-m.com###custom_html-100

--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -61,6 +61,8 @@ gundamlog.com###more > iframe[src^="https://richlink.blogsys.jp"]
 ! NOTE: Specific rules
 !
 itmedia.co.jp##.p-header-banner
+lovelive-petitsoku.com##.widget_custom_html a[href^="https://px.a8.net"]
+lovelive-petitsoku.com#%#//scriptlet('remove-node-text', '#text', '[PR]')
 jmedj.co.jp#$?#.ad-data:not([href*="jmedj.co.jp"]) { remove: true; }
 famitsu.com##div[class^="ArticleDetail_articleMainFooter"] > div[class^="CommonParts_commonPartsContainer"]:has(a[href^="https://amzn.to"])
 arekore.app##div[class^="ads"]


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix #237396 lovelive-petitsoku.com

### Add your comment

- Remove the promotion item ads
- Fix incorrect blocking section includes "コメント欄" (`#comment-area`) and  "関連記事" (`#related-entries`) links

  ```html
  <div id="custom_html-74" class="widget_text widget widget-single-content-bottom widget_custom_html">
    <div class="textwidget custom-html-widget">
       <div class="article-jump-navi">
          <a href="#comment-area">コメント欄</a>
          <a href="#related-entries">関連記事</a>
  ```

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met