### PR TITLE
Fix #241102 myworkdaysite.com

### DIFF
--- a/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
+++ b/AnnoyancesFilter/Cookies/sections/cookies_specific.txt
@@ -3620,7 +3620,7 @@ eliandelm.com#%#//scriptlet('set-cookie', '_klv_common_ext_int_popup_shown', 'tr
 denix.es#%#//scriptlet('trusted-set-cookie-reload', 'cookie_prefs', '{"functional":true,"analytics":false}')
 jarokelo.hu###cookieNoticeProContainer
 mic.eucast.org#%#//scriptlet('trusted-set-cookie', 'cookieconsent_status', 'dismiss')
-myworkdayjobs.com##div[data-automation-id="legalNotice"]
+myworkdaysite.com,myworkdayjobs.com##div[data-automation-id="legalNotice"]
 atresplayer.com#$#body { overflow: auto !important; }
 atresplayer.com#$##didomi-host { display: none !important; }
 atresplayer.com#$##didomi-host ~ div div[class^="style__StyledBackground-"]:empty { display: none !important; }
@@ -5910,7 +5910,7 @@ startujemeweby.cz###lista
 praca.by#$#body { overflow: auto !important; padding-right: 0 !important; }
 praca.by#$#.cookie-confirm { display: none !important; }
 praca.by#$##cookie-confirm ~ div.modal-backdrop { display: none !important; }
-myworkdayjobs.com#?#div[dir="ltr"] > div[class^="css-"] > div[class^="css-"]:has(div[data-automation-id="legalNotice"])
+myworkdaysite.com,myworkdayjobs.com#?#div[dir="ltr"] > div[class^="css-"] > div[class^="css-"]:has(div[data-automation-id="legalNotice"])
 myedit.online###gdpr_notes
 ledlumen.pl,blsspain-russia.com###popup
 webfail.com#%#//scriptlet('trusted-click-element', '.cmptxt_btn_yes')


### PR DESCRIPTION
Fixes #241102

`myworkdaysite.com` serves the same Workday candidate-experience app as `myworkdayjobs.com`, and its cookie notice uses identical markup — but the domain was not covered by the existing rules.

Verified on the reported page (`wd3.myworkdaysite.com/recruiting/wfp/job_openings`):

- `div[data-automation-id="legalNotice"]` — 1 match, containing the consent text ("Your privacy is important to us… you consent to the usage of 1st and 3rd party cookies"), alongside `legalNoticeAcceptButton` / `legalNoticeDeclineButton`.
- `div[dir="ltr"] > div[class^="css-"] > div[class^="css-"]:has(div[data-automation-id="legalNotice"])` — 1 match. It is an ancestor of the notice and its text content length equals the notice's exactly, so it wraps the banner and nothing else.
- Applying both rules as `display: none`: the banner is hidden, the page header and all 20 job listings still render, and no empty space is left behind.

Both existing rules are extended rather than duplicated, with the new domain added at the beginning and kept in the same order across the pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
