### PR TITLE
Fix #239093 diethueringer.de native Werbung tiles

### DIFF
--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -11,6 +11,10 @@ chip.de#$?#main[role="main"] { grid-row: 2 !important; }
 !
 ! ### Temporary END ###
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/239093
+diethueringer.de##.col-xl-3:has(> .blog-style1 a[href^="/sponsored-content/"])
+diethueringer.de##.blog-style1:has(> .blog-img > a.category)
+!
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233042
 kinox.camp,kinox.*#%#//scriptlet('abort-current-inline-script', 'Object.defineProperty', 'resetClickedUrl')
 kinox.camp,kinox.*##a[href^="/engine/player.php?code="]:not([style])

--- a/GermanFilter/sections/specific.txt
+++ b/GermanFilter/sections/specific.txt
@@ -13,7 +13,7 @@ chip.de#$?#main[role="main"] { grid-row: 2 !important; }
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/239093
 diethueringer.de##.col-xl-3:has(> .blog-style1 a[href^="/sponsored-content/"])
-diethueringer.de##.blog-style1:has(> .blog-img > a.category)
+diethueringer.de##.blog-style1:has(a[href^="/sponsored-content/"])
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/233042
 kinox.camp,kinox.*#%#//scriptlet('abort-current-inline-script', 'Object.defineProperty', 'resetClickedUrl')


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix https://github.com/AdguardTeam/AdguardFilters/issues/239093

### Add your comment and screenshots

1. Your comment

Hide native in-feed Werbung tiles on diethueringer.de (.blog-style1 + /sponsored-content/). Live: 11 ad tiles hidden, 24 editorial remain, grid/hero intact.

2. Screenshots

See the linked issue for reporter screenshots.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
