### PR TITLE
remove adring.net

### DIFF
--- a/JapaneseFilter/sections/adservers.txt
+++ b/JapaneseFilter/sections/adservers.txt
@@ -13,7 +13,6 @@
 ! not for DNS
 ||ias.rakuten.co.jp^$third-party,domain=~rakuten-co.jp|~rakuten.ne.jp
 !
-||adring.net^$third-party
 ||adwell.app^$third-party
 ||scrollpop.online^$third-party
 ||insiad.com^


### PR DESCRIPTION
Removes `||adring.net^$third-party` from `JapaneseFilter/sections/adservers.txt`.

adring.net is not an ad network. It is a mutual linking chain (webring-style) that individual developers use to introduce each other's personal sites — the participants are hobbyist developers, and the banners only link to other members' own websites. There is no commercial ad serving, no tracking business model, and no third-party ad inventory involved, so I don't think it belongs in an adservers section.

For reference, the rule was added following https://github.com/easylist/easylist/pull/24894, which was itself closed without being merged into EasyList.
