### PR TITLE
Clean up rules (JapaneseFilter - specific.txt)

### DIFF
--- a/JapaneseFilter/sections/specific.txt
+++ b/JapaneseFilter/sections/specific.txt
@@ -215,7 +215,6 @@ m-s-y.com###random-banner
 m-s-y.com##.adsense-in-article
 hokkaido-np.co.jp##.main_1col:has(> div[class^="ad-group"]:first-child + script:last-child)
 hokkaido-np.co.jp##div[class^="ad-group"]
-si-coding.net##a[href^="https://hb.afl.rakuten.co.jp/"]
 rkd3.dev##.below-article > .article-details:has(> .ads)
 gqjapan.jp##.StickyHeroAdWrapper-kurarC
 limo.media#$?#.m-articles__item:has(> div.m-articles__img > a.toplink[data-event]) { remove: true; }
@@ -541,7 +540,6 @@ dengekionline.com##div[class^="InLead_wrapper_"]
 log.dot-co.co.jp##.ad-name
 woman.excite.co.jp##.min-h-122.justify-center.py-16
 ||storage.googleapis.com/static-pcolle/parts/
-sportsseoulweb.jp##.m-adArea
 genshin-soku.com.monhan-soku.com,kasegeru.blog.jp##.promo-box
 shiba-teire.com##.sidebar > div.widget_custom_html
 gameappch.com##.ad_aside
@@ -1541,7 +1539,7 @@ volx.jp##.side-topad > div.widget_st_custom_html_widget
 news.cookpad.com##.md\:max-w-672px > div.py-5:has(> div[id^="div-gpt-"])
 somu-lier.jp##.contentBannerBox
 gizmodo.jp###sideCxItem_bottomRanking
-searchkoreanews.jp##.m-adArea
+sportsseoulweb.jp,searchkoreanews.jp##.m-adArea
 searchkoreanews.jp##.contents_side > div.pc:has(> ul.m-bannerList)
 popteen.co.jp##iframe[src^="https://popteen.co.jp/media/wp-content/themes/magazine_theme/ad_logly/"]
 baseball-mag.net##div[style="width:692px;height:280px;margin:-8px auto 0 auto;"]
@@ -6776,7 +6774,7 @@ yugioh-antenna.sakura.ne.jp##.contents_right
 webcomics.jp##.matome-pickup
 2ch-c.net##.nend_text_ad
 mukuu.herokuapp.com,patriot-e.com,the-3rd.net,tyoieronews.blog.jp,2ch-c.net##a[href^="https://www.dlsite.com/"]
-tsurimatome.com,keyboard-dojo.net,number-place-puzzle.net,2ch-c.net##a[href^="https://hb.afl.rakuten.co.jp/"]
+si-coding.net,tsurimatome.com,keyboard-dojo.net,number-place-puzzle.net,2ch-c.net##a[href^="https://hb.afl.rakuten.co.jp/"]
 ||beauty-navi.com/javascripts/violet/sp/ldh_ad.js
 beauty-navi.com##.p-headerBnr
 ||bookbang.jp/common/js/ad.js


### PR DESCRIPTION
 
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

 

### Add your comment and screenshots

These rules appear multiple times in the list.

```
##.m-adArea
##a[href^="https://hb.afl.rakuten.co.jp/"]
```



### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
