### PR TITLE
Add res.oa.opera.com to adservers_firstparty.txt

### DIFF
--- a/BaseFilter/sections/adservers_firstparty.txt
+++ b/BaseFilter/sections/adservers_firstparty.txt
@@ -182,6 +182,7 @@
 ||newrevive.detik.com^
 ||ad.serv1for.pro^
 ||res.adx.opera.com^
+||res.oa.opera.com^
 ||ads.rubiconproject.com^
 ||eus.rubiconproject.com^
 ||fastlane.rubiconproject.com^


### PR DESCRIPTION
## What problem does the pull request fix?

- [x] Missed ads or ad leftovers;

## What issue is being fixed?

Fixes #239531

## Description

Add `res.oa.opera.com` to the first-party advertising servers section.

`res.oa.opera.com/x/oa.js` is the Opera Ads JavaScript SDK endpoint. Opera's own publisher documentation identifies this URL as the Opera Ads JS SDK used to initialize and render advertising placements.

AdGuard already blocks other Opera advertising infrastructure in this section, including:

- `res.adx.opera.com`
- `t.adx.opera.com`
- `s-adx.op-mobile.opera.com`
- `dl-adx.op-mobile.opera.com`

This adds the missing Opera Ads SDK host without blocking the broader `opera.com` domain.

Source:
https://doc.adx.opera.com/publisher/web/js-tag

Related issue:
https://github.com/AdguardTeam/AdguardFilters/issues/239531