### PR TITLE
Add ssb-global.smartadserver.com to adservers

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -9,6 +9,7 @@
 !
 !
 !
+||ssb-global.smartadserver.com^
 ||wnwtfmpsmslwi.site^
 ||ads.dzeko11.st^
 ||d2pf0ys5xus6n.cloudfront.net^


### PR DESCRIPTION
## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;

## What issue is being fixed?

Fixes #239535

## Description

Add `ssb-global.smartadserver.com` to the general third-party advertising servers list.

The hostname is part of the Smart AdServer advertising platform. Smart AdServer is an advertising monetization platform for publishers, and `ssb-global.smartadserver.com` is part of that advertising infrastructure.

AdGuard already contains other Smart AdServer hosts in its filtering ecosystem.

This change adds only the specific advertising hostname and does not block the broader `smartadserver.com` domain.

Sources:

- https://www.netify.ai/resources/hostnames/ssb-global.smartadserver.com
- https://www.netify.ai/resources/domains/smartadserver.com