### PR TITLE
Add missing Google ad-serving domains

### DIFF
--- a/BaseFilter/sections/adservers.txt
+++ b/BaseFilter/sections/adservers.txt
@@ -9,6 +9,8 @@
 !
 !
 !
+||syndicatedsearch.goog^
+||adsensecustomsearchads.com^
 ||seeksgironny.com^
 ||dehorsshochet.com^
 ||wnwtfmpsmslwi.site^


### PR DESCRIPTION
Summary

Add the following legitimate Google advertising-serving domains to BaseFilter/sections/adservers.txt:

syndicatedsearch.goog
adsensecustomsearchads.com
Details

Both domains are used by Google's Search Ads / AdSense for Search infrastructure to serve advertisements and related ad content.

They are legitimate advertising-serving domains and are appropriately classified as ads, rather than trackers, malware, or phishing domains.

Neither domain is currently covered by an existing rule in AdguardTeam/AdguardFilters, resulting in missed ad requests when these domains are used by websites with Google-powered search advertising.

Changes
||syndicatedsearch.goog^
||adsensecustomsearchads.com^

Related issues
Fixes #239712
Fixes #239713