### PR TITLE
Upd #237452 robot.chaoxing.com missed subdomains

### DIFF
--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -1397,7 +1397,7 @@ blog.livedoor.jp##div[id^="shitarss_title_"]
 !
 !   SECTION: Widgets - Marketing (third-party services)
 !
-||robot-lc*.chaoxing.com/sdk/CxRobotSdkJs.js
+||robot*.chaoxing.com/sdk/CxRobotSdkJs.js
 ||prod.oddsmind.ai/js/oddsmind-chat.min.js$third-party
 ||widster.ru^$third-party
 ||widget.yourgood.app^

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -1397,7 +1397,7 @@ blog.livedoor.jp##div[id^="shitarss_title_"]
 !
 !   SECTION: Widgets - Marketing (third-party services)
 !
-||chaoxing.com/sdk/CxRobotSdkJs.js
+/CxRobotSdkJs.js
 ||prod.oddsmind.ai/js/oddsmind-chat.min.js$third-party
 ||widster.ru^$third-party
 ||widget.yourgood.app^

--- a/AnnoyancesFilter/Widgets/sections/widgets.txt
+++ b/AnnoyancesFilter/Widgets/sections/widgets.txt
@@ -1397,7 +1397,7 @@ blog.livedoor.jp##div[id^="shitarss_title_"]
 !
 !   SECTION: Widgets - Marketing (third-party services)
 !
-||robot*.chaoxing.com/sdk/CxRobotSdkJs.js
+||chaoxing.com/sdk/CxRobotSdkJs.js
 ||prod.oddsmind.ai/js/oddsmind-chat.min.js$third-party
 ||widster.ru^$third-party
 ||widget.yourgood.app^


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [x] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Upd #237452 robot.chaoxing.com missed subdomains

### Add your comment and screenshots

Change `||robot-lc*.` to `||robot*.`

`robot, robot1, robot2, robot-dev.` are missed subdomains

Reference:
- `robot-docs.chaoxing.com/docs/sdk/resource.html`
- `robot-docs.chaoxing.com/docs/channel`
- `robot-docs.chaoxing.com/docs/sdk/robotsdk/normal/demo`

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met