### PR TITLE
Add missing mobile advertising endpoints

### DIFF
--- a/MobileFilter/sections/adservers.txt
+++ b/MobileFilter/sections/adservers.txt
@@ -8,6 +8,16 @@
 !
 !
 ! ||mobileapptracking.com^ - don't block this domain with all subdomains. https://forum.adguard.com/index.php?threads/23917/
+! Observed mobile advertising endpoints
+||rtb-csync.smartadserver.com^
+||rtb.openx.net^
+||s.ad.smaato.net^
+||ads.servenobid.com^
+||ad.360yield.com^
+||ads.pubmatic.com^
+||ad-events.flashtalking.com^
+||prebid.ad.smaato.net^
+!
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/229939
 ||yodo1.com^


### PR DESCRIPTION
## Description

Adds blocking rules for eight third-party advertising endpoints observed in mobile-device traffic and not currently covered by the AdGuard Mobile Ads filter.

The rules are intentionally scoped to the exact observed hostnames rather than broader parent domains to reduce the risk of blocking unrelated services.

## Added domains

```text
rtb-csync.smartadserver.com
rtb.openx.net
s.ad.smaato.net
ads.servenobid.com
ad.360yield.com
ads.pubmatic.com
ad-events.flashtalking.com
prebid.ad.smaato.net
```

## Rules

```adblock
||rtb-csync.smartadserver.com^
||rtb.openx.net^
||s.ad.smaato.net^
||ads.servenobid.com^
||ad.360yield.com^
||ads.pubmatic.com^
||ad-events.flashtalking.com^
||prebid.ad.smaato.net^
```

## Rationale

These hosts are associated with advertising, real-time bidding, ad mediation, or ad-serving infrastructure and were observed being contacted by mobile clients.

They fit the purpose of `MobileFilter/sections/adservers.txt`, which contains full-domain rules for third-party advertising networks used on mobile devices.

Exact FQDN rules were used instead of broader rules such as `||openx.net^` or `||smaato.net^` because the available evidence establishes the advertising purpose of the observed endpoints, not necessarily every service beneath their parent domains.

## Changes

* Added eight advertising-domain rules to `MobileFilter/sections/adservers.txt`.
* No other filter files were modified.
* No existing rules were changed or removed.

## Verification

* Verified the resulting branch differs from `master` only in `MobileFilter/sections/adservers.txt`.
* Verified all eight intended rules are present in the committed file.
* Change contains 10 additions and 0 deletions.
* AGLint has not been run locally; repository CI can perform the standard filter validation.
