### PR TITLE
fix #238108 api.authsignal.com

### DIFF
--- a/BaseFilter/sections/allowlist_stealth.txt
+++ b/BaseFilter/sections/allowlist_stealth.txt
@@ -25,6 +25,8 @@
 !
 ! NOTE: Specific rules
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/238108
+@@||api.authsignal.com^$stealth=3p-auth
 ! https://github.com/AdguardTeam/AdguardFilters/issues/238665
 @@||login.sydneywater.com.au^$stealth=referrer,domain=sydneywater.com.au
 ! https://github.com/AdguardTeam/AdguardFilters/issues/238571


### PR DESCRIPTION
## What problem does the pull request fix?

- [x] Website or app doesn't work properly;

## What issue is being fixed?

Fix #238108

Resolves the ability to use and register passkeys on myaccount.more.com.au (and possibly others).
Further screenshots and info within the issue.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
