### PR TITLE
Add analytics-ios-tcp.rayjump.com to mobile spyware filter

### DIFF
--- a/SpywareFilter/sections/mobile.txt
+++ b/SpywareFilter/sections/mobile.txt
@@ -886,6 +886,7 @@ d4?appid*type*
 ||vgs-collect-keeper.apps.verygood.systems^
 ||g.analytics.versa-ai.com^
 ||analytics.rayjump.com^
+||analytics-ios-tcp.rayjump.com^
 ||events.ifunny.co^
 ||imp-*.jampp.com^
 ||telemetry.navigatorapp.net^


### PR DESCRIPTION
## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;

## What issue is being fixed?

Fixes #239545

## Description

Add `analytics-ios-tcp.rayjump.com` to the mobile spyware filter alongside the existing `analytics.rayjump.com` rule.

Both hosts are part of Rayjump's analytics infrastructure. The new hostname is currently not covered explicitly by the mobile analytics rules.

This change adds only the specific iOS analytics hostname and does not broaden the rule to the entire `rayjump.com` domain.