### PR TITLE
Fix leftover top branding gap on sports.ru (fixes #239097)

### DIFF
--- a/CyrillicFilters/RussianFilter/sections/specific.txt
+++ b/CyrillicFilters/RussianFilter/sections/specific.txt
@@ -11333,6 +11333,10 @@ sports.ru##.teaser-before-links
 sports.ru##.float-block
 sports.ru##.in-read-wrapper
 sports.ru##div[data-banner-type]
+! https://github.com/AdguardTeam/AdguardFilters/issues/239097
+sports.ru##[data-testid="top-wrapper"]
+sports.ru#$#.post-layout__branding { min-height: 0 !important; height: auto !important; }
+sports.ru#$#[data-testid="top-wrapper"] { min-height: 0 !important; height: auto !important; }
 sports.ru##a[href^="https://winline.ru/"]
 sports.ru##.right-banner-element
 sports.ru##.layout__branding


### PR DESCRIPTION
## Summary
- Collapse the reserved top branding wrapper on sports.ru / cyber.sports.ru after the ad creative is blocked.
- The inner `div[data-banner-type]` slots are already hidden; `div.post-layout__branding[data-testid="top-wrapper"]` keeps `min-height: 270px` and leaves a blank band under the header.
- Cosmetic hide on `[data-testid="top-wrapper"]` plus CSS to zero `min-height` on the existing `.post-layout__branding` wrapper.

Fixes https://github.com/AdguardTeam/AdguardFilters/issues/239097

## Test plan
- [ ] Open https://cyber.sports.ru/dota2/blogs/3445354.html (or any article) with Russian filter
- [ ] Confirm no ~270px empty gap between КИБЕР nav and breadcrumbs / content
- [ ] Confirm article body, breadcrumbs, and sidebar are unchanged