### PR TITLE
Add t.rtbscale.com to tracking servers list

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -70,6 +70,7 @@
 !
 !
 !
+||t.rtbscale.com^
 ||northstar.cr^
 ||thinkingdata.cn^
 ||bidscube.com^


### PR DESCRIPTION
Summary

Add t.rtbscale.com to SpywareFilter/sections/tracking_servers.txt.

Details

t.rtbscale.com is an advertising cookie-sync / identity-sync endpoint operated as part of RTBScale's programmatic advertising infrastructure.

The hostname is used for third-party advertising identity synchronization rather than serving site content directly. Observed requests include advertising identifiers and redirect to other advertising identity-matching infrastructure, consistent with tracking and cross-site ad targeting.

This makes t.rtbscale.com appropriate for the Tracking Protection filter rather than the malware category.

Change
||t.rtbscale.com^

Related issue
Fixes #239702