### PR TITLE
Fix #239006 msn.com Money/Markets native and display ads

### DIFF
--- a/BaseFilter/sections/specific.txt
+++ b/BaseFilter/sections/specific.txt
@@ -735,6 +735,18 @@ tz.de##article > p[class^="id-Story-"] ~ div[class*="img_"]
 ! !SECTION: Ad-Shield
 ! END: Ad-Shield ad reinsertion
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/239006
+msn.com##[class^="bannerAdsContainer-"]
+msn.com##[class^="bannerAds-"]
+msn.com##display-ads
+msn.com##div.displayAdContainer
+msn.com##[class^="rightRailSimpleAd-"]
+msn.com##[class^="simpleAdContainer-"]
+msn.com##[class^="rightRailAds"]
+msn.com#%#//scriptlet('hide-in-shadow-dom', 'cs-native-ad-card')
+msn.com#%#//scriptlet('hide-in-shadow-dom', 'cs-native-ad-card-no-hover')
+msn.com#%#//scriptlet('inject-css-in-shadow-dom', 'cs-native-ad-card, cs-native-ad-card-no-hover, display-ads, .displayAdContainer { display: none !important; }')
+!
 ! ExoClick
 .php$script,domain=onmpeg.com
 /abl.php$domain=sunporno.com


### PR DESCRIPTION
# Creating the pull request

> Please include a summary of the change and which issue is fixed\
> If the related issue does not exist in our repository, please create it before making pull request\
> It is highly recommended to use our [Web Reporting Tool](https://kb.adguard.com/technical-support/reporting-tool) instead of creating an issue on GitHub directly\
> Please note, that we verify every pull request manually, so it may take time to apply it

## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [x] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [ ] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

Fix https://github.com/AdguardTeam/AdguardFilters/issues/239006

### Add your comment and screenshots

1. Your comment

Hide MSN Money/Markets display units (bannerAds*, display-ads) and shadow-DOM native cards. Live: 2 Ad banners to 0, charts intact. Native rail cards from the issue were geo-dependent on this load.

2. Screenshots

See the linked issue for reporter screenshots.

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
